### PR TITLE
Refactor app section estimation boundaries

### DIFF
--- a/programs/genesis/README.md
+++ b/programs/genesis/README.md
@@ -65,8 +65,15 @@ the wrapper treats it as a `custom` profile.
 
 ## Estimation Sections
 
-GENESIS treats the log `dynamics` time as the FOM. The current wrapper maps the
-log into section metadata in `programs/genesis/estimate.sh`.
+GENESIS treats the log `dynamics` time as the FOM. The app-side parser
+`programs/genesis/parse_timing.sh` maps a GENESIS log and dynamics FOM into
+section/overlap timing rows. This parser is not estimation-specific; it can be
+used from `run.sh`, `estimate.sh`, or local diagnostics.
+
+`estimate.sh` should stay limited to GENESIS-owned decisions: section names,
+how to extract section timings from the GENESIS log, and which section package
+each section should use. Package loading, fallback, FOM composition, and
+Estimate JSON construction are handled by the shared BenchKit estimation layer.
 
 Current section names are:
 
@@ -116,32 +123,15 @@ FugakuNEXT.
 
 ## GPU Section Package Mapping
 
-GENESIS chooses GPU section packages inside `programs/genesis/estimate.sh`.
-Shared BenchKit code and section packages must not depend on these variables.
+GENESIS does not choose individual GPU estimator packages. It marks GPU-related
+sections as `gpu_kernel_ensemble_average`; the common section package decides
+which concrete GPU estimator packages to run. This keeps GENESIS-side ownership
+limited to app concepts: section names, timing extraction, artifact candidates,
+and kernel selectors.
 
-Single-package selection:
-
-```bash
-BK_GENESIS_GPU_SECTION_PACKAGE=gpu_kernel_mlp_v15
-# or
-BK_GENESIS_GPU_SECTION_PACKAGE=gpu_kernel_mlp_v21
-# or
-BK_GENESIS_GPU_SECTION_PACKAGE=gpu_kernel_mlp_v40
-# or
-BK_GENESIS_GPU_SECTION_PACKAGE=gpu_kernel_mlp_v41
-# or
-BK_GENESIS_GPU_SECTION_PACKAGE=gpu_kernel_lightgbm_v10
-```
-
-Multiple-package comparison:
-
-```bash
-BK_GENESIS_GPU_SECTION_PACKAGES=gpu_kernel_lightgbm_v10,gpu_kernel_mlp_v15,gpu_kernel_mlp_v21,gpu_kernel_mlp_v40,gpu_kernel_mlp_v41
-```
-
-When multiple packages are selected, the app wrapper asks for
-`gpu_kernel_ensemble_average`, and passes the candidate packages through common
-section metadata. The ensemble package does not know this is GENESIS-specific.
+BenchKit operators can override the concrete GPU estimator package set with the
+generic `BK_GPU_KERNEL_ENSEMBLE_PACKAGES` variable when needed. That knob is not
+GENESIS-specific and should not be required for normal GENESIS maintenance.
 
 Current GPU section/artifact mapping:
 
@@ -151,14 +141,16 @@ pme_real_inter -> results/padata_inter.tgz    -> force_inter_cell
 pme_real_intra -> results/padata_intra.tgz    -> force_intra_cell
 ```
 
-The app wrapper passes kernel selectors to GPU section packages through generic
-selector variables:
+`programs/genesis/run.sh` registers these artifact paths when each NCU profile
+archive is created, then writes them as `SECTION: ... artifact:...` entries in
+`results/result`. `scripts/result.sh` turns those lines into
+`fom_breakdown.sections[].artifacts[]` in the Result JSON. `estimate.sh`
+consumes that Result JSON; it should not infer profiler output paths by scanning
+the filesystem or by knowing profiler archive names.
 
-```bash
-BK_GPU_KERNEL_SECTION_PAIRLIST_REGEX=build_pairlist
-BK_GPU_KERNEL_SECTION_PME_REAL_INTER_REGEX=force_inter_cell
-BK_GPU_KERNEL_SECTION_PME_REAL_INTRA_REGEX=force_intra_cell
-```
+The app wrapper passes kernel selectors to GPU section packages through the
+common estimation helper. These selectors are GENESIS-owned because they name
+GENESIS kernels.
 
 NCU archives contain sampled kernel launches, not full application section
 timings. The GPU section packages compute source/target kernel time ratios from

--- a/programs/genesis/estimate.sh
+++ b/programs/genesis/estimate.sh
@@ -1,312 +1,24 @@
 #!/bin/bash
-# estimate.sh — GENESIS estimation entrypoint and run-time section metadata.
-
-genesis_gpu_section_packages() {
-  local raw=""
-
-  if [[ -n "${BK_GENESIS_GPU_SECTION_PACKAGES:-}" ]]; then
-    raw="$BK_GENESIS_GPU_SECTION_PACKAGES"
-  elif [[ -n "${BK_GENESIS_GPU_SECTION_PACKAGE:-}" ]]; then
-    raw="$BK_GENESIS_GPU_SECTION_PACKAGE"
-  else
-    raw="gpu_kernel_lightgbm_v10,gpu_kernel_mlp_v15,gpu_kernel_mlp_v21,gpu_kernel_mlp_v40,gpu_kernel_mlp_v41"
-  fi
-
-  printf '%s\n' "$raw" |
-    tr ',' '\n' |
-    awk '{
-      gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0)
-      if ($0 != "") print $0
-    }'
-}
-
-genesis_primary_gpu_section_package() {
-  genesis_gpu_section_packages | head -n 1
-}
-
-GENESIS_PME_OVERLAP_SECTION_MEMBERS="pme_real_wait,pme_real_inter,pme_real_intra,pme_recip"
-GENESIS_DYNAMICS_SECTION_MEMBERS="pairlist,bond,angle,dihedral,pme_real_wait,pme_real_inter,pme_real_intra,pme_recip,integrator"
-
-genesis_gpu_section_package_binding() {
-  if [[ -n "${BK_GENESIS_GPU_SECTION_PACKAGE:-}" && -z "${BK_GENESIS_GPU_SECTION_PACKAGES:-}" ]]; then
-    printf '%s\n' "$BK_GENESIS_GPU_SECTION_PACKAGE"
-  else
-    printf '%s\n' "gpu_kernel_ensemble_average"
-  fi
-}
-
-genesis_declare_estimation_layout() {
-  local gpu_section_package
-  gpu_section_package=$(genesis_gpu_section_package_binding)
-
-  bk_clear_estimation_defaults
-  bk_clear_estimation_declarations
-  bk_define_current_estimation_package weakscaling
-  bk_define_future_estimation_package instrumented_app_sections_dummy
-  bk_define_baseline_system "${BK_ESTIMATION_BASELINE_SYSTEM:-Fugaku}"
-  bk_define_baseline_exp "${BK_ESTIMATION_BASELINE_EXP:-${BK_GENESIS_EXP:-p8}}"
-  bk_define_future_system "${BK_ESTIMATION_FUTURE_SYSTEM:-FugakuNEXT}"
-  bk_define_current_target_nodes "${BK_ESTIMATION_CURRENT_TARGET_NODES:-1}"
-  bk_define_future_target_nodes "${BK_ESTIMATION_FUTURE_TARGET_NODES:-1}"
-  bk_declare_section --side future pairlist "$gpu_section_package"
-  bk_declare_section --side future bond identity
-  bk_declare_section --side future angle identity
-  bk_declare_section --side future dihedral identity
-  bk_declare_section --side future pme_real_wait identity
-  bk_declare_section --side future pme_real_inter "$gpu_section_package"
-  bk_declare_section --side future pme_real_intra "$gpu_section_package"
-  bk_declare_section --side future pme_recip identity
-  bk_declare_section --side future integrator identity
-  bk_declare_section --side future other identity
-  bk_declare_overlap --side future "$GENESIS_PME_OVERLAP_SECTION_MEMBERS" identity
-  bk_declare_overlap --side future "$GENESIS_DYNAMICS_SECTION_MEMBERS" identity
-}
-
-genesis_extract_dynamics_sections() {
-  local log_file="$1"
-  local dynamics_time="$2"
-  local pme_real_identity_fraction="${BK_GENESIS_PME_REAL_IDENTITY_FRACTION:-0.8}"
-  local pme_real_inter_fraction="${BK_GENESIS_PME_REAL_INTER_FRACTION:-0.1}"
-  local pme_real_intra_fraction="${BK_GENESIS_PME_REAL_INTRA_FRACTION:-0.1}"
-
-  awk \
-    -v dynamics="$dynamics_time" \
-    -v pme_real_identity_fraction="$pme_real_identity_fraction" \
-    -v pme_real_inter_fraction="$pme_real_inter_fraction" \
-    -v pme_real_intra_fraction="$pme_real_intra_fraction" '
-    function value(line, rest, parts) {
-      rest = line
-      sub(/^[^=]*=[[:space:]]*/, "", rest)
-      split(rest, parts, /[[:space:]]+/)
-      return parts[1] + 0
-    }
-    function min(a, b) { return a < b ? a : b }
-    /^[[:space:]]*pairlist[[:space:]]*=/ { pairlist = value($0); found_pairlist = 1 }
-    /^[[:space:]]*bond[[:space:]]*=/ { bond = value($0); found_bond = 1 }
-    /^[[:space:]]*angle[[:space:]]*=/ { angle = value($0); found_angle = 1 }
-    /^[[:space:]]*dihedral[[:space:]]*=/ { dihedral = value($0); found_dihedral = 1 }
-    /^[[:space:]]*pme real[[:space:]]*=/ { pme_real = value($0); found_pme_real = 1 }
-    /^[[:space:]]*pme recip[[:space:]]*=/ { pme_recip = value($0); found_pme_recip = 1 }
-    /^[[:space:]]*integrator[[:space:]]*=/ { integrator = value($0); found_integrator = 1 }
-    END {
-      pme_real_wait = pme_real * pme_real_identity_fraction
-      pme_real_inter = pme_real * pme_real_inter_fraction
-      pme_real_intra = pme_real * pme_real_intra_fraction
-      pme_real_total = pme_real_wait + pme_real_inter + pme_real_intra
-      pme_overlap = min(pme_real_total, pme_recip)
-      total = pairlist + bond + angle + dihedral + pme_real_total + pme_recip - pme_overlap + integrator
-      if (total <= 0) {
-        exit 1
-      }
-      other = dynamics - total
-      dynamics_overlap = 0
-      if (other < 0) {
-        dynamics_overlap = -other
-        other = 0
-      }
-      printf "section pairlist %.12g\n", pairlist
-      printf "section bond %.12g\n", bond
-      printf "section angle %.12g\n", angle
-      printf "section dihedral %.12g\n", dihedral
-      printf "section pme_real_wait %.12g\n", pme_real_wait
-      printf "section pme_real_inter %.12g\n", pme_real_inter
-      printf "section pme_real_intra %.12g\n", pme_real_intra
-      printf "section pme_recip %.12g\n", pme_recip
-      printf "section integrator %.12g\n", integrator
-      printf "section other %.12g\n", other
-      if (pme_overlap > 0) {
-        printf "overlap pme_real_wait,pme_real_inter,pme_real_intra,pme_recip %.12g\n", pme_overlap
-      }
-      if (dynamics_overlap > 0) {
-        printf "overlap pairlist,bond,angle,dihedral,pme_real_wait,pme_real_inter,pme_real_intra,pme_recip,integrator %.12g\n", dynamics_overlap
-      }
-      missing = 0
-      missing += !found_pairlist
-      missing += !found_bond
-      missing += !found_angle
-      missing += !found_dihedral
-      missing += !found_pme_real
-      missing += !found_pme_recip
-      missing += !found_integrator
-      if (missing > 0) {
-        printf "GENESIS section extraction warning: %d expected dynamics sections were not found in log\n", missing > "/dev/stderr"
-      }
-    }
-  ' "$log_file"
-}
-
-genesis_section_key() {
-  printf '%s\n' "$1" | tr '[:lower:]' '[:upper:]' | sed 's/[^A-Z0-9]/_/g'
-}
-
-genesis_artifact_file_exists() {
-  local rel_path="$1"
-
-  [[ -n "$rel_path" ]] || return 1
-  if [[ -f "$rel_path" ]]; then
-    return 0
-  fi
-  if [[ -n "${GENESIS_BENCHKIT_ROOT:-}" && -f "${GENESIS_BENCHKIT_ROOT}/${rel_path}" ]]; then
-    return 0
-  fi
-  return 1
-}
-
-genesis_section_artifact_path() {
-  local section_name="$1"
-  local section_key
-  local env_var
-  local explicit_artifact
-  local candidate
-
-  section_key=$(genesis_section_key "$section_name")
-  env_var="BK_GENESIS_SECTION_${section_key}_ARTIFACT"
-  explicit_artifact="${!env_var:-}"
-  if [[ -n "$explicit_artifact" ]]; then
-    if genesis_artifact_file_exists "$explicit_artifact"; then
-      printf '%s\n' "$explicit_artifact"
-      return 0
-    fi
-    echo "GENESIS section artifact was requested but not found: ${env_var}=${explicit_artifact}" >&2
-    return 1
-  fi
-
-  case "$section_name" in
-    pairlist)
-      for candidate in "results/padata_pairlist.tgz" "results/padata0.tgz"; do
-        if genesis_artifact_file_exists "$candidate"; then
-          printf '%s\n' "$candidate"
-          return 0
-        fi
-      done
-      ;;
-    pme_real_inter)
-      candidate="results/padata_inter.tgz"
-      if genesis_artifact_file_exists "$candidate"; then
-        printf '%s\n' "$candidate"
-        return 0
-      fi
-      ;;
-    pme_real_intra)
-      candidate="results/padata_intra.tgz"
-      if genesis_artifact_file_exists "$candidate"; then
-        printf '%s\n' "$candidate"
-        return 0
-      fi
-      ;;
-    *)
-      candidate="results/padata_${section_name}.tgz"
-      if genesis_artifact_file_exists "$candidate"; then
-        printf '%s\n' "$candidate"
-        return 0
-      fi
-      ;;
-  esac
-
-  return 1
-}
-
-genesis_emit_estimation_data_from_log() {
-  local log_file="$1"
-  local fom="$2"
-  local item_kind
-  local item_name
-  local item_time
-  local section_artifact=""
-
-  if [[ ! -f "$log_file" ]]; then
-    echo "Genesis timing log was not found: ${log_file}" >&2
-    return 0
-  fi
-
-  while read -r item_kind item_name item_time; do
-    [[ -n "$item_kind" && -n "$item_name" && -n "$item_time" ]] || continue
-    section_artifact=""
-    case "$item_kind" in
-      section)
-        case "$item_name" in
-          pairlist|pme_real_inter|pme_real_intra)
-            section_artifact=$(genesis_section_artifact_path "$item_name" || true)
-            ;;
-        esac
-        bk_emit_declared_section --side future "$item_name" "$item_time" "$section_artifact"
-        ;;
-      overlap)
-        bk_emit_declared_overlap --side future "$item_name" "$item_time"
-        ;;
-    esac
-  done < <(genesis_extract_dynamics_sections "$log_file" "$fom")
-}
-
-genesis_emit_estimation_data_from_fom() {
-  local fom="$1"
-  genesis_emit_estimation_data_from_log "${BK_GENESIS_LOG_FILE:-results/log_p8.txt}" "$fom"
-}
-
-genesis_input_has_fom_breakdown() {
-  local input_json="$1"
-
-  jq -e '((.fom_breakdown.sections // []) | length) > 0' "$input_json" >/dev/null 2>&1
-}
-
-genesis_write_total_identity_breakdown_input() {
-  local input_json="$1"
-  local output_json="$2"
-
-  jq '
-    .fom_breakdown = {
-      sections: [
-        {
-          name: "total",
-          time: (.FOM | tonumber),
-          estimation_package: "identity"
-        }
-      ],
-      overlaps: []
-    }
-  ' "$input_json" > "$output_json"
-}
-
-genesis_mark_gpu_section_time_missing() {
-  bk_estimation_set_applicability \
-    "partially_applicable" \
-    "" \
-    '["app_gpu_section_time"]' \
-    '["provide-app-side-gpu-section-time-to-enable-gpu-kernel-estimator-fom-composition"]'
-
-  est_notes_json=$(jq -cn '{
-    summary: "GENESIS GPU kernel estimator data may contain NCU sample ratios, but FOM composition used a total identity section because app-side GPU section time is not available yet.",
-    gpu_kernel_estimation: "NCU sample predicted/source ratios must be applied to app-side GPU section time before they can contribute to FOM reconstruction."
-  }')
-}
+# estimate.sh — GENESIS estimation entrypoint.
 
 source scripts/bk_functions.sh
 source scripts/estimation/common.sh
+source programs/genesis/sections.sh
 
 BK_ESTIMATION_SECTION_DEFAULT_FACTOR="${BK_ESTIMATION_SECTION_DEFAULT_FACTOR:-1.0}"
 BK_GENESIS_GPU_TARGET_GPU="${BK_GENESIS_GPU_TARGET_GPU:-GB200}"
-BK_GPU_MLP_ARTIFACT_MODE="${BK_GPU_MLP_ARTIFACT_MODE:-ncu}"
-BK_GPU_MLP_SOURCE_GPU="${BK_GPU_MLP_SOURCE_GPU:-H100}"
-BK_GPU_MLP_TARGET_GPU="${BK_GPU_MLP_TARGET_GPU:-$BK_GENESIS_GPU_TARGET_GPU}"
-BK_GPU_MLP_KERNEL_COUNT="${BK_GPU_MLP_KERNEL_COUNT:-20}"
-BK_GPU_LIGHTGBM_ARTIFACT_MODE="${BK_GPU_LIGHTGBM_ARTIFACT_MODE:-ncu}"
-BK_GPU_LIGHTGBM_SOURCE_GPU="${BK_GPU_LIGHTGBM_SOURCE_GPU:-${BK_GPU_MLP_SOURCE_GPU}}"
-BK_GPU_LIGHTGBM_TARGET_GPU="${BK_GPU_LIGHTGBM_TARGET_GPU:-$BK_GENESIS_GPU_TARGET_GPU}"
-BK_GPU_KERNEL_ENSEMBLE_PACKAGES="${BK_GPU_KERNEL_ENSEMBLE_PACKAGES:-$(genesis_gpu_section_packages | paste -sd, -)}"
-BK_GPU_KERNEL_SECTION_PAIRLIST_REGEX="${BK_GPU_KERNEL_SECTION_PAIRLIST_REGEX:-build_pairlist}"
-BK_GPU_KERNEL_SECTION_PME_REAL_INTER_REGEX="${BK_GPU_KERNEL_SECTION_PME_REAL_INTER_REGEX:-force_inter_cell}"
-BK_GPU_KERNEL_SECTION_PME_REAL_INTRA_REGEX="${BK_GPU_KERNEL_SECTION_PME_REAL_INTRA_REGEX:-force_intra_cell}"
-export BK_GPU_MLP_ARTIFACT_MODE
-export BK_GPU_MLP_SOURCE_GPU
-export BK_GPU_MLP_TARGET_GPU
-export BK_GPU_MLP_KERNEL_COUNT
-export BK_GPU_LIGHTGBM_ARTIFACT_MODE
-export BK_GPU_LIGHTGBM_SOURCE_GPU
-export BK_GPU_LIGHTGBM_TARGET_GPU
-export BK_GPU_KERNEL_ENSEMBLE_PACKAGES
-export BK_GPU_KERNEL_SECTION_PAIRLIST_REGEX
-export BK_GPU_KERNEL_SECTION_PME_REAL_INTER_REGEX
-export BK_GPU_KERNEL_SECTION_PME_REAL_INTRA_REGEX
+bk_estimation_configure_gpu_kernel_defaults \
+  H100 \
+  "$BK_GENESIS_GPU_TARGET_GPU" \
+  "" \
+  20 \
+  ncu
+bk_estimation_configure_gpu_kernel_section_regexes "$(cat <<'EOF'
+pairlist|build_pairlist
+pme_real_inter|force_inter_cell
+pme_real_intra|force_intra_cell
+EOF
+)"
 
 if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
   genesis_declare_estimation_layout
@@ -324,9 +36,9 @@ genesis_run_single_estimate() {
   genesis_declare_estimation_layout
   bk_estimation_apply_declared_defaults
   BK_ESTIMATION_PACKAGE="${BK_ESTIMATION_PACKAGE:-$BK_ESTIMATION_FUTURE_PACKAGE}"
-  if ! genesis_input_has_fom_breakdown "$input_json"; then
+  if ! bk_estimation_input_has_fom_breakdown "$input_json"; then
     package_input_json=$(mktemp "${TMPDIR:-/tmp}/benchkit-genesis-total-breakdown.XXXXXX.json")
-    genesis_write_total_identity_breakdown_input "$input_json" "$package_input_json"
+    bk_estimation_write_total_identity_breakdown_input "$input_json" "$package_input_json"
     synthetic_breakdown=1
   fi
 
@@ -342,7 +54,7 @@ genesis_run_single_estimate() {
   est_current_fom="${est_current_bench_fom:-$est_current_fom}"
 
   if [[ "$synthetic_breakdown" -eq 1 ]]; then
-    genesis_mark_gpu_section_time_missing
+    bk_estimation_mark_gpu_section_time_missing "GENESIS"
     rm -f "$package_input_json"
   fi
 

--- a/programs/genesis/parse_timing.sh
+++ b/programs/genesis/parse_timing.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# parse_timing.sh — Extract GENESIS app-side section timings from a run log.
+
+set -euo pipefail
+
+genesis_extract_dynamics_sections() {
+  local log_file="$1"
+  local dynamics_time="$2"
+  local pme_real_identity_fraction="${BK_GENESIS_PME_REAL_IDENTITY_FRACTION:-0.8}"
+  local pme_real_inter_fraction="${BK_GENESIS_PME_REAL_INTER_FRACTION:-0.1}"
+  local pme_real_intra_fraction="${BK_GENESIS_PME_REAL_INTRA_FRACTION:-0.1}"
+
+  awk \
+    -v dynamics="$dynamics_time" \
+    -v pme_real_identity_fraction="$pme_real_identity_fraction" \
+    -v pme_real_inter_fraction="$pme_real_inter_fraction" \
+    -v pme_real_intra_fraction="$pme_real_intra_fraction" '
+    function value(line, rest, parts) {
+      rest = line
+      sub(/^[^=]*=[[:space:]]*/, "", rest)
+      split(rest, parts, /[[:space:]]+/)
+      return parts[1] + 0
+    }
+    function min(a, b) { return a < b ? a : b }
+    /^[[:space:]]*pairlist[[:space:]]*=/ { pairlist = value($0); found_pairlist = 1 }
+    /^[[:space:]]*bond[[:space:]]*=/ { bond = value($0); found_bond = 1 }
+    /^[[:space:]]*angle[[:space:]]*=/ { angle = value($0); found_angle = 1 }
+    /^[[:space:]]*dihedral[[:space:]]*=/ { dihedral = value($0); found_dihedral = 1 }
+    /^[[:space:]]*pme real[[:space:]]*=/ { pme_real = value($0); found_pme_real = 1 }
+    /^[[:space:]]*pme recip[[:space:]]*=/ { pme_recip = value($0); found_pme_recip = 1 }
+    /^[[:space:]]*integrator[[:space:]]*=/ { integrator = value($0); found_integrator = 1 }
+    END {
+      pme_real_wait = pme_real * pme_real_identity_fraction
+      pme_real_inter = pme_real * pme_real_inter_fraction
+      pme_real_intra = pme_real * pme_real_intra_fraction
+      pme_real_total = pme_real_wait + pme_real_inter + pme_real_intra
+      pme_overlap = min(pme_real_total, pme_recip)
+      total = pairlist + bond + angle + dihedral + pme_real_total + pme_recip - pme_overlap + integrator
+      if (total <= 0) {
+        exit 1
+      }
+      other = dynamics - total
+      dynamics_overlap = 0
+      if (other < 0) {
+        dynamics_overlap = -other
+        other = 0
+      }
+      printf "section pairlist %.12g\n", pairlist
+      printf "section bond %.12g\n", bond
+      printf "section angle %.12g\n", angle
+      printf "section dihedral %.12g\n", dihedral
+      printf "section pme_real_wait %.12g\n", pme_real_wait
+      printf "section pme_real_inter %.12g\n", pme_real_inter
+      printf "section pme_real_intra %.12g\n", pme_real_intra
+      printf "section pme_recip %.12g\n", pme_recip
+      printf "section integrator %.12g\n", integrator
+      printf "section other %.12g\n", other
+      if (pme_overlap > 0) {
+        printf "overlap pme_real_wait,pme_real_inter,pme_real_intra,pme_recip %.12g\n", pme_overlap
+      }
+      if (dynamics_overlap > 0) {
+        printf "overlap pairlist,bond,angle,dihedral,pme_real_wait,pme_real_inter,pme_real_intra,pme_recip,integrator %.12g\n", dynamics_overlap
+      }
+      missing = 0
+      missing += !found_pairlist
+      missing += !found_bond
+      missing += !found_angle
+      missing += !found_dihedral
+      missing += !found_pme_real
+      missing += !found_pme_recip
+      missing += !found_integrator
+      if (missing > 0) {
+        printf "GENESIS section extraction warning: %d expected dynamics sections were not found in log\n", missing > "/dev/stderr"
+      }
+    }
+  ' "$log_file"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  if [[ $# -ne 2 ]]; then
+    echo "Usage: $0 <genesis-log-file> <dynamics-fom-seconds>" >&2
+    exit 2
+  fi
+  genesis_extract_dynamics_sections "$1" "$2"
+fi

--- a/programs/genesis/run.sh
+++ b/programs/genesis/run.sh
@@ -8,7 +8,12 @@ nthreads="$4"
 numproc=$(( numproc_node * nodes ))
 
 source "${PWD}/scripts/bk_functions.sh"
-source "${PWD}/programs/genesis/estimate.sh"
+source "${PWD}/scripts/estimation/common.sh"
+source "${PWD}/programs/genesis/parse_timing.sh"
+source "${PWD}/programs/genesis/sections.sh"
+
+genesis_declare_estimation_layout
+bk_estimation_apply_declared_defaults
 
 SCRIPT_DIR="${PWD}"
 export GENESIS_BENCHKIT_ROOT="$SCRIPT_DIR"
@@ -187,6 +192,35 @@ genesis_default_ncu_launch_count() {
     esac
 }
 
+genesis_profile_section_name() {
+    case "$1" in
+      inter)
+        printf '%s\n' "pme_real_inter"
+        ;;
+      intra)
+        printf '%s\n' "pme_real_intra"
+        ;;
+      pairlist)
+        printf '%s\n' "pairlist"
+        ;;
+      *)
+        printf '%s\n' "$1"
+        ;;
+    esac
+}
+
+genesis_register_section_artifact() {
+    local section_name="$1"
+    local artifact_path="$2"
+    local section_key
+    local artifact_var
+
+    section_key=$(genesis_profile_key "$section_name")
+    artifact_var="BK_GENESIS_SECTION_${section_key}_ARTIFACT"
+    printf -v "$artifact_var" '%s' "$artifact_path"
+    export "$artifact_var"
+}
+
 genesis_prepare_ncu_input() {
     local source_input="$1"
     local profile_name="$2"
@@ -243,10 +277,12 @@ genesis_run_ncu_profile() {
     shift 6
 
     local archive_path="${resultsdir}/padata_${profile_slug}.tgz"
+    local archive_rel_path="results/padata_${profile_slug}.tgz"
     local raw_dir="ncu_${profile_slug}"
     local profile_log="${resultsdir}/log_${header}_ncu_${profile_slug}.txt"
     local ncu_args
     local profile_status
+    local section_name
     local old_profiler_args="${BK_PROFILER_ARGS:-}"
     local old_profiler_raw_csv="${BK_PROFILER_NCU_RAW_CSV:-}"
     local had_profiler_args=0
@@ -288,6 +324,9 @@ genesis_run_ncu_profile() {
         echo "GENESIS NCU profile '${profile_name}' failed with status ${profile_status}" >&2
         return "$profile_status"
     fi
+
+    section_name=$(genesis_profile_section_name "$profile_name")
+    genesis_register_section_artifact "$section_name" "$archive_rel_path"
 }
 
 genesis_run_ncu_profiles() {

--- a/programs/genesis/sections.sh
+++ b/programs/genesis/sections.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# sections.sh — GENESIS section declarations and result metadata emission.
+
+GENESIS_PME_OVERLAP_SECTION_MEMBERS="pme_real_wait,pme_real_inter,pme_real_intra,pme_recip"
+GENESIS_DYNAMICS_SECTION_MEMBERS="pairlist,bond,angle,dihedral,pme_real_wait,pme_real_inter,pme_real_intra,pme_recip,integrator"
+
+genesis_declare_estimation_layout() {
+  bk_clear_estimation_defaults
+  bk_clear_estimation_declarations
+  bk_define_current_estimation_package weakscaling
+  bk_define_future_estimation_package instrumented_app_sections_dummy
+  bk_define_baseline_system "${BK_ESTIMATION_BASELINE_SYSTEM:-Fugaku}"
+  bk_define_baseline_exp "${BK_ESTIMATION_BASELINE_EXP:-${BK_GENESIS_EXP:-p8}}"
+  bk_define_future_system "${BK_ESTIMATION_FUTURE_SYSTEM:-FugakuNEXT}"
+  bk_define_current_target_nodes "${BK_ESTIMATION_CURRENT_TARGET_NODES:-1}"
+  bk_define_future_target_nodes "${BK_ESTIMATION_FUTURE_TARGET_NODES:-1}"
+  bk_declare_estimation_items --side future "$(cat <<EOF
+section|pairlist|gpu_kernel_ensemble_average
+section|bond|identity
+section|angle|identity
+section|dihedral|identity
+section|pme_real_wait|identity
+section|pme_real_inter|gpu_kernel_ensemble_average
+section|pme_real_intra|gpu_kernel_ensemble_average
+section|pme_recip|identity
+section|integrator|identity
+section|other|identity
+overlap|$GENESIS_PME_OVERLAP_SECTION_MEMBERS|identity
+overlap|$GENESIS_DYNAMICS_SECTION_MEMBERS|identity
+EOF
+)"
+}
+
+genesis_section_artifact_path() {
+  local section_name="$1"
+
+  bk_estimation_resolve_section_artifact \
+    "BK_GENESIS_SECTION" \
+    "${GENESIS_BENCHKIT_ROOT:-}" \
+    "$section_name"
+}
+
+genesis_emit_section_metadata_from_log() {
+  local log_file="$1"
+  local fom="$2"
+  local item_kind
+  local item_name
+  local item_time
+  local section_artifact=""
+  local timing_items=""
+
+  if [[ ! -f "$log_file" ]]; then
+    echo "Genesis timing log was not found: ${log_file}" >&2
+    return 0
+  fi
+
+  while read -r item_kind item_name item_time; do
+    [[ -n "$item_kind" && -n "$item_name" && -n "$item_time" ]] || continue
+    section_artifact=""
+    case "$item_kind" in
+      section)
+        case "$item_name" in
+          pairlist|pme_real_inter|pme_real_intra)
+            section_artifact=$(genesis_section_artifact_path "$item_name" || true)
+            ;;
+        esac
+        ;;
+      overlap)
+        section_artifact=""
+        ;;
+    esac
+
+    if [[ -n "$timing_items" ]]; then
+      timing_items="${timing_items}
+${item_kind}|${item_name}|${item_time}|${section_artifact}"
+    else
+      timing_items="${item_kind}|${item_name}|${item_time}|${section_artifact}"
+    fi
+  done < <(genesis_extract_dynamics_sections "$log_file" "$fom")
+
+  if [[ -n "$timing_items" ]]; then
+    bk_emit_declared_timing_items --side future "$timing_items"
+  fi
+}
+
+genesis_emit_estimation_data_from_log() {
+  genesis_emit_section_metadata_from_log "$@"
+}
+
+genesis_emit_estimation_data_from_fom() {
+  local fom="$1"
+  genesis_emit_section_metadata_from_log "${BK_GENESIS_LOG_FILE:-results/log_p8.txt}" "$fom"
+}

--- a/programs/qws/README.md
+++ b/programs/qws/README.md
@@ -1,0 +1,47 @@
+# QWS BenchKit Integration Notes
+
+This directory owns QWS-specific build, run, and estimation settings. Shared
+BenchKit CI, top-level estimation packages, and section packages should not
+depend on QWS-local variables or dummy section names.
+
+## Estimation Sections
+
+`programs/qws/estimate.sh` is a reference lightweight app wrapper. It declares
+the section names and the section-package mapping locally, then passes measured
+or synthetic section timings to the common BenchKit estimation layer.
+
+Current reference sections are:
+
+```text
+prepare_rhs
+compute_hopping
+compute_solver
+halo_exchange
+allreduce
+write_result
+```
+
+The reference overlap is:
+
+```text
+compute_hopping,halo_exchange
+```
+
+The current QWS section timings are synthetic fractions of the benchmark FOM.
+They are useful for exercising the common estimation framework and portal
+display, but they are not a substitute for app-side timers from QWS itself.
+
+## Responsibility Split
+
+QWS-owned code should decide:
+
+- which application sections exist
+- how section timings are obtained from QWS output or test fixtures
+- which section package each section should use
+
+Common BenchKit code should handle:
+
+- package loading and fallback
+- section and overlap composition
+- current/future system Estimate JSON construction
+- result-server artifact upload and portal rendering

--- a/programs/qws/estimate.sh
+++ b/programs/qws/estimate.sh
@@ -32,13 +32,16 @@ qws_declare_estimation_layout() {
   bk_define_future_system FugakuNEXT
   bk_define_current_target_nodes 1024
   bk_define_future_target_nodes 256
-  bk_declare_section --side future prepare_rhs half
-  bk_declare_section --side future compute_hopping quarter
-  bk_declare_section --side future compute_solver half
-  bk_declare_section --side future halo_exchange quarter
-  bk_declare_section --side future allreduce logp
-  bk_declare_section --side future write_result half
-  bk_declare_overlap --side future compute_hopping,halo_exchange half
+  bk_declare_estimation_items --side future "$(cat <<'EOF'
+section|prepare_rhs|half
+section|compute_hopping|quarter
+section|compute_solver|half
+section|halo_exchange|quarter
+section|allreduce|logp
+section|write_result|half
+overlap|compute_hopping,halo_exchange|half
+EOF
+)"
 }
 
 qws_create_dummy_estimation_artifact() {
@@ -53,21 +56,6 @@ qws_create_dummy_estimation_artifact() {
 
 qws_emit_estimation_data_from_fom() {
   local fom="$1"
-  local section_prepare_rhs
-  local section_compute_hopping
-  local section_compute_solver
-  local section_halo_exchange
-  local section_allreduce
-  local section_write_result
-  local overlap_compute_halo
-
-  section_prepare_rhs=$(awk -v x="$fom" 'BEGIN {printf "%.3f", x * 0.16}')
-  section_compute_hopping=$(awk -v x="$fom" 'BEGIN {printf "%.3f", x * 0.28}')
-  section_compute_solver=$(awk -v x="$fom" 'BEGIN {printf "%.3f", x * 0.18}')
-  section_halo_exchange=$(awk -v x="$fom" 'BEGIN {printf "%.3f", x * 0.18}')
-  section_allreduce=$(awk -v x="$fom" 'BEGIN {printf "%.3f", x * 0.16}')
-  section_write_result=$(awk -v x="$fom" 'BEGIN {printf "%.3f", x * 0.08}')
-  overlap_compute_halo=$(awk -v x="$fom" 'BEGIN {printf "%.3f", x * 0.04}')
 
   qws_create_dummy_estimation_artifact "estimation_artifacts/prepare_rhs_interval.json" "{\"section\":\"prepare_rhs\",\"kind\":\"interval_time\"}"
   qws_create_dummy_estimation_artifact "estimation_artifacts/compute_hopping_papi.tgz" "dummy papi archive for compute_hopping"
@@ -77,13 +65,16 @@ qws_emit_estimation_data_from_fom() {
   qws_create_dummy_estimation_artifact "estimation_artifacts/write_result_interval.json" "{\"section\":\"write_result\",\"kind\":\"interval_time\"}"
   qws_create_dummy_estimation_artifact "estimation_artifacts/compute_halo_overlap.json" "{\"overlap\":[\"compute_hopping\",\"halo_exchange\"],\"kind\":\"overlap_time\"}"
 
-  bk_emit_declared_section --side future prepare_rhs "$section_prepare_rhs" results/estimation_artifacts/prepare_rhs_interval.json
-  bk_emit_declared_section --side future compute_hopping "$section_compute_hopping" results/estimation_artifacts/compute_hopping_papi.tgz
-  bk_emit_declared_section --side future compute_solver "$section_compute_solver" results/estimation_artifacts/compute_solver_papi.tgz
-  bk_emit_declared_section --side future halo_exchange "$section_halo_exchange" results/estimation_artifacts/halo_exchange_trace.tgz
-  bk_emit_declared_section --side future allreduce "$section_allreduce" results/estimation_artifacts/allreduce_trace.tgz
-  bk_emit_declared_section --side future write_result "$section_write_result" results/estimation_artifacts/write_result_interval.json
-  bk_emit_declared_overlap --side future compute_hopping,halo_exchange "$overlap_compute_halo" results/estimation_artifacts/compute_halo_overlap.json
+  bk_emit_declared_fractional_items --side future "$fom" "$(cat <<'EOF'
+section|prepare_rhs|0.16|results/estimation_artifacts/prepare_rhs_interval.json
+section|compute_hopping|0.28|results/estimation_artifacts/compute_hopping_papi.tgz
+section|compute_solver|0.18|results/estimation_artifacts/compute_solver_papi.tgz
+section|halo_exchange|0.18|results/estimation_artifacts/halo_exchange_trace.tgz
+section|allreduce|0.16|results/estimation_artifacts/allreduce_trace.tgz
+section|write_result|0.08|results/estimation_artifacts/write_result_interval.json
+overlap|compute_hopping,halo_exchange|0.04|results/estimation_artifacts/compute_halo_overlap.json
+EOF
+)"
 }
 
 source scripts/bk_functions.sh

--- a/scripts/bk_functions.sh
+++ b/scripts/bk_functions.sh
@@ -423,6 +423,44 @@ overlap|${_bk_decl_members}|${_bk_decl_package}"
   export BK_ESTIMATION_DECLARATIONS
 }
 
+bk_declare_estimation_items() {
+  _bk_decl_side="future"
+  if [ $# -gt 1 ] && [ "$1" = "--side" ]; then
+    shift
+    if [ $# -eq 0 ]; then
+      echo "bk_declare_estimation_items: --side requires current or future" >&2
+      return 1
+    fi
+    _bk_decl_side="$1"
+    shift
+  fi
+
+  if [ $# -ne 1 ] || [ -z "$1" ]; then
+    echo "bk_declare_estimation_items: requires a newline-separated declaration list" >&2
+    return 1
+  fi
+
+  while IFS='|' read -r _bk_decl_kind _bk_decl_name _bk_decl_package; do
+    [ -n "$_bk_decl_kind$_bk_decl_name$_bk_decl_package" ] || continue
+    case "$_bk_decl_kind" in
+      section)
+        bk_declare_section --side "$_bk_decl_side" "$_bk_decl_name" "$_bk_decl_package"
+        ;;
+      overlap)
+        bk_declare_overlap --side "$_bk_decl_side" "$_bk_decl_name" "$_bk_decl_package"
+        ;;
+      \#*)
+        ;;
+      *)
+        echo "bk_declare_estimation_items: unsupported item kind '${_bk_decl_kind}'" >&2
+        return 1
+        ;;
+    esac
+  done <<EOF
+$1
+EOF
+}
+
 bk_lookup_declared_estimation_package() {
   _bk_lookup_side="future"
   if [ $# -gt 1 ] && [ "$1" = "--side" ]; then
@@ -523,6 +561,89 @@ bk_emit_declared_overlap() {
   _bk_decl_ovl_package=$(bk_lookup_declared_estimation_package --side "$_bk_decl_side" overlap "$_bk_decl_ovl_members") || return 1
 
   bk_emit_overlap "$_bk_decl_ovl_members" "$_bk_decl_ovl_time" "$_bk_decl_ovl_package" "$_bk_decl_ovl_artifact"
+}
+
+bk_emit_declared_timing_items() {
+  _bk_decl_side="future"
+  if [ $# -gt 1 ] && [ "$1" = "--side" ]; then
+    shift
+    if [ $# -eq 0 ]; then
+      echo "bk_emit_declared_timing_items: --side requires current or future" >&2
+      return 1
+    fi
+    _bk_decl_side="$1"
+    shift
+  fi
+
+  if [ $# -ne 1 ] || [ -z "$1" ]; then
+    echo "bk_emit_declared_timing_items: requires a newline-separated item list" >&2
+    return 1
+  fi
+
+  while IFS='|' read -r _bk_decl_kind _bk_decl_name _bk_decl_time _bk_decl_artifact; do
+    [ -n "$_bk_decl_kind$_bk_decl_name$_bk_decl_time$_bk_decl_artifact" ] || continue
+    case "$_bk_decl_kind" in
+      section)
+        bk_emit_declared_section --side "$_bk_decl_side" "$_bk_decl_name" "$_bk_decl_time" "$_bk_decl_artifact"
+        ;;
+      overlap)
+        bk_emit_declared_overlap --side "$_bk_decl_side" "$_bk_decl_name" "$_bk_decl_time" "$_bk_decl_artifact"
+        ;;
+      \#*)
+        ;;
+      *)
+        echo "bk_emit_declared_timing_items: unsupported item kind '${_bk_decl_kind}'" >&2
+        return 1
+        ;;
+    esac
+  done <<EOF
+$1
+EOF
+}
+
+bk_emit_declared_fractional_items() {
+  _bk_decl_side="future"
+  if [ $# -gt 1 ] && [ "$1" = "--side" ]; then
+    shift
+    if [ $# -eq 0 ]; then
+      echo "bk_emit_declared_fractional_items: --side requires current or future" >&2
+      return 1
+    fi
+    _bk_decl_side="$1"
+    shift
+  fi
+
+  if [ $# -ne 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
+    echo "bk_emit_declared_fractional_items: requires <total_time> <newline-separated fractional item list>" >&2
+    return 1
+  fi
+
+  _bk_decl_total_time="$1"
+  _bk_decl_timing_items=""
+  while IFS='|' read -r _bk_decl_kind _bk_decl_name _bk_decl_fraction _bk_decl_artifact; do
+    [ -n "$_bk_decl_kind$_bk_decl_name$_bk_decl_fraction$_bk_decl_artifact" ] || continue
+    case "$_bk_decl_kind" in
+      section|overlap)
+        _bk_decl_time=$(awk -v total="$_bk_decl_total_time" -v fraction="$_bk_decl_fraction" 'BEGIN {printf "%.3f", total * fraction}')
+        if [ -n "$_bk_decl_timing_items" ]; then
+          _bk_decl_timing_items="${_bk_decl_timing_items}
+${_bk_decl_kind}|${_bk_decl_name}|${_bk_decl_time}|${_bk_decl_artifact}"
+        else
+          _bk_decl_timing_items="${_bk_decl_kind}|${_bk_decl_name}|${_bk_decl_time}|${_bk_decl_artifact}"
+        fi
+        ;;
+      \#*)
+        ;;
+      *)
+        echo "bk_emit_declared_fractional_items: unsupported item kind '${_bk_decl_kind}'" >&2
+        return 1
+        ;;
+    esac
+  done <<EOF
+$2
+EOF
+
+  bk_emit_declared_timing_items --side "$_bk_decl_side" "$_bk_decl_timing_items"
 }
 
 bk_list_declared_estimation_packages() {

--- a/scripts/estimation/common.sh
+++ b/scripts/estimation/common.sh
@@ -369,6 +369,149 @@ bk_estimation_write_output() {
   echo "Estimate written to $output_file"
 }
 
+bk_estimation_section_key() {
+  printf '%s\n' "$1" | tr '[:lower:]' '[:upper:]' | sed 's/[^A-Z0-9]/_/g'
+}
+
+bk_estimation_configure_gpu_kernel_defaults() {
+  local source_gpu="$1"
+  local target_gpu="$2"
+  local candidate_packages="${3:-}"
+  local kernel_count="${4:-20}"
+  local artifact_mode="${5:-ncu}"
+
+  BK_GPU_MLP_ARTIFACT_MODE="${BK_GPU_MLP_ARTIFACT_MODE:-$artifact_mode}"
+  BK_GPU_MLP_SOURCE_GPU="${BK_GPU_MLP_SOURCE_GPU:-$source_gpu}"
+  BK_GPU_MLP_TARGET_GPU="${BK_GPU_MLP_TARGET_GPU:-$target_gpu}"
+  BK_GPU_MLP_KERNEL_COUNT="${BK_GPU_MLP_KERNEL_COUNT:-$kernel_count}"
+  BK_GPU_LIGHTGBM_ARTIFACT_MODE="${BK_GPU_LIGHTGBM_ARTIFACT_MODE:-$artifact_mode}"
+  BK_GPU_LIGHTGBM_SOURCE_GPU="${BK_GPU_LIGHTGBM_SOURCE_GPU:-$source_gpu}"
+  BK_GPU_LIGHTGBM_TARGET_GPU="${BK_GPU_LIGHTGBM_TARGET_GPU:-$target_gpu}"
+  if [[ -n "$candidate_packages" ]]; then
+    BK_GPU_KERNEL_ENSEMBLE_PACKAGES="${BK_GPU_KERNEL_ENSEMBLE_PACKAGES:-$candidate_packages}"
+    export BK_GPU_KERNEL_ENSEMBLE_PACKAGES
+  fi
+  export BK_GPU_MLP_ARTIFACT_MODE
+  export BK_GPU_MLP_SOURCE_GPU
+  export BK_GPU_MLP_TARGET_GPU
+  export BK_GPU_MLP_KERNEL_COUNT
+  export BK_GPU_LIGHTGBM_ARTIFACT_MODE
+  export BK_GPU_LIGHTGBM_SOURCE_GPU
+  export BK_GPU_LIGHTGBM_TARGET_GPU
+}
+
+bk_estimation_configure_gpu_kernel_section_regexes() {
+  local section_key
+  local var_name
+
+  if [[ $# -ne 1 || -z "$1" ]]; then
+    echo "bk_estimation_configure_gpu_kernel_section_regexes: requires a newline-separated section|regex list" >&2
+    return 1
+  fi
+
+  while IFS='|' read -r section_name regex; do
+    [[ -n "$section_name$regex" ]] || continue
+    case "$section_name" in
+      \#*)
+        continue
+        ;;
+    esac
+    section_key=$(bk_estimation_section_key "$section_name")
+    var_name="BK_GPU_KERNEL_SECTION_${section_key}_REGEX"
+    if [[ -z "${!var_name:-}" ]]; then
+      printf -v "$var_name" '%s' "$regex"
+    fi
+    export "$var_name"
+  done <<EOF
+$1
+EOF
+}
+
+bk_estimation_artifact_file_exists() {
+  local rel_path="$1"
+  local root="${2:-}"
+
+  [[ -n "$rel_path" ]] || return 1
+  if [[ -f "$rel_path" ]]; then
+    return 0
+  fi
+  if [[ -n "$root" && -f "${root}/${rel_path}" ]]; then
+    return 0
+  fi
+  return 1
+}
+
+bk_estimation_resolve_section_artifact() {
+  local env_prefix="$1"
+  local root="$2"
+  local section_name="$3"
+  local section_key
+  local env_var
+  local explicit_artifact
+  local candidate
+
+  shift 3
+  section_key=$(bk_estimation_section_key "$section_name")
+  env_var="${env_prefix}_${section_key}_ARTIFACT"
+  explicit_artifact="${!env_var:-}"
+  if [[ -n "$explicit_artifact" ]]; then
+    if bk_estimation_artifact_file_exists "$explicit_artifact" "$root"; then
+      printf '%s\n' "$explicit_artifact"
+      return 0
+    fi
+    echo "Section artifact was requested but not found: ${env_var}=${explicit_artifact}" >&2
+    return 1
+  fi
+
+  for candidate in "$@"; do
+    if bk_estimation_artifact_file_exists "$candidate" "$root"; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+bk_estimation_input_has_fom_breakdown() {
+  local input_json="$1"
+
+  jq -e '((.fom_breakdown.sections // []) | length) > 0' "$input_json" >/dev/null 2>&1
+}
+
+bk_estimation_write_total_identity_breakdown_input() {
+  local input_json="$1"
+  local output_json="$2"
+
+  jq '
+    .fom_breakdown = {
+      sections: [
+        {
+          name: "total",
+          time: (.FOM | tonumber),
+          estimation_package: "identity"
+        }
+      ],
+      overlaps: []
+    }
+  ' "$input_json" > "$output_json"
+}
+
+bk_estimation_mark_gpu_section_time_missing() {
+  local app_name="${1:-application}"
+
+  bk_estimation_set_applicability \
+    "partially_applicable" \
+    "" \
+    '["app_gpu_section_time"]' \
+    '["provide-app-side-gpu-section-time-to-enable-gpu-kernel-estimator-fom-composition"]'
+
+  est_notes_json=$(jq -cn --arg app_name "$app_name" '{
+    summary: ($app_name + " GPU kernel estimator data may contain profiler sample ratios, but FOM composition used a total identity section because app-side GPU section time is not available yet."),
+    gpu_kernel_estimation: "Profiler sample predicted/source ratios must be applied to app-side GPU section time before they can contribute to FOM reconstruction."
+  }')
+}
+
 # ---------------------------------------------------------------------------
 # read_values — Read benchmark Result_JSON into global variables
 #

--- a/scripts/estimation/section_packages/gpu_kernel_ensemble_average.sh
+++ b/scripts/estimation/section_packages/gpu_kernel_ensemble_average.sh
@@ -27,7 +27,7 @@ EOF
 
 _bk_gpu_kernel_ensemble_packages() {
   local item_json="$1"
-  local raw="${BK_GPU_KERNEL_ENSEMBLE_PACKAGES:-}"
+  local raw="${BK_GPU_KERNEL_ENSEMBLE_PACKAGES:-gpu_kernel_lightgbm_v10,gpu_kernel_mlp_v15,gpu_kernel_mlp_v21,gpu_kernel_mlp_v40,gpu_kernel_mlp_v41}"
 
   if echo "$item_json" | jq -e '(.candidate_estimation_packages // []) | length > 0' >/dev/null 2>&1; then
     echo "$item_json" | jq -r '.candidate_estimation_packages[]'

--- a/scripts/tests/test_estimation_gpu_kernel_ensemble_average.sh
+++ b/scripts/tests/test_estimation_gpu_kernel_ensemble_average.sh
@@ -94,6 +94,7 @@ EOF
 pushd "${TMP_DIR}" >/dev/null
 source scripts/estimation/common.sh
 source scripts/estimation/packages/instrumented_app_sections_dummy.sh
+source scripts/estimation/section_packages/gpu_kernel_ensemble_average.sh
 
 export BK_GPU_KERNEL_ENSEMBLE_PACKAGES="gpu_kernel_lightgbm_v10,gpu_kernel_mlp_v15"
 export BK_GPU_LIGHTGBM_ARTIFACT_MODE="prediction"
@@ -106,6 +107,11 @@ export BK_GPU_MLP_INPUT_CSV="${TMP_DIR}/source_input_single.csv"
 export BK_GPU_MLP_PYTHON="$PYTHON_BIN"
 
 transformed_single=$(bk_top_level_transform_breakdown "$(cat "${TMP_DIR}/breakdown.json")" "1" "1" "1" "identity" "identity")
+
+unset BK_GPU_KERNEL_ENSEMBLE_PACKAGES
+default_packages=$(_bk_gpu_kernel_ensemble_packages "$(cat "${TMP_DIR}/breakdown.json")" | paste -sd, -)
+test "$default_packages" = "gpu_kernel_lightgbm_v10,gpu_kernel_mlp_v15,gpu_kernel_mlp_v21,gpu_kernel_mlp_v40,gpu_kernel_mlp_v41"
+export BK_GPU_KERNEL_ENSEMBLE_PACKAGES="gpu_kernel_lightgbm_v10,gpu_kernel_mlp_v15"
 
 export BK_GPU_MLP_PREDICTION_CSV="${TMP_DIR}/mlp_pred_zero.csv"
 transformed_zero_candidate=$(bk_top_level_transform_breakdown "$(cat "${TMP_DIR}/breakdown.json")" "1" "1" "1" "identity" "identity")

--- a/scripts/tests/test_genesis_gpu_mlp_estimation.sh
+++ b/scripts/tests/test_genesis_gpu_mlp_estimation.sh
@@ -20,7 +20,11 @@ source programs/genesis/estimate.sh
 test "${BK_ESTIMATION_BASELINE_EXP}" = "p8"
 test "${BK_ESTIMATION_BASELINE_SYSTEM}" = "Fugaku"
 test "${BK_ESTIMATION_FUTURE_SYSTEM}" = "FugakuNEXT"
-test "${BK_GPU_KERNEL_ENSEMBLE_PACKAGES}" = "gpu_kernel_lightgbm_v10,gpu_kernel_mlp_v15,gpu_kernel_mlp_v21,gpu_kernel_mlp_v40,gpu_kernel_mlp_v41"
+
+source programs/genesis/parse_timing.sh
+source programs/genesis/sections.sh
+genesis_declare_estimation_layout
+bk_estimation_apply_declared_defaults
 
 cat > results/no_breakdown_input.json <<'EOF'
 {
@@ -32,9 +36,9 @@ cat > results/no_breakdown_input.json <<'EOF'
   "numproc_node": 8
 }
 EOF
-! genesis_input_has_fom_breakdown results/no_breakdown_input.json
-genesis_write_total_identity_breakdown_input results/no_breakdown_input.json results/total_breakdown_input.json
-genesis_input_has_fom_breakdown results/total_breakdown_input.json
+! bk_estimation_input_has_fom_breakdown results/no_breakdown_input.json
+bk_estimation_write_total_identity_breakdown_input results/no_breakdown_input.json results/total_breakdown_input.json
+bk_estimation_input_has_fom_breakdown results/total_breakdown_input.json
 jq -e '
   .fom_breakdown.sections[0].name == "total" and
   .fom_breakdown.sections[0].time == 50.5 and
@@ -65,6 +69,8 @@ cat > results/log_p8.txt <<'EOF'
 EOF
 
 genesis_extract_dynamics_sections results/log_p8.txt 48.862 > results/genesis_sections.tsv
+bash programs/genesis/parse_timing.sh results/log_p8.txt 48.862 > results/genesis_sections_cli.tsv
+cmp results/genesis_sections.tsv results/genesis_sections_cli.tsv
 test "$(wc -l < results/genesis_sections.tsv)" = "11"
 awk '
   $1 == "section" { sum += $3 }
@@ -165,6 +171,7 @@ genesis_emit_estimation_data_from_log results/log_p8_overlap.txt 156.531 > resul
 grep -q '^SECTION:overlap:pairlist,bond,angle,dihedral,pme_real_wait,pme_real_inter,pme_real_intra,pme_recip,integrator .* type:overlap members:pairlist,bond,angle,dihedral,pme_real_wait,pme_real_inter,pme_real_intra,pme_recip,integrator estimation_package:identity' results/sections_with_overlap.result
 
 touch results/padata_pairlist.tgz
+export BK_GENESIS_SECTION_PAIRLIST_ARTIFACT="results/padata_pairlist.tgz"
 genesis_emit_estimation_data_from_log results/log_p8.txt 48.862 > results/sections_with_archive.result
 grep -q '^SECTION:pairlist .* estimation_package:gpu_kernel_ensemble_average artifact:results/padata_pairlist.tgz' results/sections_with_archive.result
 grep -q '^SECTION:pme_real_inter .* estimation_package:gpu_kernel_ensemble_average$' results/sections_with_archive.result
@@ -172,18 +179,15 @@ grep -q '^SECTION:pme_real_intra .* estimation_package:gpu_kernel_ensemble_avera
 
 touch results/padata_inter.tgz
 touch results/padata_intra.tgz
+export BK_GENESIS_SECTION_PME_REAL_INTER_ARTIFACT="results/padata_inter.tgz"
+export BK_GENESIS_SECTION_PME_REAL_INTRA_ARTIFACT="results/padata_intra.tgz"
 genesis_emit_estimation_data_from_log results/log_p8.txt 48.862 > results/sections_with_explicit_pme_real_archive.result
 grep -q '^SECTION:pme_real_inter .* estimation_package:gpu_kernel_ensemble_average artifact:results/padata_inter.tgz' results/sections_with_explicit_pme_real_archive.result
 grep -q '^SECTION:pme_real_intra .* estimation_package:gpu_kernel_ensemble_average artifact:results/padata_intra.tgz' results/sections_with_explicit_pme_real_archive.result
 
-BK_GENESIS_GPU_SECTION_PACKAGE=gpu_kernel_mlp_v15 \
-  bash -c 'source programs/genesis/estimate.sh; genesis_emit_estimation_data_from_log results/log_p8.txt 48.862' \
-  > results/sections_with_mlp_archive.result
-grep -q '^SECTION:pairlist .* estimation_package:gpu_kernel_mlp_v15 artifact:results/padata_pairlist.tgz' results/sections_with_mlp_archive.result
-
 mkdir -p genesis_benchmark_input/npt/genesis2.0beta_3.5fs/apoa1
 GENESIS_BENCHKIT_ROOT="$PWD" \
-  bash -c 'source programs/genesis/estimate.sh; cd genesis_benchmark_input/npt/genesis2.0beta_3.5fs/apoa1; genesis_emit_estimation_data_from_log "$GENESIS_BENCHKIT_ROOT/results/log_p8.txt" 48.862' \
+  bash -c 'source scripts/bk_functions.sh; source scripts/estimation/common.sh; source programs/genesis/parse_timing.sh; source programs/genesis/sections.sh; genesis_declare_estimation_layout; bk_estimation_apply_declared_defaults; export BK_GENESIS_SECTION_PAIRLIST_ARTIFACT=results/padata_pairlist.tgz; cd genesis_benchmark_input/npt/genesis2.0beta_3.5fs/apoa1; genesis_emit_estimation_data_from_log "$GENESIS_BENCHKIT_ROOT/results/log_p8.txt" 48.862' \
   > results/from_subdir.result
 grep -q 'artifact:results/padata_pairlist.tgz' results/from_subdir.result
 popd >/dev/null


### PR DESCRIPTION
Split GENESIS timing parsing, section metadata emission, and estimation execution so run-time result metadata can carry section artifact bindings through results/result and Result JSON.

Move shared fallback helpers and declaration emitters into common BenchKit functions, keep GPU estimator package selection in common section packages, and document the app-local boundary for GENESIS and QWS.