### PR TITLE
Fix usage report period column width

### DIFF
--- a/result_server/templates/usage_report.html
+++ b/result_server/templates/usage_report.html
@@ -67,8 +67,18 @@
     .usage-node-hours-table .usage-node-hours-head {
       background-color: #f2f2f2;
     }
-    .usage-node-hours-table .usage-node-hours-period {
+    .usage-node-hours-table th.usage-node-hours-period {
+      background-color: #f2f2f2;
+      box-shadow: inset 0 -1px 0 #d8e3e8;
+      left: auto;
+      min-width: 78px;
+      text-align: center;
       white-space: nowrap;
+      width: 78px;
+      z-index: 3;
+    }
+    .usage-node-hours-table th.usage-node-hours-total-head.usage-node-hours-period {
+      background-color: #e2e2e2;
     }
     .usage-node-hours-table .usage-node-hours-app {
       font-weight: bold;


### PR DESCRIPTION
Override the generic first-column sticky styling for node-hour period headers so the first period column under each grouped system no longer expands wider than the other period columns.