### PR TITLE
confirm test_submit.sh works on Miyabi

### DIFF
--- a/scripts/test_submit.sh
+++ b/scripts/test_submit.sh
@@ -22,7 +22,8 @@ if [ ! -f "$list_file" ]; then
 fi
 
 # --- ヘッダを除いて列をチェック ---
-line=$(tail -n +2 "$list_file" | sed -n "${sys}p")
+#line=$(tail -n +2 "$list_file" | sed -n "${sys}p")
+line=$(tail -n +2 "$list_file" | grep "${sys}")
 if [ -z "$line" ]; then
     echo "Error: Line $sys does not exist in $list_file"
     exit 1


### PR DESCRIPTION
needed to fix the following:
```
$ bash scripts/test_submit.sh LQCD_dw_solver MiaybiG
sed: -e expression #1, char 1: unknown command: `M'
Error: Line MiaybiG does not exist in programs/LQCD_dw_solver/list.csv
```