### PR TITLE
Fix Rikyu and DGX Spark scheduler configuration

### DIFF
--- a/config/queue.csv
+++ b/config/queue.csv
@@ -1,5 +1,5 @@
 queue,submit_cmd,template
-SLURM_RIKYU,sbatch,"-p ${queue_group} --account=${account} -t ${elapse} -N ${nodes} --ntasks-per-node=${numproc_node} --cpus-per-task=${nthreads} --gpus-per-node=${numproc_node}"
+SLURM_RIKYU,sbatch,"-p ${queue_group} --account=${account} -t ${elapse} -N ${nodes} --ntasks-per-node=${numproc_node} --cpus-per-task=${nthreads} --gpus=${proc}"
 FJ,pjsub,"-L rscunit=rscunit_ft01,rscgrp=${queue_group},elapse=${elapse},node=${nodes} --mpi max-proc-per-node=${numproc_node} -x PJM_LLIO_GFSCACHE=/vol0002:/vol0003:/vol0004:/vol0005"
 PJM_GENKAI,pjsub,"-L rscgrp=${queue_group},elapse=${elapse},node=${nodes} --mpi proc=${proc}"
 SLURM_RC,sbatch,"-p ${queue_group} -t ${elapse} -N ${nodes} --ntasks-per-node=${numproc_node} --cpus-per-task=${nthreads}"

--- a/config/queue.csv
+++ b/config/queue.csv
@@ -1,5 +1,5 @@
 queue,submit_cmd,template
-SLURM_RIKYU,sbatch,"-p ${queue_group} -t ${elapse} -N ${nodes} --ntasks-per-node=${numproc_node} --cpus-per-task=${nthreads} --gpus-per-node=${numproc_node}"
+SLURM_RIKYU,sbatch,"-p ${queue_group} --account=${account} -t ${elapse} -N ${nodes} --ntasks-per-node=${numproc_node} --cpus-per-task=${nthreads} --gpus-per-node=${numproc_node}"
 FJ,pjsub,"-L rscunit=rscunit_ft01,rscgrp=${queue_group},elapse=${elapse},node=${nodes} --mpi max-proc-per-node=${numproc_node} -x PJM_LLIO_GFSCACHE=/vol0002:/vol0003:/vol0004:/vol0005"
 PJM_GENKAI,pjsub,"-L rscgrp=${queue_group},elapse=${elapse},node=${nodes} --mpi proc=${proc}"
 SLURM_RC,sbatch,"-p ${queue_group} -t ${elapse} -N ${nodes} --ntasks-per-node=${numproc_node} --cpus-per-task=${nthreads}"

--- a/config/system.csv
+++ b/config/system.csv
@@ -1,9 +1,9 @@
-system,mode,tag_build,tag_run,queue,queue_group
-RIKYU,cross,ai4ss_login,ai4ss_jacamar,SLURM_RIKYU,1n1gpu
+system,mode,tag_build,tag_run,queue,queue_group,account
+RIKYU,cross,ai4ss_login,ai4ss_jacamar,SLURM_RIKYU,gpu,rkp00012
 Fugaku,cross,fugaku_login1,fugaku_jacamar,FJ,small
 FugakuCN,native,,fugaku_jacamar,FJ,small
 RC_GH200,native,,cloud_jacamar,SLURM_RC,qc-gh200
-RC_DGXSP,native,,cloud_jacamar,SLURM_RC,ng-dgx-3h
+RC_DGXSP,native,,cloud_jacamar,SLURM_RC,ng-dgx-m1
 RC_GENOA,native,,cloud_jacamar,SLURM_RC,genoa
 RC_FX700,native,,cloud_jacamar,SLURM_RC,fx700
 MiyabiG,cross,miyabi_g_login,miyabi_g_jacamar,PBS_Miyabi,debug-g

--- a/docs/cx/BENCHKIT_SPEC.md
+++ b/docs/cx/BENCHKIT_SPEC.md
@@ -251,7 +251,7 @@ BenchKit の system / queue 定義層である。
 - `queue.csv` に scheduler template を持つ
 - app 側の `list.csv` から system 固有事情を切り離す
 
-`system.csv` は system 名、mode、runner tag、queue、queue_group などの正本である。
+`system.csv` は system 名、mode、runner tag、queue、queue_group、scheduler account などの正本である。
 
 This is the system and queue definition layer.
 
@@ -261,7 +261,8 @@ Main roles:
 - `queue.csv` holds scheduler templates
 - system-specific concerns are separated from app-side `list.csv`
 
-`system.csv` is the source of truth for items such as system name, mode, runner tag, queue, and queue_group.
+`system.csv` is the source of truth for items such as system name, mode,
+runner tag, queue, queue_group, and scheduler account.
 
 ### 6.4 ポータル層 / Portal Layer
 

--- a/docs/guides/add-site.md
+++ b/docs/guides/add-site.md
@@ -547,12 +547,12 @@ command_delay = "30s"
 ### `config/system.csv` にシステムを追加
 
 ```csv
-system,mode,tag_build,tag_run,queue,queue_group
+system,mode,tag_build,tag_run,queue,queue_group,account
 # 既存エントリ...
 # cross モード（ビルドと実行が別ノード）
-NewSystem,cross,newsystem_login,newsystem_jacamar,PBS_NewSystem,default
+NewSystem,cross,newsystem_login,newsystem_jacamar,PBS_NewSystem,default,
 # native モード（同一ノードでビルドと実行）
-NewSystemLN,native,,newsystem_login,none,default
+NewSystemLN,native,,newsystem_login,none,default,
 ```
 
 - `system`: システム名（アプリの `list.csv` から参照される）
@@ -561,6 +561,7 @@ NewSystemLN,native,,newsystem_login,none,default
 - `tag_run`: 実行用GitLab Runnerタグ（`native`の場合はbuild_runジョブ用）
 - `queue`: `config/queue.csv` のキュー名（ログインノードは `none`）
 - `queue_group`: キューグループ名
+- `account`: scheduler account/project。不要な拠点では空欄
 
 ### `config/queue.csv` にキューシステムを追加（必要な場合）
 
@@ -571,7 +572,7 @@ queue,submit_cmd,template
 PBS_NewSystem,qsub,"-q ${queue_group} -l select=${nodes} -l walltime=${elapse} -W group_list=your_group"
 ```
 
-テンプレート内で使える変数：`${queue_group}`, `${nodes}`, `${numproc_node}`, `${nthreads}`, `${elapse}`, `${proc}`（`nodes * numproc_node`）, `${cpu_per_node}`, `${gpu_per_node}`, `${cpu_sockets}`（`nodes * cpu_per_node`）, `${gpu_cards}`（`nodes * gpu_per_node`）
+テンプレート内で使える変数：`${queue_group}`, `${account}`, `${nodes}`, `${numproc_node}`, `${nthreads}`, `${elapse}`, `${proc}`（`nodes * numproc_node`）, `${cpu_per_node}`, `${gpu_per_node}`, `${cpu_sockets}`（`nodes * cpu_per_node`）, `${gpu_cards}`（`nodes * gpu_per_node`）
 
 `${cpu_per_node}` と `${gpu_per_node}` は `config/system_info.csv` から取得します。CPU socket 数や GPU card 数を scheduler に明示するサイトでは、`system_info.csv` の値も投入条件に使われます。
 

--- a/scripts/job_functions.sh
+++ b/scripts/job_functions.sh
@@ -64,6 +64,14 @@ get_system_queue_group() {
     return 0
 }
 
+# System_CSVからscheduler accountを取得する
+# Account-less systems return an empty string.
+get_system_account() {
+    local system="$1"
+    awk -F, -v s="$system" '$1==s {print $7}' "$SYSTEM_FILE"
+    return 0
+}
+
 # Queue templates can request aggregate CPU sockets or GPU cards. Pull the
 # per-node values from system_info.csv instead of duplicating them in queue.csv.
 get_system_cpu_per_node() {

--- a/scripts/matrix_generate.sh
+++ b/scripts/matrix_generate.sh
@@ -69,6 +69,7 @@ for listfile in programs/*/list.csv; do
 
     mode=$(get_system_mode "$system")
     queue_group=$(get_system_queue_group "$system")
+    account=$(get_system_account "$system")
 
     # Skip if mode or queue_group is empty (system not found in System_CSV)
     if [[ -z "$mode" || -z "$queue_group" ]]; then
@@ -88,7 +89,7 @@ for listfile in programs/*/list.csv; do
     [[ "$gpu_per_node" =~ ^[0-9]+$ ]] || gpu_per_node=0
     cpu_sockets=$((nodes * cpu_per_node))
     gpu_cards=$((nodes * gpu_per_node))
-	export elapse nodes queue_group numproc_node nthreads proc cpu_per_node gpu_per_node cpu_sockets gpu_cards
+	export elapse nodes queue_group account numproc_node nthreads proc cpu_per_node gpu_per_node cpu_sockets gpu_cards
 
 	read -r submit_cmd template <<< "$(get_queue_template "$system")"
     if [[ -z "$submit_cmd" || -z "$template" ]]; then

--- a/scripts/test_submit.sh
+++ b/scripts/test_submit.sh
@@ -85,13 +85,14 @@ fi
 # --- System_CSV から mode/queue_group を取得 ---
 mode=$(get_system_mode "$system")
 queue_group=$(get_system_queue_group "$system")
+account=$(get_system_account "$system")
 
 # --- 選択された設定を表示 ---
 echo "Selected configuration from $list_file (line $list_csv_line_num):"
 echo "  $line"
 echo ""
 echo "Parsed values:"
-echo "  system=$system, enable=$enable, mode=$mode (from system.csv), queue_group=$queue_group (from system.csv)"
+echo "  system=$system, enable=$enable, mode=$mode (from system.csv), queue_group=$queue_group (from system.csv), account=${account:-<default>}"
 echo "  nodes=$nodes, numproc_node=$numproc_node, nthreads=$nthreads, elapse=$elapse"
 
 # --- 投入用スクリプト作成 ---
@@ -221,9 +222,13 @@ case "$system" in
          -l elapstim_req=${elapse} -v OMP_NUM_THREADS=${nthreads} script.sh
     ;;
   RIKYU)
-    echo sbatch -p $queue_group -N $nodes -t $elapse --ntasks-per-node=${numproc_node} --cpus-per-task=$nthreads --gpus-per-node=${numproc_node} \
+    if [[ -z "$account" ]]; then
+      echo "Error: RIKYU requires an account in config/system.csv" >&2
+      exit 1
+    fi
+    echo sbatch -p $queue_group --account=$account -N $nodes -t $elapse --ntasks-per-node=${numproc_node} --cpus-per-task=$nthreads --gpus-per-node=${numproc_node} \
 	 --wrap="bash programs/$code/run.sh $system $nodes $numproc_node $nthreads"
-    sbatch -p $queue_group -N $nodes -t $elapse --ntasks-per-node=${numproc_node} --cpus-per-task=$nthreads --gpus-per-node=${numproc_node} \
+    sbatch -p $queue_group --account=$account -N $nodes -t $elapse --ntasks-per-node=${numproc_node} --cpus-per-task=$nthreads --gpus-per-node=${numproc_node} \
 	   --wrap="bash programs/${code}/run.sh $system $nodes $numproc_node $nthreads"
     ;;
   RC_GH200|RC_DGXSP|RC_GENOA|RC_FX700)

--- a/scripts/test_submit.sh
+++ b/scripts/test_submit.sh
@@ -226,9 +226,10 @@ case "$system" in
       echo "Error: RIKYU requires an account in config/system.csv" >&2
       exit 1
     fi
-    echo sbatch -p $queue_group --account=$account -N $nodes -t $elapse --ntasks-per-node=${numproc_node} --cpus-per-task=$nthreads --gpus-per-node=${numproc_node} \
+    proc=$((nodes * numproc_node))
+    echo sbatch -p $queue_group --account=$account -N $nodes -t $elapse --ntasks-per-node=${numproc_node} --cpus-per-task=$nthreads --gpus=$proc \
 	 --wrap="bash programs/$code/run.sh $system $nodes $numproc_node $nthreads"
-    sbatch -p $queue_group --account=$account -N $nodes -t $elapse --ntasks-per-node=${numproc_node} --cpus-per-task=$nthreads --gpus-per-node=${numproc_node} \
+    sbatch -p $queue_group --account=$account -N $nodes -t $elapse --ntasks-per-node=${numproc_node} --cpus-per-task=$nthreads --gpus=$proc \
 	   --wrap="bash programs/${code}/run.sh $system $nodes $numproc_node $nthreads"
     ;;
   RC_GH200|RC_DGXSP|RC_GENOA|RC_FX700)


### PR DESCRIPTION
## Problem

BenchKit's shared scheduler configuration no longer matched the live Rikyu
and R-CCS Cloud DGX Spark queues:

- Rikyu used the retired `1n1gpu` partition and did not pass a project account.
- DGX Spark used the retired `ng-dgx-3h` partition.

## Changes

- Add an optional `account` field to `config/system.csv` and expose it to
  scheduler templates.
- Configure Rikyu to use partition `gpu` and account `rkp00012`.
- Configure DGX Spark to use partition `ng-dgx-m1`.
- Pass the Rikyu account through matrix generation and `test_submit.sh`.
- Request Rikyu GPUs as the scheduler-required total `--gpus=N`, rather than
  the unsupported per-node form.
- Document the optional site-level scheduler account.

Systems that do not require an explicit account leave the field empty and
retain their current behavior.

## Validation

- `bash -n scripts/job_functions.sh scripts/matrix_generate.sh scripts/test_submit.sh`
- `python3 result_server/tests/check_site_config.py`
- `git diff --check`
- Generated the matrix under Linux Bash on Rikyu and confirmed:
  - Rikyu: `-p gpu --account=rkp00012`
  - DGX Spark: `-p ng-dgx-m1`
- Used `scripts/test_submit.sh sbd 2` from the dependent PR checkout to submit
  a real two-node/eight-GPU Rikyu job. Slurm accepted
  `--gpus=8`, the job completed successfully, and SBD converged to
  `-76.2437767768609 Ha`.

The SBD application PR depends on this shared site fix.
