### PR TITLE
Clarify portal GitLab trigger scope

### DIFF
--- a/docs/guides/portal-execution-profiles-handoff.md
+++ b/docs/guides/portal-execution-profiles-handoff.md
@@ -42,6 +42,11 @@ GitLab schedules should not be the primary governance point. The Portal should
 own periodic and event-triggered execution decisions, then trigger GitLab CI
 with resolved site-local variables.
 
+The current GitLab CI entry point consumes `code`, `system`, BenchPark controls,
+and optional scheduler extra args. Execution profile fields such as `exp` remain
+Portal-side matching and audit metadata until the GitLab matrix generator grows
+a matching selector.
+
 ## GitLab Pipeline Trigger Configuration
 
 Dry-run payload rendering requires:

--- a/result_server/routes/admin.py
+++ b/result_server/routes/admin.py
@@ -166,6 +166,10 @@ def _build_execution_pipeline_plan(store):
         scheduler_extra_args=resolve_result.scheduler_extra_args,
         target_id=gitlab_target.id if gitlab_target else gitlab_target_id,
     )
+    if exp:
+        plan.warnings.append(
+            "Profile Exp is used for Portal profile matching and is not sent to GitLab CI."
+        )
     return {
         "target_ref": target_ref,
         "profile_id": profile_id,
@@ -321,6 +325,9 @@ def dry_run_execution_profile_submit():
         payload={
             "api_url": plan.api_url,
             "gitlab_target": gitlab_target_id,
+            "gitlab_project": submit_plan["gitlab_target"].repo
+            if submit_plan["gitlab_target"]
+            else "",
             "payload": plan.payload,
         },
         errors=errors,
@@ -353,6 +360,9 @@ def dry_run_execution_profile_submit():
             "profile": profile,
             "api_url": plan.api_url,
             "gitlab_target": gitlab_target_id,
+            "gitlab_project": submit_plan["gitlab_target"].repo
+            if submit_plan["gitlab_target"]
+            else "",
             "payload_json": json.dumps(plan.payload, indent=2, sort_keys=True),
             "errors": errors,
             "warnings": plan.warnings,
@@ -401,6 +411,8 @@ def submit_execution_profile_pipeline():
     payload = {"api_url": plan.api_url, "payload": plan.payload}
     if gitlab_target_id:
         payload["gitlab_target"] = gitlab_target_id
+    if gitlab_target:
+        payload["gitlab_project"] = gitlab_target.repo
     if submit_result is not None:
         payload["submit"] = {
             "status_code": submit_result.status_code,
@@ -449,6 +461,7 @@ def submit_execution_profile_pipeline():
             "profile": profile,
             "api_url": plan.api_url,
             "gitlab_target": gitlab_target_id,
+            "gitlab_project": gitlab_target.repo if gitlab_target else "",
             "payload_json": json.dumps(plan.payload, indent=2, sort_keys=True),
             "errors": errors,
             "warnings": plan.warnings,

--- a/result_server/templates/admin_execution_profiles.html
+++ b/result_server/templates/admin_execution_profiles.html
@@ -251,8 +251,8 @@
 <section class="page-card">
     <h2 class="section-title">GitLab Pipeline Trigger</h2>
     <p class="section-intro">
-        Resolve an approved profile for a target scope and preview the GitLab
-        pipeline trigger request before submitting it.
+        Trigger the current GitLab CI entry point with project, ref, code,
+        system, and BenchPark controls.
     </p>
     <form method="POST" action="{{ url_for('admin.dry_run_execution_profile_submit') }}" class="profile-form">
         {% if csrf_token is defined %}<input type="hidden" name="csrf_token" value="{{ csrf_token() }}">{% endif %}
@@ -265,7 +265,7 @@
             {% if gitlab_targets %}
             <select name="gitlab_target">
                 {% for target in gitlab_targets %}
-                <option value="{{ target.id }}">{{ target.id }}</option>
+                <option value="{{ target.id }}">{{ target.id }} - {{ target.repo }}</option>
                 {% endfor %}
             </select>
             {% else %}
@@ -285,8 +285,8 @@
             <input type="text" name="system" placeholder="RIKYU">
         </label>
         <label>
-            Exp
-            <input type="text" name="exp" placeholder="case0">
+            Profile Exp
+            <input type="text" name="exp" placeholder="profile matching only">
         </label>
         <label>
             BenchPark App
@@ -315,6 +315,9 @@
         {{ dry_run_result.status }}
         {% if dry_run_result.gitlab_target %}
         target <span class="profile-mono">{{ dry_run_result.gitlab_target }}</span>
+        {% endif %}
+        {% if dry_run_result.gitlab_project %}
+        project <span class="profile-mono">{{ dry_run_result.gitlab_project }}</span>
         {% endif %}
         {% if dry_run_result.profile %}
         using profile <span class="profile-mono">{{ dry_run_result.profile.id }}</span>
@@ -355,7 +358,7 @@
             {% if gitlab_targets %}
             <select name="gitlab_target">
                 {% for target in gitlab_targets %}
-                <option value="{{ target.id }}">{{ target.id }}</option>
+                <option value="{{ target.id }}">{{ target.id }} - {{ target.repo }}</option>
                 {% endfor %}
             </select>
             {% else %}
@@ -375,8 +378,8 @@
             <input type="text" name="system" placeholder="RIKYU">
         </label>
         <label>
-            Exp
-            <input type="text" name="exp" placeholder="case0">
+            Profile Exp
+            <input type="text" name="exp" placeholder="profile matching only">
         </label>
         <label>
             BenchPark App
@@ -412,6 +415,9 @@
         {% endif %}
         {% if submit_result.gitlab_target %}
         target <span class="profile-mono">{{ submit_result.gitlab_target }}</span>
+        {% endif %}
+        {% if submit_result.gitlab_project %}
+        project <span class="profile-mono">{{ submit_result.gitlab_project }}</span>
         {% endif %}
         {% if submit_result.profile %}
         using profile <span class="profile-mono">{{ submit_result.profile.id }}</span>

--- a/result_server/tests/test_execution_profiles.py
+++ b/result_server/tests/test_execution_profiles.py
@@ -404,6 +404,8 @@ def test_admin_execution_profiles_dry_run_submit_renders_payload(tmp_path, monke
         assert "Dry-run request #1" in html
         assert "dry_run_ready" in html
         assert "https://gitlab.example.org/api/v4/projects/group%2Fbenchkit/trigger/pipeline" in html
+        assert "gitlab.example.org/group/benchkit.git" in html
+        assert "Profile Exp is used for Portal profile matching" in html
         assert "--account=site-local" in html
 
         with sqlite3.connect(db_path) as conn:
@@ -415,6 +417,8 @@ def test_admin_execution_profiles_dry_run_submit_renders_payload(tmp_path, monke
         variables = payload_record["payload"]["variables"]
         assert variables["code"] == "qws"
         assert variables["BK_SCHEDULER_EXTRA_ARGS_RIKYU"] == "--account=site-local"
+        assert "exp" not in variables
+        assert payload_record["gitlab_project"] == "gitlab.example.org/group/benchkit.git"
     finally:
         _cleanup(temp_dirs)
 
@@ -573,6 +577,8 @@ def test_admin_execution_profiles_submit_posts_pipeline_and_records_request(
         payload_record = json.loads(row[3])
         assert payload_record["submit"]["status_code"] == 201
         assert payload_record["submit"]["response"]["id"] == 123
+        assert payload_record["gitlab_project"] == "gitlab.example.org/group/benchkit.git"
+        assert "exp" not in payload_record["payload"]["variables"]
         assert "secret-token" not in row[3]
     finally:
         _cleanup(temp_dirs)
@@ -631,6 +637,7 @@ def test_admin_execution_profiles_submit_uses_selected_gitlab_target(
             ).fetchone()
         payload_record = json.loads(row[0])
         assert payload_record["gitlab_target"] == "gitlab_com"
+        assert payload_record["gitlab_project"] == "gitlab.com/yoshifuminakamura/benchkit"
         assert payload_record["submit"]["response"]["id"] == 456
     finally:
         _cleanup(temp_dirs)


### PR DESCRIPTION
## Summary
- show the configured GitLab project next to each Portal trigger target
- label exp as Profile Exp and warn that it is Portal-side matching metadata, not a GitLab CI filter
- record the selected GitLab project in dry-run and submit execution request payloads

## Validation
- /home/nakamura/fugakunext/venv/bin/python -m py_compile result_server/routes/admin.py result_server/utils/gitlab_pipeline.py
- /home/nakamura/fugakunext/venv/bin/python -m pytest result_server/tests/test_execution_profiles.py result_server/tests/test_app_dev_security.py result_server/tests/test_api_routes.py result_server/tests/test_preflight.py