### PR TITLE
Support multiple portal GitLab targets

### DIFF
--- a/docs/guides/portal-execution-profiles-handoff.md
+++ b/docs/guides/portal-execution-profiles-handoff.md
@@ -61,6 +61,20 @@ have permission to create pipelines in that GitLab project. The Portal records
 the request payload, GitLab response metadata, status, and errors in
 `execution_requests`; it must not record the token value.
 
+For multiple destinations, configure named targets instead of the single-repo
+fallback:
+
+```text
+RESULT_SERVER_GITLAB_TARGETS=swc=gitlab.swc.example.org/group/project,gitlab_com=gitlab.com/group/project
+RESULT_SERVER_GITLAB_TOKEN_SWC=<site-local GitLab API token>
+RESULT_SERVER_GITLAB_TOKEN_GITLAB_COM=<site-local GitLab API token>
+```
+
+Target IDs may contain letters, digits, `_`, `.`, and `-`. The token variable is
+`RESULT_SERVER_GITLAB_TOKEN_<TARGET_ID>` with non-alphanumeric characters
+converted to `_` and uppercased. Store these variables in the Portal systemd
+`EnvironmentFile`, not in the repository.
+
 ## Compatibility Expectations
 
 Keep the existing `list.csv` and `queue.csv` paths working. Execution profiles

--- a/result_server/routes/admin.py
+++ b/result_server/routes/admin.py
@@ -28,7 +28,8 @@ from utils.execution_profiles import (
 )
 from utils.gitlab_pipeline import (
     build_pipeline_plan,
-    configured_gitlab_repo,
+    configured_gitlab_target,
+    configured_gitlab_targets,
     configured_gitlab_token,
     submit_pipeline_plan,
 )
@@ -136,6 +137,7 @@ def _build_execution_pipeline_plan(store):
     """Resolve the submitted target and build a GitLab pipeline plan."""
     target_ref = request.form.get("target_ref", "").strip() or "develop"
     profile_id = request.form.get("profile_id", "").strip()
+    gitlab_target_id = request.form.get("gitlab_target", "").strip()
     code = request.form.get("code", "").strip()
     system = request.form.get("system", "").strip()
     exp = request.form.get("exp", "").strip()
@@ -151,8 +153,9 @@ def _build_execution_pipeline_plan(store):
         exp=exp,
     )
     profile = resolve_result.profile
+    gitlab_target, target_errors = configured_gitlab_target(gitlab_target_id)
     plan = build_pipeline_plan(
-        gitlab_repo=configured_gitlab_repo(),
+        gitlab_repo=gitlab_target.repo if gitlab_target else "",
         target_ref=target_ref,
         code=code,
         system=system,
@@ -161,16 +164,19 @@ def _build_execution_pipeline_plan(store):
         park_only=park_only,
         park_send=park_send,
         scheduler_extra_args=resolve_result.scheduler_extra_args,
+        target_id=gitlab_target.id if gitlab_target else gitlab_target_id,
     )
     return {
         "target_ref": target_ref,
         "profile_id": profile_id,
+        "gitlab_target": gitlab_target,
+        "gitlab_target_id": gitlab_target.id if gitlab_target else gitlab_target_id,
         "code": code,
         "system": system,
         "exp": exp,
         "profile": profile,
         "plan": plan,
-        "errors": resolve_result.errors + plan.errors,
+        "errors": target_errors + resolve_result.errors + plan.errors,
     }
 
 
@@ -226,6 +232,8 @@ def execution_profiles():
         "admin_execution_profiles.html",
         profile_result=profile_result,
         dry_run_result=None,
+        submit_result=None,
+        gitlab_targets=configured_gitlab_targets()[0],
     )
 
 
@@ -293,6 +301,7 @@ def dry_run_execution_profile_submit():
     submit_plan = _build_execution_pipeline_plan(store)
     target_ref = submit_plan["target_ref"]
     profile_id = submit_plan["profile_id"]
+    gitlab_target_id = submit_plan["gitlab_target_id"]
     code = submit_plan["code"]
     system = submit_plan["system"]
     exp = submit_plan["exp"]
@@ -309,7 +318,11 @@ def dry_run_execution_profile_submit():
         code=code,
         system=system,
         exp=exp,
-        payload={"api_url": plan.api_url, "payload": plan.payload},
+        payload={
+            "api_url": plan.api_url,
+            "gitlab_target": gitlab_target_id,
+            "payload": plan.payload,
+        },
         errors=errors,
         actor=session.get("user_email", ""),
     )
@@ -322,6 +335,7 @@ def dry_run_execution_profile_submit():
         details={
             "request_id": request_id,
             "target_ref": target_ref,
+            "gitlab_target": gitlab_target_id,
             "code": code,
             "system": system,
             "exp": exp,
@@ -338,11 +352,13 @@ def dry_run_execution_profile_submit():
             "status": status,
             "profile": profile,
             "api_url": plan.api_url,
+            "gitlab_target": gitlab_target_id,
             "payload_json": json.dumps(plan.payload, indent=2, sort_keys=True),
             "errors": errors,
             "warnings": plan.warnings,
         },
         submit_result=None,
+        gitlab_targets=configured_gitlab_targets()[0],
     )
 
 
@@ -356,6 +372,8 @@ def submit_execution_profile_pipeline():
     submit_plan = _build_execution_pipeline_plan(store)
     target_ref = submit_plan["target_ref"]
     profile_id = submit_plan["profile_id"]
+    gitlab_target = submit_plan["gitlab_target"]
+    gitlab_target_id = submit_plan["gitlab_target_id"]
     code = submit_plan["code"]
     system = submit_plan["system"]
     exp = submit_plan["exp"]
@@ -370,7 +388,7 @@ def submit_execution_profile_pipeline():
     if not errors:
         submit_result = submit_pipeline_plan(
             plan,
-            token=configured_gitlab_token(),
+            token=configured_gitlab_token(gitlab_target),
         )
         errors.extend(submit_result.errors)
 
@@ -381,6 +399,8 @@ def submit_execution_profile_pipeline():
     else:
         status = "submit_blocked"
     payload = {"api_url": plan.api_url, "payload": plan.payload}
+    if gitlab_target_id:
+        payload["gitlab_target"] = gitlab_target_id
     if submit_result is not None:
         payload["submit"] = {
             "status_code": submit_result.status_code,
@@ -408,6 +428,7 @@ def submit_execution_profile_pipeline():
         details={
             "request_id": request_id,
             "target_ref": target_ref,
+            "gitlab_target": gitlab_target_id,
             "code": code,
             "system": system,
             "exp": exp,
@@ -427,12 +448,14 @@ def submit_execution_profile_pipeline():
             "status": status,
             "profile": profile,
             "api_url": plan.api_url,
+            "gitlab_target": gitlab_target_id,
             "payload_json": json.dumps(plan.payload, indent=2, sort_keys=True),
             "errors": errors,
             "warnings": plan.warnings,
             "response": submit_result.response if submit_result else {},
             "status_code": submit_result.status_code if submit_result else 0,
         },
+        gitlab_targets=configured_gitlab_targets()[0],
     )
 
 

--- a/result_server/templates/admin_execution_profiles.html
+++ b/result_server/templates/admin_execution_profiles.html
@@ -261,6 +261,18 @@
             <input type="text" name="target_ref" value="develop" required>
         </label>
         <label>
+            GitLab Target
+            {% if gitlab_targets %}
+            <select name="gitlab_target">
+                {% for target in gitlab_targets %}
+                <option value="{{ target.id }}">{{ target.id }}</option>
+                {% endfor %}
+            </select>
+            {% else %}
+            <input type="text" name="gitlab_target" placeholder="default">
+            {% endif %}
+        </label>
+        <label>
             Profile ID
             <input type="text" name="profile_id" placeholder="optional explicit profile">
         </label>
@@ -301,6 +313,9 @@
     <div class="inline-notice">
         <strong>Dry-run request #{{ dry_run_result.request_id }}:</strong>
         {{ dry_run_result.status }}
+        {% if dry_run_result.gitlab_target %}
+        target <span class="profile-mono">{{ dry_run_result.gitlab_target }}</span>
+        {% endif %}
         {% if dry_run_result.profile %}
         using profile <span class="profile-mono">{{ dry_run_result.profile.id }}</span>
         {% endif %}
@@ -334,6 +349,18 @@
         <label>
             Target Ref
             <input type="text" name="target_ref" value="develop" required>
+        </label>
+        <label>
+            GitLab Target
+            {% if gitlab_targets %}
+            <select name="gitlab_target">
+                {% for target in gitlab_targets %}
+                <option value="{{ target.id }}">{{ target.id }}</option>
+                {% endfor %}
+            </select>
+            {% else %}
+            <input type="text" name="gitlab_target" placeholder="default">
+            {% endif %}
         </label>
         <label>
             Profile ID
@@ -382,6 +409,9 @@
         {{ submit_result.status }}
         {% if submit_result.status_code %}
         HTTP {{ submit_result.status_code }}
+        {% endif %}
+        {% if submit_result.gitlab_target %}
+        target <span class="profile-mono">{{ submit_result.gitlab_target }}</span>
         {% endif %}
         {% if submit_result.profile %}
         using profile <span class="profile-mono">{{ submit_result.profile.id }}</span>

--- a/result_server/tests/test_execution_profiles.py
+++ b/result_server/tests/test_execution_profiles.py
@@ -24,6 +24,9 @@ from utils.execution_profiles import (  # noqa: E402
 from utils.gitlab_pipeline import (  # noqa: E402
     GitLabPipelineSubmitResult,
     build_pipeline_plan,
+    configured_gitlab_target,
+    configured_gitlab_targets,
+    configured_gitlab_token,
     submit_pipeline_plan,
 )
 
@@ -494,6 +497,27 @@ def test_gitlab_pipeline_submit_blocks_without_token():
     assert result.errors == ["RESULT_SERVER_GITLAB_TOKEN is not set"]
 
 
+def test_gitlab_pipeline_targets_parse_multiple_destinations():
+    env = {
+        "RESULT_SERVER_GITLAB_TARGETS": (
+            "swc=gitlab.swc.example.org/fugakunext/benchmark/benchkit,"
+            "gitlab_com=gitlab.com/yoshifuminakamura/benchkit"
+        ),
+        "RESULT_SERVER_GITLAB_TOKEN_SWC": "swc-token",
+        "RESULT_SERVER_GITLAB_TOKEN_GITLAB_COM": "com-token",
+    }
+
+    targets, errors = configured_gitlab_targets(env)
+    selected, selected_errors = configured_gitlab_target("gitlab_com", env)
+
+    assert errors == []
+    assert [target.id for target in targets] == ["swc", "gitlab_com"]
+    assert targets[0].token_env == "RESULT_SERVER_GITLAB_TOKEN_SWC"
+    assert selected_errors == []
+    assert selected.repo == "gitlab.com/yoshifuminakamura/benchkit"
+    assert configured_gitlab_token(selected, env) == "com-token"
+
+
 def test_admin_execution_profiles_submit_posts_pipeline_and_records_request(
     tmp_path,
     monkeypatch,
@@ -549,6 +573,64 @@ def test_admin_execution_profiles_submit_posts_pipeline_and_records_request(
         assert payload_record["submit"]["status_code"] == 201
         assert payload_record["submit"]["response"]["id"] == 123
         assert "secret-token" not in row[3]
+    finally:
+        _cleanup(temp_dirs)
+
+
+def test_admin_execution_profiles_submit_uses_selected_gitlab_target(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.delenv("RESULT_SERVER_GITLAB_REPO", raising=False)
+    monkeypatch.delenv("RESULT_SERVER_GITLAB_TOKEN", raising=False)
+    monkeypatch.setenv(
+        "RESULT_SERVER_GITLAB_TARGETS",
+        "swc=gitlab.swc.example.org/fugakunext/benchmark/benchkit,"
+        "gitlab_com=gitlab.com/yoshifuminakamura/benchkit",
+    )
+    monkeypatch.setenv("RESULT_SERVER_GITLAB_TOKEN_GITLAB_COM", "com-token")
+    db_path = tmp_path / "cx_portal.sqlite3"
+    ExecutionProfileStore(str(db_path)).upsert_profile(_profile(), actor="admin")
+    app, temp_dirs = _admin_app(db_path)
+
+    def fake_submit(plan, *, token):
+        assert token == "com-token"
+        assert plan.target_id == "gitlab_com"
+        assert plan.api_url == "https://gitlab.com/api/v4/projects/yoshifuminakamura%2Fbenchkit/pipeline"
+        return GitLabPipelineSubmitResult(
+            status_code=201,
+            response={"id": 456, "web_url": "https://gitlab.com/p/456"},
+            errors=[],
+        )
+
+    monkeypatch.setattr("routes.admin.submit_pipeline_plan", fake_submit)
+    try:
+        with app.test_client() as client:
+            _login_admin(client)
+            resp = client.post(
+                "/admin/execution-profiles/submit",
+                data={
+                    "gitlab_target": "gitlab_com",
+                    "target_ref": "develop",
+                    "code": "qws",
+                    "system": "RIKYU",
+                    "exp": "case0",
+                    "confirm_submit": "on",
+                },
+            )
+
+        html = resp.data.decode()
+        assert resp.status_code == 200
+        assert "submitted" in html
+        assert "gitlab_com" in html
+
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT payload_json FROM execution_requests"
+            ).fetchone()
+        payload_record = json.loads(row[0])
+        assert payload_record["gitlab_target"] == "gitlab_com"
+        assert payload_record["submit"]["response"]["id"] == 456
     finally:
         _cleanup(temp_dirs)
 

--- a/result_server/utils/gitlab_pipeline.py
+++ b/result_server/utils/gitlab_pipeline.py
@@ -12,6 +12,16 @@ from typing import Any
 
 
 GITLAB_REPO_RE = re.compile(r"^[A-Za-z0-9_.:-]+/[A-Za-z0-9_.~/:-]+(?:\\.git)?$")
+GITLAB_TARGET_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$")
+
+
+@dataclass(frozen=True)
+class GitLabPipelineTarget:
+    """Configured GitLab pipeline destination."""
+
+    id: str
+    repo: str
+    token_env: str
 
 
 @dataclass(frozen=True)
@@ -22,6 +32,7 @@ class GitLabPipelinePlan:
     payload: dict[str, Any]
     errors: list[str]
     warnings: list[str]
+    target_id: str = ""
 
 
 @dataclass(frozen=True)
@@ -46,9 +57,93 @@ def configured_gitlab_repo(env: dict[str, str] | None = None) -> str:
     )
 
 
-def configured_gitlab_token(env: dict[str, str] | None = None) -> str:
+def _target_token_env(target_id: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9]", "_", target_id).upper()
+    return f"RESULT_SERVER_GITLAB_TOKEN_{normalized}"
+
+
+def configured_gitlab_targets(
+    env: dict[str, str] | None = None,
+) -> tuple[list[GitLabPipelineTarget], list[str]]:
+    """Return configured GitLab pipeline targets and validation errors."""
+    source = env if env is not None else os.environ
+    raw_targets = source.get("RESULT_SERVER_GITLAB_TARGETS", "").strip()
+    targets: list[GitLabPipelineTarget] = []
+    errors: list[str] = []
+    seen: set[str] = set()
+
+    if raw_targets:
+        for chunk in raw_targets.replace("\n", ",").split(","):
+            entry = chunk.strip()
+            if not entry:
+                continue
+            if "=" not in entry:
+                errors.append(
+                    "RESULT_SERVER_GITLAB_TARGETS entries must use target=host/path"
+                )
+                continue
+            target_id, repo = [part.strip() for part in entry.split("=", 1)]
+            if not GITLAB_TARGET_ID_RE.match(target_id):
+                errors.append(f"invalid GitLab target id: {target_id}")
+                continue
+            if target_id in seen:
+                errors.append(f"duplicate GitLab target id: {target_id}")
+                continue
+            seen.add(target_id)
+            targets.append(
+                GitLabPipelineTarget(
+                    id=target_id,
+                    repo=repo,
+                    token_env=_target_token_env(target_id),
+                )
+            )
+        return targets, errors
+
+    repo = configured_gitlab_repo(source)
+    if repo:
+        targets.append(
+            GitLabPipelineTarget(
+                id="default",
+                repo=repo,
+                token_env="RESULT_SERVER_GITLAB_TOKEN",
+            )
+        )
+    return targets, errors
+
+
+def configured_gitlab_target(
+    target_id: str = "",
+    env: dict[str, str] | None = None,
+) -> tuple[GitLabPipelineTarget | None, list[str]]:
+    """Return the selected GitLab target, defaulting to the first configured target."""
+    targets, errors = configured_gitlab_targets(env)
+    if errors:
+        return None, errors
+    if not targets:
+        return None, ["RESULT_SERVER_GITLAB_REPO or RESULT_SERVER_GITLAB_TARGETS is not set"]
+
+    selected = target_id.strip()
+    if not selected:
+        return targets[0], []
+
+    for target in targets:
+        if target.id == selected:
+            return target, []
+    return None, [f"unknown GitLab target: {selected}"]
+
+
+def configured_gitlab_token(
+    target: GitLabPipelineTarget | None = None,
+    env: dict[str, str] | None = None,
+) -> str:
     """Return the configured GitLab API token for Portal submits."""
     source = env if env is not None else os.environ
+    if target is not None:
+        token = source.get(target.token_env, "").strip()
+        if token:
+            return token
+        if target.token_env != "RESULT_SERVER_GITLAB_TOKEN":
+            return ""
     return source.get("RESULT_SERVER_GITLAB_TOKEN", "").strip()
 
 
@@ -85,6 +180,7 @@ def build_pipeline_plan(
     park_only: bool = False,
     park_send: bool = False,
     scheduler_extra_args: str = "",
+    target_id: str = "",
 ) -> GitLabPipelinePlan:
     """Build the GitLab Pipeline API URL and JSON payload without sending it."""
     errors: list[str] = []
@@ -126,6 +222,7 @@ def build_pipeline_plan(
         payload={"ref": ref, "variables": variables},
         errors=errors,
         warnings=warnings,
+        target_id=target_id,
     )
 
 
@@ -139,7 +236,10 @@ def submit_pipeline_plan(
     """Submit a planned GitLab Pipeline API request."""
     errors = list(plan.errors)
     if not token:
-        errors.append("RESULT_SERVER_GITLAB_TOKEN is not set")
+        if plan.target_id:
+            errors.append(f"GitLab token is not set for target: {plan.target_id}")
+        else:
+            errors.append("RESULT_SERVER_GITLAB_TOKEN is not set")
     if not plan.api_url:
         errors.append("GitLab Pipeline API URL is not configured")
     if errors:


### PR DESCRIPTION
## Summary
- add named GitLab pipeline targets for Portal submit/dry-run
- keep the existing RESULT_SERVER_GITLAB_REPO / RESULT_SERVER_GITLAB_TOKEN single-target fallback
- add target selection to the admin execution profile form
- document RESULT_SERVER_GITLAB_TARGETS and target-specific token env names

## Configuration
- single target: RESULT_SERVER_GITLAB_REPO + RESULT_SERVER_GITLAB_TOKEN
- multiple targets: RESULT_SERVER_GITLAB_TARGETS plus RESULT_SERVER_GITLAB_TOKEN_<TARGET_ID>
- named targets require their own token; they do not fall back to the global token

## Validation
- /home/nakamura/fugakunext/venv/bin/python -m pytest result_server/tests/test_execution_profiles.py result_server/tests/test_app_dev_security.py result_server/tests/test_api_routes.py result_server/tests/test_preflight.py
- /home/nakamura/fugakunext/venv/bin/python result_server/tests/run_result_server_tests.py
- python3 -m py_compile result_server/routes/admin.py result_server/utils/gitlab_pipeline.py
