### PR TITLE
Add MHDTurbulence application

### DIFF
--- a/programs/MHDTurbulence/build.sh
+++ b/programs/MHDTurbulence/build.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# usage: bash programs/MHDTurbulence/build.sh system
+
+set -e
+system="$1"
+
+code=MHDTurbulence
+REPO=https://github.com/cfcanaoj/MHDTurbulence.git
+artdir=artifacts
+
+echo "[${code}] Building on system: $system"
+
+mkdir -p ${artdir}
+
+if [ ! -d "$code" ]; then
+    git clone $REPO
+fi
+
+DIR=$code
+
+cd $DIR
+BIN=Simulation.x
+case "$system" in
+    MiyabiC)
+	cd src_f90_omp_host
+	echo "Compile cods in "`pwd`
+	make
+	echo "Executable is "${BIN}" and copied to "${artdir} 
+	cp ../exe/$BIN ../../${artdir}
+	;;
+    MiyabiG) 
+	cd src_f90_acc_device
+	echo "Compile cods in "`pwd`
+	make
+	echo "Executable is "${BIN}" and copied to "${artdir} 
+	cp ../exe/$BIN ../../${artdir}
+	;;
+# in the future, we may add this
+#    MiyabiG/OpenMP) 
+#	cd src_f90_omp_device
+#	echo "Compile cods in "`pwd`
+#	make
+#	echo "Executable is "${BIN}" and copied to "${artdir} 
+#	cp ../exe/$BIN ../../${artdir}
+#	;;
+    *)
+	echo "Unknown system: $system"
+	exit 1
+	;;
+esac
+
+echo "Storing executables and related artifacts for subsequent CI/CD jobs."

--- a/programs/MHDTurbulence/list.csv
+++ b/programs/MHDTurbulence/list.csv
@@ -1,0 +1,4 @@
+system,enable,nodes,numproc_node,nthreads,elapse
+Fugaku,no,1,4,12,0:10:00
+MiyabiC,yes,1,96,1,0:10:00
+MiyabiG,yes,1,1,1,0:10:00

--- a/programs/MHDTurbulence/run.sh
+++ b/programs/MHDTurbulence/run.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# usage: bash scripts/test_submit.sh MHDTurbulence n
+
+set -eux
+system="$1"
+nodes="$2"
+numproc_node="$3"
+nthreads="$4"
+
+code=MHDTurbulence
+artdir=artifacts
+BIN=Simulation.x
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+mkdir -p results
+
+LOG=stdout.log
+case "$system" in
+    MiyabiC)
+	exedir=exe
+	mkdir -p $code/$exedir/
+	cp $artdir/${BIN} $code/$exedir/
+	cd $code/$exedir/
+	echo "code is executed in "$code/$exedir/
+	NP=$((nodes * numproc_node))
+	export OMP_NUM_THREADS=$nthreads
+	export KMP_AFFINITY=compact
+	mpirun -np "$NP" ./Simulation.x > ${LOG} 2>&1
+	elapsed=$(grep " sim time \[s\]:    " ${LOG} | awk '{print $4}' | tail -n 1)
+	tcc=$(grep " time/count/cell" ${LOG} | awk '{print $2}' | tail -n 1)
+	;;
+    MiyabiG)
+	exedir=exe
+	mkdir -p $code/$exedir/
+	cp $artdir/${BIN} $code/$exedir/
+	cd $code/$exedir/
+	echo "code is executed in "$code/$exedir/
+	NP=$((nodes * numproc_node))
+	mpirun -np "$NP" ./Simulation.x > ${LOG} 2>&1
+	elapsed=$(grep " sim time \[s\]:    " ${LOG} | awk '{print $4}' | tail -n 1)
+	tcc=$(grep " time/count/cell" ${LOG} | awk '{print $2}' | tail -n 1)
+	;;
+    *)
+	echo "Unknown system: $system"
+	exit 1
+	;;
+esac
+
+
+if [ -z "${elapsed}" ]; then
+  echo "ERROR: elapsed time was not found in ${LOG}"
+  exit 1
+fi
+
+if [ -z "${tcc}" ]; then
+  echo "ERROR: time/count/cell was not found in ${LOG}"
+  exit 1
+fi
+
+cd ${ROOT}
+source "${ROOT}/scripts/bk_functions.sh"
+
+fomtcc=$(awk "BEGIN {printf \"%.6e\", 1.0/$tcc}")
+
+
+########################################
+# emit benchkit result
+########################################
+{
+  bk_emit_result \
+    --fom "$fomtcc" \
+    --fom-version "cell_updates_per_sec" \
+    --exp "KH" \
+    --nodes "$nodes" \
+    --numproc-node "$numproc_node" \
+    --nthreads "$nthreads"
+
+  bk_emit_section total "$elapsed"
+} > "${ROOT}/results/result"

--- a/programs/MHDTurbulence/run.sh
+++ b/programs/MHDTurbulence/run.sh
@@ -26,8 +26,8 @@ case "$system" in
 	export OMP_NUM_THREADS=$nthreads
 	export KMP_AFFINITY=compact
 	mpirun -np "$NP" ./Simulation.x > ${LOG} 2>&1
-	elapsed=$(grep " sim time \[s\]:    " ${LOG} | awk '{print $4}' | tail -n 1)
-	tcc=$(grep " time/count/cell" ${LOG} | awk '{print $2}' | tail -n 1)
+	elapsed=$(grep "sim time \[s\]:" ${LOG} | awk '{print $4}' | tail -n 1)
+	tcc=$(grep "time/count/cell" ${LOG} | awk '{print $2}' | tail -n 1)
 	;;
     MiyabiG)
 	exedir=exe
@@ -37,8 +37,8 @@ case "$system" in
 	echo "code is executed in "$code/$exedir/
 	NP=$((nodes * numproc_node))
 	mpirun -np "$NP" ./Simulation.x > ${LOG} 2>&1
-	elapsed=$(grep " sim time \[s\]:    " ${LOG} | awk '{print $4}' | tail -n 1)
-	tcc=$(grep " time/count/cell" ${LOG} | awk '{print $2}' | tail -n 1)
+	elapsed=$(grep "sim time \[s\]:" ${LOG} | awk '{print $4}' | tail -n 1)
+	tcc=$(grep "time/count/cell" ${LOG} | awk '{print $2}' | tail -n 1)
 	;;
     *)
 	echo "Unknown system: $system"


### PR DESCRIPTION
# Overview
This PR adds support for the MHDTurbulence application following the guide in:

docs/guides/add-app.md
# Changes
Added the MHDTurbulence application
Implemented the required benchmark integration
Added related configuration and execution components
Updated application registration and setup
# Testing
Verified build and execution in Miyabi-C and Miyabi-G
# Notes
This PR targets the develop branch.
Previously, in `build.sh`, we use MiyabiG/OpenACC and MiyabiGOpenMP but now I just use Miyabi G. It is consistent with `run.sh`.