### PR TITLE
Add portal trigger definitions and result return routing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,6 +116,9 @@ trigger_child_pipeline:
       - artifact: .gitlab-ci.generated.yml
         job: generate_matrix
     strategy: depend
+    forward:
+      pipeline_variables: true
+      yaml_variables: true
   needs:
     - job: generate_matrix
       optional: true
@@ -192,6 +195,9 @@ trigger_benchpark_pipeline:
       - artifact: .gitlab-ci.benchpark.yml
         job: generate_benchpark_matrix
     strategy: depend
+    forward:
+      pipeline_variables: true
+      yaml_variables: true
   inherit:
     variables: true
   needs:

--- a/result_server/routes/admin.py
+++ b/result_server/routes/admin.py
@@ -2,8 +2,10 @@
 
 from functools import wraps
 
+from datetime import UTC, datetime
 import json
 import logging
+import os
 import sqlite3
 
 from flask import (
@@ -25,6 +27,7 @@ from utils.execution_profiles import (
     ExecutionProfileStore,
     load_execution_profiles,
     normalize_profile,
+    normalize_trigger_definition,
 )
 from utils.gitlab_pipeline import (
     build_pipeline_plan,
@@ -93,40 +96,56 @@ def _split_form_list(value):
 def _parse_execution_profile_form():
     """Return a raw execution profile object from the submitted admin form."""
     errors = []
-    metadata_raw = request.form.get("metadata_json", "").strip()
     metadata = {}
-    if metadata_raw:
-        try:
-            metadata = json.loads(metadata_raw)
-        except json.JSONDecodeError as exc:
-            errors.append(f"metadata_json must be valid JSON: {exc.msg}")
-        else:
-            if not isinstance(metadata, dict):
-                errors.append("metadata_json must be a JSON object")
-                metadata = {}
+    code = _split_form_list(request.form.get("code", ""))
+    system = _split_form_list(request.form.get("system", ""))
+    allocation_project_id = request.form.get("allocation_project_id", "").strip()
+    if allocation_project_id and len(system) != 1:
+        errors.append("allocation_project_id requires exactly one system")
+    if request.form.get("status", "").strip() == "approved" and not allocation_project_id:
+        errors.append("approved profiles require allocation_project_id")
 
     actor = session.get("user_email", "")
     raw_profile = {
         "id": request.form.get("id", "").strip(),
-        "display_name": request.form.get("display_name", "").strip(),
-        "enabled": request.form.get("enabled") == "on",
+        "display_name": request.form.get("id", "").strip(),
+        "enabled": True,
         "status": request.form.get("status", "").strip(),
-        "owner": request.form.get("owner", "").strip(),
-        "purpose": request.form.get("purpose", "").strip(),
+        "owner": "",
+        "purpose": "",
         "activity": request.form.get("activity", "").strip(),
-        "code": _split_form_list(request.form.get("code", "")),
-        "system": _split_form_list(request.form.get("system", "")),
+        "code": code,
+        "system": system,
         "exp": _split_form_list(request.form.get("exp", "")),
-        "scheduler_extra_args": request.form.get("scheduler_extra_args", "").strip(),
-        "visibility": request.form.get("visibility", "").strip(),
+        "allocation_project_id": allocation_project_id,
+        "scheduler_extra_args": "",
+        "visibility": "",
         "valid_from": request.form.get("valid_from", "").strip(),
         "valid_until": request.form.get("valid_until", "").strip(),
         "created_by": request.form.get("created_by", "").strip() or actor,
-        "approved_by": request.form.get("approved_by", "").strip(),
-        "approved_at": request.form.get("approved_at", "").strip(),
         "metadata_json": metadata,
     }
     return raw_profile, errors
+
+
+def _parse_trigger_definition_form():
+    """Return a raw trigger definition object from the submitted admin form."""
+    actor = session.get("user_email", "")
+    return {
+        "id": request.form.get("id", "").strip(),
+        "name": request.form.get("id", "").strip(),
+        "trigger_type": request.form.get("trigger_type", "").strip(),
+        "profile_id": request.form.get("profile_id", "").strip(),
+        "enabled": request.form.get("enabled", "on") == "on",
+        "gitlab_target": request.form.get("gitlab_target", "").strip(),
+        "target_ref": "",
+        "cron_expr": request.form.get("cron_expr", "").strip(),
+        "timezone": request.form.get("timezone", "").strip(),
+        "watch_kind": request.form.get("watch_kind", "").strip(),
+        "watch_targets": _split_form_list(request.form.get("watch_targets", "")),
+        "match_mode": request.form.get("match_mode", "").strip(),
+        "created_by": actor,
+    }
 
 
 def _parse_bool_form(name):
@@ -140,18 +159,77 @@ def _profile_scope_csv(profile, key):
     return ",".join(str(value).strip() for value in values if str(value).strip())
 
 
+def _default_trigger_ref():
+    path = request.path or ""
+    return "develop" if path.startswith(("/dev/", "/dev2/")) else "main"
+
+
+def _portal_result_server_url():
+    configured = os.environ.get("RESULT_SERVER_PUBLIC_URL", "").strip()
+    if configured:
+        return configured.rstrip("/")
+    path = request.path or ""
+    prefix = path.split("/admin/", 1)[0] if "/admin/" in path else ""
+    if prefix == "/admin":
+        prefix = ""
+    return f"{request.url_root.rstrip('/')}{prefix}"
+
+
+def _profile_filter_options():
+    return [
+        ("all", "All"),
+        ("approved", "Approved"),
+        ("draft", "Draft"),
+        ("paused", "Paused"),
+        ("retired", "Retired"),
+        ("inactive", "Inactive"),
+        ("expired", "Expired"),
+    ]
+
+
+def _profile_is_expired(profile):
+    valid_until = profile.get("valid_until", "")
+    return bool(valid_until and valid_until < datetime.now(UTC).date().isoformat())
+
+
+def _profile_matches_filter(profile, selected_filter):
+    if selected_filter == "all":
+        return True
+    if selected_filter == "inactive":
+        return (
+            not profile.get("enabled", True)
+            or profile.get("status") in {"paused", "retired"}
+        )
+    if selected_filter == "expired":
+        return _profile_is_expired(profile)
+    return profile.get("status") == selected_filter
+
+
+def _list_trigger_definitions(db_path):
+    try:
+        return ExecutionProfileStore(db_path).list_trigger_definitions()
+    except sqlite3.Error as exc:
+        flash(f"Trigger definitions could not be loaded: {exc}")
+        return []
+
+
+def _find_trigger_definition(triggers, trigger_id):
+    if not trigger_id:
+        return None
+    return next(
+        (trigger for trigger in triggers if trigger.get("id") == trigger_id),
+        None,
+    )
+
+
 def _build_execution_pipeline_plan(store):
     """Resolve the submitted target and build a GitLab pipeline plan."""
-    target_ref = request.form.get("target_ref", "").strip() or "develop"
+    target_ref = request.form.get("target_ref", "").strip() or _default_trigger_ref()
     profile_id = request.form.get("profile_id", "").strip()
     gitlab_target_id = request.form.get("gitlab_target", "").strip()
     code = request.form.get("code", "").strip()
     system = request.form.get("system", "").strip()
     exp = request.form.get("exp", "").strip()
-    app = request.form.get("app", "").strip()
-    benchpark = _parse_bool_form("benchpark")
-    park_only = _parse_bool_form("park_only")
-    park_send = _parse_bool_form("park_send")
 
     resolve_result = store.resolve_profile(
         profile_id=profile_id,
@@ -169,13 +247,20 @@ def _build_execution_pipeline_plan(store):
         target_ref=target_ref,
         code=effective_code,
         system=effective_system,
-        app=app,
-        benchpark=benchpark,
-        park_only=park_only,
-        park_send=park_send,
-        scheduler_extra_args=resolve_result.scheduler_extra_args,
+        app="",
+        benchpark=False,
+        park_only=False,
+        park_send=False,
+        allocation_project_id=resolve_result.allocation_project_id,
+        scheduler_extra_args="",
+        result_server_url=_portal_result_server_url(),
         target_id=gitlab_target.id if gitlab_target else gitlab_target_id,
     )
+    request_errors = []
+    if not profile_id:
+        request_errors.append("profile_id is required")
+    if profile and not resolve_result.allocation_project_id:
+        request_errors.append("profile allocation_project_id is required")
     if effective_exp:
         plan.warnings.append(
             "Profile Exp is used for Portal profile matching and is not sent to GitLab CI."
@@ -190,7 +275,7 @@ def _build_execution_pipeline_plan(store):
         "exp": effective_exp,
         "profile": profile,
         "plan": plan,
-        "errors": target_errors + resolve_result.errors + plan.errors,
+        "errors": request_errors + target_errors + resolve_result.errors + plan.errors,
     }
 
 
@@ -239,16 +324,153 @@ def users():
 @admin_required
 def execution_profiles():
     """Render site-local execution profiles for admin review."""
-    profile_result = load_execution_profiles(
-        current_app.config.get("EXECUTION_PROFILE_DB_PATH")
-    )
+    db_path = current_app.config.get("EXECUTION_PROFILE_DB_PATH")
+    profile_result = load_execution_profiles(db_path)
+    registered_profiles = profile_result.profiles
+    trigger_definitions = _list_trigger_definitions(db_path)
+    edit_profile_id = request.args.get("edit", "").strip()
+    edit_trigger_id = request.args.get("edit_trigger", "").strip()
+    edit_profile = None
+    if edit_profile_id:
+        edit_profile = next(
+            (
+                profile
+                for profile in profile_result.profiles
+                if profile.get("id") == edit_profile_id
+            ),
+            None,
+        )
+    edit_trigger = _find_trigger_definition(trigger_definitions, edit_trigger_id)
     return render_template(
         "admin_execution_profiles.html",
         profile_result=profile_result,
+        registered_profiles=registered_profiles,
+        trigger_definitions=trigger_definitions,
+        profile_filter="all",
+        profile_filter_options=_profile_filter_options(),
+        today=datetime.now(UTC).date().isoformat(),
+        edit_profile=edit_profile,
+        edit_trigger=edit_trigger,
+        default_target_ref=_default_trigger_ref(),
         dry_run_result=None,
         submit_result=None,
         gitlab_targets=configured_gitlab_targets()[0],
     )
+
+
+@admin_bp.route("/execution-profiles/triggers/upsert", methods=["POST"])
+@admin_required
+@rate_limited(max_per_minute=20, key_fn=_admin_rate_key, scope="admin_write")
+def upsert_execution_profile_trigger():
+    """Create or update a site-local trigger definition."""
+    raw_trigger = _parse_trigger_definition_form()
+    trigger, errors = normalize_trigger_definition(raw_trigger)
+
+    if errors or trigger is None:
+        audit_event(
+            "admin_execution_profile_trigger_rejected",
+            actor=session.get("user_email"),
+            target=raw_trigger.get("id", "")[:128],
+            result="failure",
+            level=logging.WARNING,
+            details={"errors": errors},
+        )
+        flash("Trigger definition was not saved: " + "; ".join(errors))
+        return redirect(url_for("admin.execution_profiles"))
+
+    try:
+        store = ExecutionProfileStore(current_app.config.get("EXECUTION_PROFILE_DB_PATH"))
+        store.upsert_trigger_definition(trigger, actor=session.get("user_email", ""))
+    except sqlite3.Error as exc:
+        audit_event(
+            "admin_execution_profile_trigger_save_failed",
+            actor=session.get("user_email"),
+            target=trigger["id"],
+            result="failure",
+            level=logging.ERROR,
+            details={"error": str(exc)},
+        )
+        flash(f"Trigger definition was not saved: {exc}")
+        return redirect(url_for("admin.execution_profiles"))
+
+    audit_event(
+        "admin_execution_profile_trigger_saved",
+        actor=session.get("user_email"),
+        target=trigger["id"],
+        result="success",
+        details={
+            "trigger_type": trigger["trigger_type"],
+            "profile_id": trigger["profile_id"],
+            "enabled": trigger["enabled"],
+        },
+    )
+    flash(f"Trigger definition {trigger['id']} saved.")
+    return redirect(url_for("admin.execution_profiles"))
+
+
+@admin_bp.route("/execution-profiles/triggers/<trigger_id>/pause", methods=["POST"])
+@admin_required
+@rate_limited(max_per_minute=20, key_fn=_admin_rate_key, scope="admin_write")
+def pause_execution_profile_trigger(trigger_id):
+    """Pause a site-local trigger definition."""
+    store = ExecutionProfileStore(current_app.config.get("EXECUTION_PROFILE_DB_PATH"))
+    if not store.set_trigger_definition_enabled(
+        trigger_id,
+        False,
+        actor=session.get("user_email", ""),
+    ):
+        flash(f"Trigger definition {trigger_id} was not found.")
+    else:
+        audit_event(
+            "admin_execution_profile_trigger_paused",
+            actor=session.get("user_email"),
+            target=trigger_id,
+            result="success",
+        )
+        flash(f"Trigger definition {trigger_id} paused.")
+    return redirect(url_for("admin.execution_profiles"))
+
+
+@admin_bp.route("/execution-profiles/triggers/<trigger_id>/resume", methods=["POST"])
+@admin_required
+@rate_limited(max_per_minute=20, key_fn=_admin_rate_key, scope="admin_write")
+def resume_execution_profile_trigger(trigger_id):
+    """Resume a site-local trigger definition."""
+    store = ExecutionProfileStore(current_app.config.get("EXECUTION_PROFILE_DB_PATH"))
+    if not store.set_trigger_definition_enabled(
+        trigger_id,
+        True,
+        actor=session.get("user_email", ""),
+    ):
+        flash(f"Trigger definition {trigger_id} was not found.")
+    else:
+        audit_event(
+            "admin_execution_profile_trigger_resumed",
+            actor=session.get("user_email"),
+            target=trigger_id,
+            result="success",
+        )
+        flash(f"Trigger definition {trigger_id} resumed.")
+    return redirect(url_for("admin.execution_profiles"))
+
+
+@admin_bp.route("/execution-profiles/triggers/<trigger_id>/delete", methods=["POST"])
+@admin_required
+@rate_limited(max_per_minute=20, key_fn=_admin_rate_key, scope="admin_write")
+def delete_execution_profile_trigger(trigger_id):
+    """Delete a site-local trigger definition."""
+    store = ExecutionProfileStore(current_app.config.get("EXECUTION_PROFILE_DB_PATH"))
+    if not store.delete_trigger_definition(trigger_id, actor=session.get("user_email", "")):
+        flash(f"Trigger definition {trigger_id} was not found.")
+    else:
+        audit_event(
+            "admin_execution_profile_trigger_deleted",
+            actor=session.get("user_email"),
+            target=trigger_id,
+            result="success",
+        )
+        flash(f"Trigger definition {trigger_id} deleted.")
+    return redirect(url_for("admin.execution_profiles"))
 
 
 @admin_bp.route("/execution-profiles/upsert", methods=["POST"])
@@ -302,6 +524,25 @@ def upsert_execution_profile():
         },
     )
     flash(f"Execution profile {profile['id']} saved.")
+    return redirect(url_for("admin.execution_profiles"))
+
+
+@admin_bp.route("/execution-profiles/<profile_id>/delete", methods=["POST"])
+@admin_required
+@rate_limited(max_per_minute=20, key_fn=_admin_rate_key, scope="admin_write")
+def delete_execution_profile(profile_id):
+    """Delete a site-local execution profile."""
+    store = ExecutionProfileStore(current_app.config.get("EXECUTION_PROFILE_DB_PATH"))
+    if not store.delete_profile(profile_id, actor=session.get("user_email", "")):
+        flash(f"Execution profile {profile_id} was not found.")
+    else:
+        audit_event(
+            "admin_execution_profile_deleted",
+            actor=session.get("user_email"),
+            target=profile_id,
+            result="success",
+        )
+        flash(f"Execution profile {profile_id} deleted.")
     return redirect(url_for("admin.execution_profiles"))
 
 
@@ -364,6 +605,14 @@ def dry_run_execution_profile_submit():
     return render_template(
         "admin_execution_profiles.html",
         profile_result=profile_result,
+        registered_profiles=profile_result.profiles,
+        trigger_definitions=_list_trigger_definitions(db_path),
+        profile_filter="all",
+        profile_filter_options=_profile_filter_options(),
+        today=datetime.now(UTC).date().isoformat(),
+        edit_profile=None,
+        edit_trigger=None,
+        default_target_ref=_default_trigger_ref(),
         dry_run_result={
             "request_id": request_id,
             "status": status,
@@ -464,6 +713,14 @@ def submit_execution_profile_pipeline():
     return render_template(
         "admin_execution_profiles.html",
         profile_result=profile_result,
+        registered_profiles=profile_result.profiles,
+        trigger_definitions=_list_trigger_definitions(db_path),
+        profile_filter="all",
+        profile_filter_options=_profile_filter_options(),
+        today=datetime.now(UTC).date().isoformat(),
+        edit_profile=None,
+        edit_trigger=None,
+        default_target_ref=_default_trigger_ref(),
         dry_run_result=None,
         submit_result={
             "request_id": request_id,

--- a/result_server/templates/admin_execution_profiles.html
+++ b/result_server/templates/admin_execution_profiles.html
@@ -38,8 +38,8 @@
         color: #52525b;
     }
     .profile-table td {
-        vertical-align: top;
-        white-space: normal;
+        vertical-align: middle;
+        white-space: nowrap;
     }
     .profile-mono {
         font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -73,6 +73,117 @@
         gap: 12px;
         grid-column: 1 / -1;
     }
+    .profile-row-actions {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        min-width: 0;
+        white-space: nowrap;
+    }
+    .profile-row-actions form {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+    }
+    .profile-mini-actions {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        white-space: nowrap;
+    }
+    .profile-mini-actions form {
+        margin: 0;
+    }
+    .btn-mini {
+        padding: 4px 8px;
+        border-radius: 5px;
+        font-size: 12px;
+        line-height: 1.2;
+    }
+    .btn-danger {
+        background-color: #991b1b;
+        border-color: #991b1b;
+        color: #fff;
+    }
+    .btn-danger:hover {
+        background-color: #7f1d1d;
+        color: #fff;
+    }
+    .profile-row-actions select {
+        width: auto;
+        box-sizing: border-box;
+    }
+    .profile-trigger-ref {
+        color: #475569;
+        font-size: 12px;
+        font-weight: 700;
+        white-space: nowrap;
+    }
+    .profile-scope-line {
+        white-space: nowrap;
+    }
+    .profile-id-link {
+        color: #0f766e;
+        text-decoration: none;
+        font-weight: 700;
+    }
+    .profile-id-link:hover {
+        text-decoration: underline;
+    }
+    .profile-icon-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 22px;
+        height: 22px;
+        padding: 0;
+        border-radius: 5px;
+        line-height: 1;
+        font-size: 10px;
+        font-weight: 900;
+    }
+    .profile-play-icon {
+        display: block;
+        width: 0;
+        height: 0;
+        margin-left: 1px;
+        border-top: 5px solid transparent;
+        border-bottom: 5px solid transparent;
+        border-left: 7px solid currentColor;
+    }
+    .trigger-definition-table td {
+        vertical-align: middle;
+    }
+    .trigger-condition {
+        max-width: 46ch;
+    }
+    .trigger-type-fields {
+        display: none;
+    }
+    .trigger-type-fields-active {
+        display: contents;
+    }
+    .profile-col-trigger {
+        width: 1%;
+    }
+    .profile-col-id {
+        width: 16ch;
+        max-width: 16ch;
+    }
+    .profile-col-id .profile-mono {
+        display: inline-block;
+        max-width: 16ch;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        vertical-align: bottom;
+        white-space: nowrap;
+    }
+    .profile-col-scope {
+        min-width: 22ch;
+    }
+    .profile-col-governance {
+        min-width: 28ch;
+    }
     .profile-check-label {
         display: inline-flex;
         align-items: center;
@@ -81,6 +192,28 @@
     }
     .profile-check-label input {
         width: auto;
+    }
+    .profile-filter-row {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-bottom: 12px;
+    }
+    .profile-filter-button {
+        padding: 5px 10px;
+        border: 1px solid #cbd5e1;
+        border-radius: 999px;
+        color: #334155;
+        background: #fff;
+        font-size: 13px;
+        font-weight: 700;
+        cursor: pointer;
+    }
+    .profile-filter-active {
+        background: #0f766e;
+        border-color: #0f766e;
+        color: #fff;
     }
     .btn {
         padding: 7px 14px;
@@ -117,10 +250,10 @@
 <section class="page-card">
     <h2 class="section-title">Execution Profiles</h2>
     <p class="section-intro">
-        Execution profiles are site-local operational records stored in the
-        portal SQLite registry. They map approved application execution scopes
-        to scheduler allocation arguments without committing account or budget
-        values to the OSS repository.
+        Execution profiles are site-local governance records stored in the
+        portal SQLite registry. They approve application execution scopes and
+        semantic allocation IDs without embedding scheduler-specific command
+        line syntax in the Portal.
     </p>
 
     <div class="profile-summary-grid">
@@ -129,12 +262,16 @@
             <span>Total profiles</span>
         </div>
         <div class="profile-summary-card">
-            <strong>{{ profile_result.enabled_count }}</strong>
-            <span>Enabled</span>
+            <strong>{{ profile_result.approved_count }}</strong>
+            <span>Approved</span>
         </div>
         <div class="profile-summary-card">
-            <strong>{{ profile_result.disabled_count }}</strong>
-            <span>Disabled</span>
+            <strong>{{ profile_result.inactive_count }}</strong>
+            <span>Inactive</span>
+        </div>
+        <div class="profile-summary-card">
+            <strong>{{ profile_result.expired_count }}</strong>
+            <span>Expired</span>
         </div>
     </div>
 
@@ -161,252 +298,67 @@
 </section>
 
 <section class="page-card">
-    <h2 class="section-title">Create / Update Profile</h2>
+    <h2 class="section-title">{% if edit_profile %}Edit Profile{% else %}Create Profile{% endif %}</h2>
     <p class="section-intro">
-        Enter the same profile ID to update an existing record. Use comma or
-        newline separated scope values. Leave a scope empty to allow all values
-        for that dimension.
+        Enter the same profile ID to update an existing record. A profile
+        approves code scopes for one system and one allocation project ID.
     </p>
     <form method="POST" action="{{ url_for('admin.upsert_execution_profile') }}" class="profile-form">
         {% if csrf_token is defined %}<input type="hidden" name="csrf_token" value="{{ csrf_token() }}">{% endif %}
         <label>
             Profile ID
-            <input type="text" name="id" required placeholder="rikyu-qws-nightly">
-        </label>
-        <label>
-            Display Name
-            <input type="text" name="display_name" placeholder="RIKYU QWS nightly">
+            <input type="text" name="id" required placeholder="qws-fugaku-rkp00010" value="{{ edit_profile.id if edit_profile else '' }}">
         </label>
         <label>
             Status
             <select name="status">
-                <option value="draft">draft</option>
-                <option value="approved">approved</option>
-                <option value="paused">paused</option>
-                <option value="retired">retired</option>
+                {% set selected_status = edit_profile.status if edit_profile else 'draft' %}
+                <option value="draft" {% if selected_status == 'draft' %}selected{% endif %}>draft</option>
+                <option value="approved" {% if selected_status == 'approved' %}selected{% endif %}>approved</option>
+                <option value="paused" {% if selected_status == 'paused' %}selected{% endif %}>paused</option>
+                <option value="retired" {% if selected_status == 'retired' %}selected{% endif %}>retired</option>
             </select>
         </label>
         <label>
             Activity
-            <input type="text" name="activity" placeholder="FugakuNEXT">
+            <input type="text" name="activity" placeholder="FugakuNEXT" value="{{ edit_profile.activity if edit_profile else '' }}">
         </label>
         <label>
-            Owner
-            <input type="text" name="owner" placeholder="project or team">
-        </label>
-        <label>
-            Visibility
-            <input type="text" name="visibility" placeholder="public-results">
+            Allocation Project ID
+            <input type="text" name="allocation_project_id" required placeholder="rkp00010" value="{{ edit_profile.allocation_project_id if edit_profile else '' }}">
         </label>
         <label>
             Valid From
-            <input type="date" name="valid_from">
+            <input type="date" name="valid_from" value="{{ edit_profile.valid_from if edit_profile else '' }}">
         </label>
         <label>
             Valid Until
-            <input type="date" name="valid_until">
-        </label>
-        <label>
-            Approved By
-            <input type="text" name="approved_by" placeholder="admin@example.org">
-        </label>
-        <label>
-            Approved At
-            <input type="text" name="approved_at" placeholder="2026-09-01T00:00:00Z">
+            <input type="date" name="valid_until" value="{{ edit_profile.valid_until if edit_profile else '' }}">
         </label>
         <label class="profile-form-wide">
             Code Scope
-            <textarea name="code" rows="2" placeholder="qws, genesis"></textarea>
+            <textarea name="code" rows="2" placeholder="qws, genesis">{{ edit_profile.code | join(', ') if edit_profile else '' }}</textarea>
         </label>
         <label class="profile-form-wide">
-            System Scope
-            <textarea name="system" rows="2" placeholder="RIKYU, MiyabiG"></textarea>
+            System
+            <input type="text" name="system" placeholder="Fugaku" value="{{ edit_profile.system | join(', ') if edit_profile else '' }}">
         </label>
         <label class="profile-form-wide">
             Exp Scope
-            <textarea name="exp" rows="2" placeholder="case0"></textarea>
-        </label>
-        <label class="profile-form-wide">
-            Scheduler Extra Args
-            <textarea name="scheduler_extra_args" rows="2" placeholder="--account=&lt;site-local-account&gt;"></textarea>
-        </label>
-        <label class="profile-form-wide">
-            Purpose
-            <textarea name="purpose" rows="2" placeholder="Why this profile exists and who approved it."></textarea>
-        </label>
-        <label class="profile-form-wide">
-            Metadata JSON
-            <textarea name="metadata_json" rows="3" placeholder='{"terms_version":"2026-07"}'></textarea>
+            <textarea name="exp" rows="2" placeholder="case0">{{ edit_profile.exp | join(', ') if edit_profile else '' }}</textarea>
         </label>
         <div class="profile-form-actions">
-            <label class="profile-check-label">
-                <input type="checkbox" name="enabled" checked>
-                Enabled
-            </label>
             <button type="submit" class="btn btn-primary">Save Profile</button>
+            {% if edit_profile %}
+            <a class="btn btn-secondary" href="{{ url_for('admin.execution_profiles') }}">Cancel Edit</a>
+            {% endif %}
         </div>
     </form>
 </section>
 
+{% if submit_result %}
 <section class="page-card">
     <h2 class="section-title">GitLab Pipeline Trigger</h2>
-    <p class="section-intro">
-        Trigger the current GitLab CI entry point with project, ref, code,
-        system, and BenchPark controls.
-    </p>
-    <form method="POST" action="{{ url_for('admin.dry_run_execution_profile_submit') }}" class="profile-form">
-        {% if csrf_token is defined %}<input type="hidden" name="csrf_token" value="{{ csrf_token() }}">{% endif %}
-        <label>
-            Target Ref
-            <input type="text" name="target_ref" value="develop" required>
-        </label>
-        <label>
-            GitLab Target
-            {% if gitlab_targets %}
-            <select name="gitlab_target">
-                {% for target in gitlab_targets %}
-                <option value="{{ target.id }}">{{ target.id }} - {{ target.repo }}</option>
-                {% endfor %}
-            </select>
-            {% else %}
-            <input type="text" name="gitlab_target" placeholder="default">
-            {% endif %}
-        </label>
-        <label>
-            Profile ID
-            <input type="text" name="profile_id" placeholder="optional explicit profile">
-        </label>
-        <label>
-            Code
-            <input type="text" name="code" placeholder="qws">
-        </label>
-        <label>
-            System
-            <input type="text" name="system" placeholder="RIKYU">
-        </label>
-        <label>
-            Profile Exp
-            <input type="text" name="exp" placeholder="profile matching only">
-        </label>
-        <label>
-            BenchPark App
-            <input type="text" name="app" placeholder="osu-micro-benchmarks">
-        </label>
-        <div class="profile-form-actions">
-            <label class="profile-check-label">
-                <input type="checkbox" name="benchpark">
-                benchpark
-            </label>
-            <label class="profile-check-label">
-                <input type="checkbox" name="park_only">
-                park_only
-            </label>
-            <label class="profile-check-label">
-                <input type="checkbox" name="park_send">
-                park_send
-            </label>
-            <button type="submit" class="btn btn-secondary">Preview Payload</button>
-        </div>
-    </form>
-
-    {% if dry_run_result %}
-    <div class="inline-notice">
-        <strong>Dry-run request #{{ dry_run_result.request_id }}:</strong>
-        {{ dry_run_result.status }}
-        {% if dry_run_result.gitlab_target %}
-        target <span class="profile-mono">{{ dry_run_result.gitlab_target }}</span>
-        {% endif %}
-        {% if dry_run_result.gitlab_project %}
-        project <span class="profile-mono">{{ dry_run_result.gitlab_project }}</span>
-        {% endif %}
-        {% if dry_run_result.profile %}
-        using profile <span class="profile-mono">{{ dry_run_result.profile.id }}</span>
-        {% endif %}
-    </div>
-    {% if dry_run_result.errors %}
-    <div class="inline-notice">
-        <strong>Dry-run blockers:</strong>
-        <ul>
-            {% for error in dry_run_result.errors %}
-            <li>{{ error }}</li>
-            {% endfor %}
-        </ul>
-    </div>
-    {% endif %}
-    {% if dry_run_result.warnings %}
-    <div class="inline-notice">
-        <strong>Dry-run warnings:</strong>
-        <ul>
-            {% for warning in dry_run_result.warnings %}
-            <li>{{ warning }}</li>
-            {% endfor %}
-        </ul>
-    </div>
-    {% endif %}
-    <p><strong>Trigger API URL:</strong> <span class="profile-mono">{{ dry_run_result.api_url or 'not configured' }}</span></p>
-    <pre class="profile-dry-run-output">{{ dry_run_result.payload_json }}</pre>
-    {% endif %}
-
-    <form method="POST" action="{{ url_for('admin.submit_execution_profile_pipeline') }}" class="profile-form">
-        {% if csrf_token is defined %}<input type="hidden" name="csrf_token" value="{{ csrf_token() }}">{% endif %}
-        <label>
-            Target Ref
-            <input type="text" name="target_ref" value="develop" required>
-        </label>
-        <label>
-            GitLab Target
-            {% if gitlab_targets %}
-            <select name="gitlab_target">
-                {% for target in gitlab_targets %}
-                <option value="{{ target.id }}">{{ target.id }} - {{ target.repo }}</option>
-                {% endfor %}
-            </select>
-            {% else %}
-            <input type="text" name="gitlab_target" placeholder="default">
-            {% endif %}
-        </label>
-        <label>
-            Profile ID
-            <input type="text" name="profile_id" placeholder="optional explicit profile">
-        </label>
-        <label>
-            Code
-            <input type="text" name="code" placeholder="qws">
-        </label>
-        <label>
-            System
-            <input type="text" name="system" placeholder="RIKYU">
-        </label>
-        <label>
-            Profile Exp
-            <input type="text" name="exp" placeholder="profile matching only">
-        </label>
-        <label>
-            BenchPark App
-            <input type="text" name="app" placeholder="osu-micro-benchmarks">
-        </label>
-        <div class="profile-form-actions">
-            <label class="profile-check-label">
-                <input type="checkbox" name="benchpark">
-                benchpark
-            </label>
-            <label class="profile-check-label">
-                <input type="checkbox" name="park_only">
-                park_only
-            </label>
-            <label class="profile-check-label">
-                <input type="checkbox" name="park_send">
-                park_send
-            </label>
-            <label class="profile-check-label">
-                <input type="checkbox" name="confirm_submit">
-                confirm submit
-            </label>
-            <button type="submit" class="btn btn-primary">Trigger Pipeline</button>
-        </div>
-    </form>
-
-    {% if submit_result %}
     <div class="inline-notice">
         <strong>Submit request #{{ submit_result.request_id }}:</strong>
         {{ submit_result.status }}
@@ -448,53 +400,81 @@
     {% if submit_result.response %}
     <pre class="profile-dry-run-output">{{ submit_result.response | tojson(indent=2) }}</pre>
     {% endif %}
-    {% endif %}
 </section>
+{% endif %}
 
 <section class="page-card table-card">
     <h2 class="section-title">Registered Profiles</h2>
+    <div class="profile-filter-row">
+        {% for value, label in profile_filter_options %}
+        <button type="button" class="profile-filter-button{% if profile_filter == value %} profile-filter-active{% endif %}" data-profile-filter="{{ value }}">{{ label }}</button>
+        {% endfor %}
+    </div>
     <div class="table-wrap">
         <table class="profile-table">
             <thead>
                 <tr>
-                    <th>ID</th>
-                    <th>Status</th>
-                    <th>Scope</th>
-                    <th>Scheduler Args</th>
-                    <th>Governance</th>
+                    <th class="profile-col-trigger">Trigger</th>
+                    <th class="profile-col-id">ID</th>
+                    <th class="profile-col-scope">Scope / Allocation</th>
+                    <th class="profile-col-governance">Governance</th>
+                    <th>Manage</th>
                 </tr>
             </thead>
             <tbody>
-            {% for profile in profile_result.profiles %}
-                <tr>
-                    <td>
-                        <strong>{{ profile.display_name }}</strong><br>
-                        <span class="profile-mono">{{ profile.id }}</span>
+            {% for profile in registered_profiles %}
+                <tr data-profile-row
+                    data-status="{{ profile.status or 'draft' }}"
+                    data-inactive="{% if (not profile.enabled) or profile.status in ['paused', 'retired'] %}1{% else %}0{% endif %}"
+                    data-expired="{% if profile.valid_until and profile.valid_until < today %}1{% else %}0{% endif %}">
+                    <td class="profile-col-trigger">
+                        <div class="profile-row-actions">
+                            <form method="POST" action="{{ url_for('admin.submit_execution_profile_pipeline') }}">
+                                {% if csrf_token is defined %}<input type="hidden" name="csrf_token" value="{{ csrf_token() }}">{% endif %}
+                                <input type="hidden" name="profile_id" value="{{ profile.id }}">
+                                <input type="hidden" name="target_ref" value="{{ default_target_ref }}">
+                                <input type="hidden" name="confirm_submit" value="on">
+                                {% if gitlab_targets %}
+                                {% if gitlab_targets | length > 1 %}
+                                <select name="gitlab_target" aria-label="GitLab target">
+                                    {% for target in gitlab_targets %}
+                                    <option value="{{ target.id }}">{{ target.id }}</option>
+                                    {% endfor %}
+                                </select>
+                                {% else %}
+                                <input type="hidden" name="gitlab_target" value="{{ gitlab_targets[0].id }}">
+                                {% endif %}
+                                {% else %}
+                                <input type="hidden" name="gitlab_target" value="">
+                                {% endif %}
+                                <button type="submit" class="btn btn-primary profile-icon-button" title="Trigger pipeline on {{ default_target_ref }}" aria-label="Trigger pipeline on {{ default_target_ref }}"><span class="profile-play-icon" aria-hidden="true"></span></button>
+                            </form>
+                        </div>
+                    </td>
+                    <td class="profile-col-id">
+                        <a class="profile-mono profile-id-link" href="{{ url_for('admin.execution_profiles', edit=profile.id) }}" title="{{ profile.id }}">{{ profile.id }}</a>
+                    </td>
+                    <td class="profile-col-scope">
+                        <span class="profile-scope-line">
+                            <span class="profile-mono">{{ profile.code | join(', ') or '*' }}</span>
+                            on
+                            <span class="profile-mono">{{ profile.system | join(', ') or '*' }}</span>
+                            {% if profile.exp %}
+                            / <span class="profile-mono">{{ profile.exp | join(', ') }}</span>
+                            {% endif %}
+                        </span>
+                        / <span class="profile-mono">{{ profile.allocation_project_id or '-' }}</span>
+                    </td>
+                    <td class="profile-col-governance">
+                        {{ profile.activity or '-' }} / {{ profile.approved_by or '-' }} / {{ profile.valid_from or '-' }} to {{ profile.valid_until or '-' }}
                     </td>
                     <td>
-                        {% if profile.enabled %}
-                        <span class="profile-status profile-status-enabled">Enabled</span>
-                        {% else %}
-                        <span class="profile-status profile-status-disabled">Disabled</span>
-                        {% endif %}
-                        <br>{{ profile.status or 'draft' }}
-                    </td>
-                    <td>
-                        <strong>Code:</strong> {{ profile.code | join(', ') or '*' }}<br>
-                        <strong>System:</strong> {{ profile.system | join(', ') or '*' }}<br>
-                        <strong>Exp:</strong> {{ profile.exp | join(', ') or '*' }}
-                    </td>
-                    <td class="profile-mono">{{ profile.scheduler_extra_args or '-' }}</td>
-                    <td>
-                        <strong>Owner:</strong> {{ profile.owner or '-' }}<br>
-                        <strong>Activity:</strong> {{ profile.activity or '-' }}<br>
-                        <strong>Visibility:</strong> {{ profile.visibility or '-' }}<br>
-                        <strong>Approved by:</strong> {{ profile.approved_by or '-' }}<br>
-                        <strong>Valid:</strong>
-                        {{ profile.valid_from or '-' }} to {{ profile.valid_until or '-' }}<br>
-                        {% if profile.purpose %}
-                        <strong>Purpose:</strong> {{ profile.purpose }}
-                        {% endif %}
+                        <div class="profile-mini-actions">
+                            <form method="POST" action="{{ url_for('admin.delete_execution_profile', profile_id=profile.id) }}" onsubmit="return confirm('Delete profile {{ profile.id }}?');">
+                                {% if csrf_token is defined %}<input type="hidden" name="csrf_token" value="{{ csrf_token() }}">{% endif %}
+                                <button type="submit" class="btn btn-danger btn-mini" title="Delete profile">Delete</button>
+                            </form>
+                        </div>
                     </td>
                 </tr>
             {% else %}
@@ -506,4 +486,192 @@
         </table>
     </div>
 </section>
+
+<section class="page-card">
+    <h2 class="section-title">{% if edit_trigger %}Edit Trigger{% else %}Create Trigger{% endif %}</h2>
+    <form method="POST" action="{{ url_for('admin.upsert_execution_profile_trigger') }}" class="profile-form">
+        {% if csrf_token is defined %}<input type="hidden" name="csrf_token" value="{{ csrf_token() }}">{% endif %}
+        {% set selected_trigger_type = edit_trigger.trigger_type if edit_trigger else 'scheduled' %}
+        {% set selected_trigger_profile = edit_trigger.profile_id if edit_trigger else '' %}
+        {% set selected_trigger_target = edit_trigger.gitlab_target if edit_trigger else '' %}
+        {% set selected_match_mode = edit_trigger.match_mode if edit_trigger else 'any' %}
+        {% set trigger_enabled = edit_trigger.enabled if edit_trigger else true %}
+        <input type="hidden" name="enabled" value="{% if trigger_enabled %}on{% endif %}">
+        <label>
+            Trigger ID
+            <input type="text" name="id" required placeholder="qws-fugaku-nightly" value="{{ edit_trigger.id if edit_trigger else '' }}">
+        </label>
+        <label>
+            Type
+            <select name="trigger_type" data-trigger-type-select>
+                <option value="scheduled" {% if selected_trigger_type == 'scheduled' %}selected{% endif %}>scheduled</option>
+                <option value="watch_event" {% if selected_trigger_type == 'watch_event' %}selected{% endif %}>watch_event</option>
+            </select>
+        </label>
+        <label>
+            Profile
+            <select name="profile_id" required>
+                <option value="">Select profile</option>
+                {% for profile in registered_profiles %}
+                <option value="{{ profile.id }}" {% if selected_trigger_profile == profile.id %}selected{% endif %}>{{ profile.id }}</option>
+                {% endfor %}
+            </select>
+        </label>
+        <label>
+            GitLab Target
+            <select name="gitlab_target">
+                {% if gitlab_targets %}
+                {% for target in gitlab_targets %}
+                <option value="{{ target.id }}" {% if selected_trigger_target == target.id %}selected{% endif %}>{{ target.id }}</option>
+                {% endfor %}
+                {% else %}
+                <option value="">default</option>
+                {% endif %}
+            </select>
+        </label>
+        <div class="trigger-type-fields{% if selected_trigger_type == 'scheduled' %} trigger-type-fields-active{% endif %}" data-trigger-type-fields="scheduled">
+            <label>
+                Cron
+                <input
+                    type="text"
+                    name="cron_expr"
+                    placeholder="0 2 * * *"
+                    value="{{ edit_trigger.cron_expr if edit_trigger else '' }}"
+                    title="Examples: 0 2 * * * = daily 02:00; 0 */6 * * * = every 6 hours; 30 1 * * 1 = Mondays 01:30; 0 9 1 * * = monthly on day 1 09:00; */15 * * * * = every 15 minutes"
+                >
+            </label>
+            <label>
+                Timezone
+                <input type="text" name="timezone" value="{{ edit_trigger.timezone if edit_trigger else 'Asia/Tokyo' }}">
+            </label>
+        </div>
+        <div class="trigger-type-fields{% if selected_trigger_type == 'watch_event' %} trigger-type-fields-active{% endif %}" data-trigger-type-fields="watch_event">
+            <label>
+                Watch Kind
+                <input type="text" name="watch_kind" placeholder="repo_ref" value="{{ edit_trigger.watch_kind if edit_trigger else '' }}">
+            </label>
+            <label>
+                Match Mode
+                <select name="match_mode">
+                    <option value="any" {% if selected_match_mode == 'any' %}selected{% endif %}>any</option>
+                    <option value="all" {% if selected_match_mode == 'all' %}selected{% endif %}>all</option>
+                </select>
+            </label>
+            <label class="profile-form-wide">
+                Watch Targets
+                <textarea name="watch_targets" rows="2" placeholder="https://github.com/RIKEN-LQCD/qws.git@master&#10;https://github.com/RIKEN-LQCD/qws.git@develop">{{ edit_trigger.watch_targets | join('\n') if edit_trigger else '' }}</textarea>
+            </label>
+        </div>
+        <div class="profile-form-actions">
+            <button type="submit" class="btn btn-primary">Save Trigger</button>
+            {% if edit_trigger %}
+            <a class="btn btn-secondary" href="{{ url_for('admin.execution_profiles') }}">Cancel Edit</a>
+            {% endif %}
+        </div>
+    </form>
+</section>
+
+<section class="page-card table-card">
+    <h2 class="section-title">Registered Triggers</h2>
+    <div class="table-wrap">
+        <table class="trigger-definition-table">
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Type</th>
+                    <th>Profile</th>
+                    <th>Condition</th>
+                    <th>Target</th>
+                    <th>State</th>
+                    <th>Manage</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for trigger in trigger_definitions %}
+                <tr>
+                    <td><a class="profile-mono profile-id-link" href="{{ url_for('admin.execution_profiles', edit_trigger=trigger.id) }}" title="{{ trigger.id }}">{{ trigger.id }}</a></td>
+                    <td>{{ trigger.trigger_type }}</td>
+                    <td><span class="profile-mono">{{ trigger.profile_id }}</span></td>
+                    <td class="trigger-condition">
+                        {% if trigger.trigger_type == 'scheduled' %}
+                        <span class="profile-mono">{{ trigger.cron_expr }}</span> / {{ trigger.timezone }}
+                        {% elif trigger.trigger_type == 'watch_event' %}
+                        {{ trigger.watch_kind }} / {{ trigger.match_mode }} / <span class="profile-mono">{{ trigger.watch_targets | join(', ') }}</span>
+                        {% else %}
+                        -
+                        {% endif %}
+                    </td>
+                    <td>
+                        <span class="profile-mono">{{ trigger.gitlab_target or 'default' }}</span>
+                        / <span class="profile-mono">{{ trigger.target_ref or default_target_ref }}</span>
+                    </td>
+                    <td>{% if trigger.enabled %}enabled{% else %}disabled{% endif %}</td>
+                    <td>
+                        <div class="profile-mini-actions">
+                            {% if trigger.enabled %}
+                            <form method="POST" action="{{ url_for('admin.pause_execution_profile_trigger', trigger_id=trigger.id) }}">
+                                {% if csrf_token is defined %}<input type="hidden" name="csrf_token" value="{{ csrf_token() }}">{% endif %}
+                                <button type="submit" class="btn btn-secondary btn-mini" title="Pause trigger">Pause</button>
+                            </form>
+                            {% else %}
+                            <form method="POST" action="{{ url_for('admin.resume_execution_profile_trigger', trigger_id=trigger.id) }}">
+                                {% if csrf_token is defined %}<input type="hidden" name="csrf_token" value="{{ csrf_token() }}">{% endif %}
+                                <button type="submit" class="btn btn-primary btn-mini" title="Resume trigger">Resume</button>
+                            </form>
+                            {% endif %}
+                            <form method="POST" action="{{ url_for('admin.delete_execution_profile_trigger', trigger_id=trigger.id) }}" onsubmit="return confirm('Delete trigger {{ trigger.id }}?');">
+                                {% if csrf_token is defined %}<input type="hidden" name="csrf_token" value="{{ csrf_token() }}">{% endif %}
+                                <button type="submit" class="btn btn-danger btn-mini" title="Delete trigger">Delete</button>
+                            </form>
+                        </div>
+                    </td>
+                </tr>
+            {% else %}
+                <tr>
+                    <td colspan="7">No trigger definitions are registered.</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</section>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+    const buttons = Array.from(document.querySelectorAll("[data-profile-filter]"));
+    const rows = Array.from(document.querySelectorAll("[data-profile-row]"));
+    function matches(row, filter) {
+        if (filter === "all") return true;
+        if (filter === "inactive") return row.dataset.inactive === "1";
+        if (filter === "expired") return row.dataset.expired === "1";
+        return row.dataset.status === filter;
+    }
+    buttons.forEach(function (button) {
+        button.addEventListener("click", function () {
+            const filter = button.dataset.profileFilter;
+            buttons.forEach(function (item) {
+                item.classList.toggle("profile-filter-active", item === button);
+            });
+            rows.forEach(function (row) {
+                row.hidden = !matches(row, filter);
+            });
+        });
+    });
+
+    const triggerTypeSelect = document.querySelector("[data-trigger-type-select]");
+    const triggerTypeFields = Array.from(document.querySelectorAll("[data-trigger-type-fields]"));
+    function updateTriggerTypeFields() {
+        if (!triggerTypeSelect) return;
+        triggerTypeFields.forEach(function (field) {
+            field.classList.toggle(
+                "trigger-type-fields-active",
+                field.dataset.triggerTypeFields === triggerTypeSelect.value
+            );
+        });
+    }
+    if (triggerTypeSelect) {
+        triggerTypeSelect.addEventListener("change", updateTriggerTypeFields);
+        updateTriggerTypeFields();
+    }
+});
+</script>
 {% endblock %}

--- a/result_server/tests/test_execution_profiles.py
+++ b/result_server/tests/test_execution_profiles.py
@@ -21,6 +21,7 @@ from utils.execution_profiles import (  # noqa: E402
     import_execution_profiles_json,
     load_execution_profiles,
     normalize_profile,
+    normalize_trigger_definition,
 )
 from utils.gitlab_pipeline import (  # noqa: E402
     GitLabPipelineSubmitResult,
@@ -30,6 +31,7 @@ from utils.gitlab_pipeline import (  # noqa: E402
     configured_gitlab_trigger_token,
     submit_pipeline_plan,
 )
+from routes.admin import _portal_result_server_url  # noqa: E402
 
 
 class _Store:
@@ -73,6 +75,7 @@ def _profile(**overrides):
         "code": "qws",
         "system": ["RIKYU"],
         "exp": ["case0"],
+        "allocation_project_id": "rkp00010",
         "scheduler_extra_args": "--account=site-local",
         "visibility": "public-results",
         "valid_from": "2026-09-01",
@@ -104,6 +107,7 @@ def test_execution_profile_store_creates_sqlite_registry(tmp_path):
     assert result.profiles[0]["code"] == ["qws"]
     assert result.profiles[0]["system"] == ["RIKYU"]
     assert result.profiles[0]["exp"] == ["case0"]
+    assert result.profiles[0]["allocation_project_id"] == "rkp00010"
     assert result.profiles[0]["scheduler_extra_args"] == "--account=site-local"
     assert result.profiles[0]["metadata_json"] == {"terms_version": "v1"}
 
@@ -127,6 +131,115 @@ def test_execution_profile_store_updates_profile_and_scopes(tmp_path):
     assert result.profiles[0]["system"] == ["MiyabiG", "RIKYU"]
     assert result.profiles[0]["exp"] == []
     assert result.profiles[0]["scheduler_extra_args"] == "--account=updated"
+
+
+def test_execution_profile_summary_counts_status_and_expiration(tmp_path):
+    db_path = tmp_path / "cx_portal.sqlite3"
+    store = ExecutionProfileStore(str(db_path))
+    store.upsert_profile(_profile(id="approved"), actor="admin")
+    store.upsert_profile(_profile(id="paused", status="paused"), actor="admin")
+    store.upsert_profile(
+        _profile(id="expired", valid_until="2000-01-01"),
+        actor="admin",
+    )
+
+    result = load_execution_profiles(str(db_path))
+
+    assert result.approved_count == 2
+    assert result.inactive_count == 1
+    assert result.expired_count == 1
+
+
+def test_execution_profile_store_sets_approval_fields_from_actor(tmp_path):
+    db_path = tmp_path / "cx_portal.sqlite3"
+    store = ExecutionProfileStore(str(db_path))
+    profile = _profile(
+        approved_by="manual@example.org",
+        approved_at="1999-01-01T00:00:00Z",
+    )
+
+    store.upsert_profile(profile, actor="admin@test.com")
+
+    result = load_execution_profiles(str(db_path))
+    assert result.profiles[0]["approved_by"] == "admin@test.com"
+    assert result.profiles[0]["approved_at"].endswith("Z")
+    assert result.profiles[0]["approved_at"] != "1999-01-01T00:00:00Z"
+
+
+def test_execution_profile_store_preserves_existing_approval_on_update(tmp_path):
+    db_path = tmp_path / "cx_portal.sqlite3"
+    store = ExecutionProfileStore(str(db_path))
+    store.upsert_profile(_profile(system=["RIKYU"]), actor="approver@test.com")
+    first = load_execution_profiles(str(db_path)).profiles[0]
+
+    store.upsert_profile(_profile(system=["RIKYU", "MiyabiG"]), actor="editor@test.com")
+
+    result = load_execution_profiles(str(db_path))
+    assert result.profiles[0]["approved_by"] == "approver@test.com"
+    assert result.profiles[0]["approved_at"] == first["approved_at"]
+
+
+def test_execution_profile_store_creates_scheduled_trigger_definition(tmp_path):
+    db_path = tmp_path / "cx_portal.sqlite3"
+    store = ExecutionProfileStore(str(db_path))
+    store.upsert_profile(_profile(), actor="admin@test.com")
+    trigger, errors = normalize_trigger_definition(
+        {
+            "id": "rikyu-qws-nightly",
+            "trigger_type": "scheduled",
+            "profile_id": "rikyu-qws-nightly",
+            "enabled": True,
+            "gitlab_target": "swc",
+            "cron_expr": "0 2 * * *",
+            "timezone": "Asia/Tokyo",
+        }
+    )
+    assert errors == []
+    assert trigger is not None
+
+    store.upsert_trigger_definition(trigger, actor="admin@test.com")
+
+    triggers = store.list_trigger_definitions()
+    assert len(triggers) == 1
+    assert triggers[0]["id"] == "rikyu-qws-nightly"
+    assert triggers[0]["trigger_type"] == "scheduled"
+    assert triggers[0]["profile_id"] == "rikyu-qws-nightly"
+    assert triggers[0]["cron_expr"] == "0 2 * * *"
+    assert triggers[0]["timezone"] == "Asia/Tokyo"
+    assert triggers[0]["gitlab_target"] == "swc"
+
+
+def test_execution_profile_store_creates_watch_event_trigger_definition(tmp_path):
+    db_path = tmp_path / "cx_portal.sqlite3"
+    store = ExecutionProfileStore(str(db_path))
+    store.upsert_profile(_profile(), actor="admin@test.com")
+    trigger, errors = normalize_trigger_definition(
+        {
+            "id": "rikyu-qws-watch",
+            "trigger_type": "watch_event",
+            "profile_id": "rikyu-qws-nightly",
+            "enabled": True,
+            "watch_kind": "repo_ref",
+            "watch_targets": (
+                "https://github.com/RIKEN-LQCD/qws.git@master\n"
+                "https://github.com/RIKEN-LQCD/qws.git@develop"
+            ),
+            "match_mode": "any",
+        }
+    )
+    assert errors == []
+    assert trigger is not None
+
+    store.upsert_trigger_definition(trigger, actor="admin@test.com")
+
+    triggers = store.list_trigger_definitions()
+    assert triggers[0]["trigger_type"] == "watch_event"
+    assert triggers[0]["watch_kind"] == "repo_ref"
+    assert triggers[0]["watch_targets"] == [
+        "https://github.com/RIKEN-LQCD/qws.git@master",
+        "https://github.com/RIKEN-LQCD/qws.git@develop",
+    ]
+    assert triggers[0]["match_mode"] == "any"
 
 
 def test_execution_profile_store_resolves_approved_matching_profile(tmp_path):
@@ -297,7 +410,10 @@ def test_admin_execution_profiles_requires_admin(tmp_path):
 
 def test_admin_execution_profiles_renders_profile_summary(tmp_path):
     db_path = tmp_path / "cx_portal.sqlite3"
-    ExecutionProfileStore(str(db_path)).upsert_profile(_profile(), actor="admin")
+    ExecutionProfileStore(str(db_path)).upsert_profile(
+        _profile(),
+        actor="admin@test.com",
+    )
     app, temp_dirs = _admin_app(db_path)
     try:
         with app.test_client() as client:
@@ -306,13 +422,50 @@ def test_admin_execution_profiles_renders_profile_summary(tmp_path):
 
         html = resp.data.decode()
         assert resp.status_code == 200
-        assert "RIKYU QWS nightly" in html
+        assert "RIKYU QWS nightly" not in html
         assert "rikyu-qws-nightly" in html
-        assert "--account=site-local" in html
+        assert "Approved</span>" in html
+        assert "Inactive</span>" in html
+        assert "Expired</span>" in html
+        assert "rkp00010" in html
         assert "approved" in html
         assert "admin@test.com" in html
         assert "qws" in html
         assert "RIKYU" in html
+        assert 'href="/admin/execution-profiles?edit=rikyu-qws-nightly"' in html
+        assert 'name="profile_id" value="rikyu-qws-nightly"' in html
+        assert 'name="target_ref" value="main"' in html
+        assert 'name="confirm_submit" value="on"' in html
+        assert 'aria-label="Trigger pipeline on main"' in html
+        assert "Preview" not in html
+        assert "Manual triggers are launched from Registered Profiles" not in html
+    finally:
+        _cleanup(temp_dirs)
+
+
+def test_admin_execution_profiles_filters_registered_profiles_by_status(tmp_path):
+    db_path = tmp_path / "cx_portal.sqlite3"
+    store = ExecutionProfileStore(str(db_path))
+    store.upsert_profile(_profile(id="approved-profile"), actor="admin@test.com")
+    store.upsert_profile(
+        _profile(id="paused-profile", status="paused"),
+        actor="admin@test.com",
+    )
+    app, temp_dirs = _admin_app(db_path)
+    try:
+        with app.test_client() as client:
+            _login_admin(client)
+            resp = client.get("/admin/execution-profiles")
+
+        html = resp.data.decode()
+        assert resp.status_code == 200
+        assert "paused-profile" in html
+        assert "approved-profile" in html
+        assert 'data-profile-filter="paused"' in html
+        assert 'data-status="paused"' in html
+        assert 'data-status="approved"' in html
+        assert "profile-filter-active" in html
+        assert "document.addEventListener" in html
     finally:
         _cleanup(temp_dirs)
 
@@ -327,21 +480,15 @@ def test_admin_execution_profiles_upserts_profile_from_form(tmp_path):
                 "/admin/execution-profiles/upsert",
                 data={
                     "id": "rikyu-qws-nightly",
-                    "display_name": "RIKYU QWS nightly",
                     "enabled": "on",
                     "status": "approved",
-                    "owner": "project-a",
                     "activity": "FugakuNEXT",
+                    "allocation_project_id": "rkp00010",
                     "code": "qws, genesis",
-                    "system": "RIKYU\nMiyabiG",
+                    "system": "RIKYU",
                     "exp": "case0",
-                    "scheduler_extra_args": "--account=site-local",
-                    "visibility": "public-results",
                     "valid_from": "2026-09-01",
                     "valid_until": "2027-03-31",
-                    "approved_by": "admin@test.com",
-                    "approved_at": "2026-09-01T00:00:00Z",
-                    "metadata_json": '{"terms_version":"v1"}',
                 },
                 follow_redirects=True,
             )
@@ -350,14 +497,209 @@ def test_admin_execution_profiles_upserts_profile_from_form(tmp_path):
         assert resp.status_code == 200
         assert b"Execution profile rikyu-qws-nightly saved." in resp.data
         assert len(result.profiles) == 1
+        assert result.profiles[0]["display_name"] == "rikyu-qws-nightly"
         assert result.profiles[0]["code"] == ["genesis", "qws"]
-        assert result.profiles[0]["system"] == ["MiyabiG", "RIKYU"]
-        assert result.profiles[0]["metadata_json"] == {"terms_version": "v1"}
+        assert result.profiles[0]["system"] == ["RIKYU"]
+        assert result.profiles[0]["allocation_project_id"] == "rkp00010"
+        assert result.profiles[0]["approved_by"] == "admin@test.com"
+        assert result.profiles[0]["approved_at"].endswith("Z")
+        assert result.profiles[0]["metadata_json"] == {}
     finally:
         _cleanup(temp_dirs)
 
 
-def test_admin_execution_profiles_rejects_invalid_metadata_json(tmp_path):
+def test_admin_execution_profiles_upserts_scheduled_trigger_from_form(tmp_path):
+    db_path = tmp_path / "cx_portal.sqlite3"
+    ExecutionProfileStore(str(db_path)).upsert_profile(
+        _profile(),
+        actor="admin@test.com",
+    )
+    app, temp_dirs = _admin_app(db_path)
+    try:
+        with app.test_client() as client:
+            _login_admin(client)
+            resp = client.post(
+                "/admin/execution-profiles/triggers/upsert",
+                data={
+                    "id": "rikyu-qws-nightly",
+                    "trigger_type": "scheduled",
+                    "profile_id": "rikyu-qws-nightly",
+                    "enabled": "on",
+                    "gitlab_target": "swc",
+                    "cron_expr": "0 2 * * *",
+                    "timezone": "Asia/Tokyo",
+                },
+                follow_redirects=True,
+            )
+
+        triggers = ExecutionProfileStore(str(db_path)).list_trigger_definitions()
+        html = resp.data.decode()
+        assert resp.status_code == 200
+        assert b"Trigger definition rikyu-qws-nightly saved." in resp.data
+        assert triggers[0]["cron_expr"] == "0 2 * * *"
+        assert "Registered Triggers" in html
+        assert "rikyu-qws-nightly" in html
+        assert "0 2 * * *" in html
+        assert "0 */6 * * * = every 6 hours" in html
+        assert 'type="checkbox" name="enabled"' not in html
+    finally:
+        _cleanup(temp_dirs)
+
+
+def test_admin_execution_profiles_upserts_watch_event_trigger_from_form(tmp_path):
+    db_path = tmp_path / "cx_portal.sqlite3"
+    ExecutionProfileStore(str(db_path)).upsert_profile(
+        _profile(),
+        actor="admin@test.com",
+    )
+    app, temp_dirs = _admin_app(db_path)
+    try:
+        with app.test_client() as client:
+            _login_admin(client)
+            resp = client.post(
+                "/admin/execution-profiles/triggers/upsert",
+                data={
+                    "id": "rikyu-qws-watch",
+                    "trigger_type": "watch_event",
+                    "profile_id": "rikyu-qws-nightly",
+                    "enabled": "on",
+                    "watch_kind": "repo_ref",
+                    "watch_targets": (
+                        "https://github.com/RIKEN-LQCD/qws.git@master\n"
+                        "https://github.com/RIKEN-LQCD/qws.git@develop"
+                    ),
+                    "match_mode": "all",
+                },
+                follow_redirects=True,
+            )
+
+        triggers = ExecutionProfileStore(str(db_path)).list_trigger_definitions()
+        html = resp.data.decode()
+        assert resp.status_code == 200
+        assert triggers[0]["watch_kind"] == "repo_ref"
+        assert triggers[0]["watch_targets"] == [
+            "https://github.com/RIKEN-LQCD/qws.git@master",
+            "https://github.com/RIKEN-LQCD/qws.git@develop",
+        ]
+        assert triggers[0]["match_mode"] == "all"
+        assert (
+            "https://github.com/RIKEN-LQCD/qws.git@master, "
+            "https://github.com/RIKEN-LQCD/qws.git@develop"
+        ) in html
+    finally:
+        _cleanup(temp_dirs)
+
+
+def test_admin_execution_profiles_edits_pauses_resumes_and_deletes_trigger(tmp_path):
+    db_path = tmp_path / "cx_portal.sqlite3"
+    store = ExecutionProfileStore(str(db_path))
+    store.upsert_profile(_profile(), actor="admin@test.com")
+    trigger, errors = normalize_trigger_definition(
+        {
+            "id": "rikyu-qws-nightly",
+            "trigger_type": "scheduled",
+            "profile_id": "rikyu-qws-nightly",
+            "enabled": True,
+            "cron_expr": "0 2 * * *",
+            "timezone": "Asia/Tokyo",
+        }
+    )
+    assert errors == []
+    assert trigger is not None
+    store.upsert_trigger_definition(trigger, actor="admin@test.com")
+    app, temp_dirs = _admin_app(db_path)
+    try:
+        with app.test_client() as client:
+            _login_admin(client)
+            edit_resp = client.get(
+                "/admin/execution-profiles?edit_trigger=rikyu-qws-nightly"
+            )
+            pause_resp = client.post(
+                "/admin/execution-profiles/triggers/rikyu-qws-nightly/pause",
+                follow_redirects=True,
+            )
+            resume_resp = client.post(
+                "/admin/execution-profiles/triggers/rikyu-qws-nightly/resume",
+                follow_redirects=True,
+            )
+            delete_resp = client.post(
+                "/admin/execution-profiles/triggers/rikyu-qws-nightly/delete",
+                follow_redirects=True,
+            )
+
+        edit_html = edit_resp.data.decode()
+        assert edit_resp.status_code == 200
+        assert "Edit Trigger" in edit_html
+        assert 'name="id" required placeholder="qws-fugaku-nightly" value="rikyu-qws-nightly"' in edit_html
+        assert pause_resp.status_code == 200
+        assert b"Trigger definition rikyu-qws-nightly paused." in pause_resp.data
+        assert resume_resp.status_code == 200
+        assert b"Trigger definition rikyu-qws-nightly resumed." in resume_resp.data
+        assert delete_resp.status_code == 200
+        assert b"Trigger definition rikyu-qws-nightly deleted." in delete_resp.data
+        assert ExecutionProfileStore(str(db_path)).list_trigger_definitions() == []
+    finally:
+        _cleanup(temp_dirs)
+
+
+def test_admin_execution_profiles_deletes_profile(tmp_path):
+    db_path = tmp_path / "cx_portal.sqlite3"
+    ExecutionProfileStore(str(db_path)).upsert_profile(
+        _profile(),
+        actor="admin@test.com",
+    )
+    app, temp_dirs = _admin_app(db_path)
+    try:
+        with app.test_client() as client:
+            _login_admin(client)
+            resp = client.post(
+                "/admin/execution-profiles/rikyu-qws-nightly/delete",
+                follow_redirects=True,
+            )
+
+        result = load_execution_profiles(str(db_path))
+        assert resp.status_code == 200
+        assert b"Execution profile rikyu-qws-nightly deleted." in resp.data
+        assert result.profiles == []
+    finally:
+        _cleanup(temp_dirs)
+
+
+def test_admin_execution_profiles_edit_link_prefills_form(tmp_path):
+    db_path = tmp_path / "cx_portal.sqlite3"
+    ExecutionProfileStore(str(db_path)).upsert_profile(
+        _profile(
+            id="qws-fugaku",
+            code=["qws"],
+            system=["Fugaku"],
+            exp=[],
+            allocation_project_id="rkp00010",
+            activity="CX",
+            valid_from="2026-08-01",
+            valid_until="2026-09-30",
+        ),
+        actor="admin@test.com",
+    )
+    app, temp_dirs = _admin_app(db_path)
+    try:
+        with app.test_client() as client:
+            _login_admin(client)
+            resp = client.get("/admin/execution-profiles?edit=qws-fugaku")
+
+        html = resp.data.decode()
+        assert resp.status_code == 200
+        assert "Edit Profile" in html
+        assert 'name="id" required placeholder="qws-fugaku-rkp00010" value="qws-fugaku"' in html
+        assert 'name="activity" placeholder="FugakuNEXT" value="CX"' in html
+        assert 'name="allocation_project_id" required placeholder="rkp00010" value="rkp00010"' in html
+        assert 'name="system" placeholder="Fugaku" value="Fugaku"' in html
+        assert "qws</textarea>" in html
+        assert "Cancel Edit" in html
+    finally:
+        _cleanup(temp_dirs)
+
+
+def test_admin_execution_profiles_rejects_allocation_without_single_system(tmp_path):
     db_path = tmp_path / "cx_portal.sqlite3"
     app, temp_dirs = _admin_app(db_path)
     try:
@@ -366,22 +708,49 @@ def test_admin_execution_profiles_rejects_invalid_metadata_json(tmp_path):
             resp = client.post(
                 "/admin/execution-profiles/upsert",
                 data={
-                    "id": "bad-metadata",
-                    "enabled": "on",
-                    "metadata_json": "[1, 2, 3]",
+                    "id": "bad-allocation-scope",
+                    "status": "approved",
+                    "allocation_project_id": "rkp00010",
+                    "code": "qws",
+                    "system": "Fugaku,MiyabiG",
                 },
                 follow_redirects=True,
             )
 
         result = load_execution_profiles(str(db_path))
         assert resp.status_code == 200
-        assert b"metadata_json must be a JSON object" in resp.data
+        assert b"allocation_project_id requires exactly one system" in resp.data
         assert result.profiles == []
     finally:
         _cleanup(temp_dirs)
 
 
-def test_admin_execution_profiles_dry_run_submit_renders_payload(tmp_path, monkeypatch):
+def test_admin_execution_profiles_rejects_approved_profile_without_allocation(tmp_path):
+    db_path = tmp_path / "cx_portal.sqlite3"
+    app, temp_dirs = _admin_app(db_path)
+    try:
+        with app.test_client() as client:
+            _login_admin(client)
+            resp = client.post(
+                "/admin/execution-profiles/upsert",
+                data={
+                    "id": "missing-allocation",
+                    "status": "approved",
+                    "code": "qws",
+                    "system": "Fugaku",
+                },
+                follow_redirects=True,
+            )
+
+        result = load_execution_profiles(str(db_path))
+        assert resp.status_code == 200
+        assert b"approved profiles require allocation_project_id" in resp.data
+        assert result.profiles == []
+    finally:
+        _cleanup(temp_dirs)
+
+
+def test_admin_execution_profiles_dry_run_submit_records_payload(tmp_path, monkeypatch):
     monkeypatch.setenv("RESULT_SERVER_GITLAB_REPO", "gitlab.example.org/group/benchkit.git")
     db_path = tmp_path / "cx_portal.sqlite3"
     ExecutionProfileStore(str(db_path)).upsert_profile(_profile(), actor="admin")
@@ -393,20 +762,11 @@ def test_admin_execution_profiles_dry_run_submit_renders_payload(tmp_path, monke
                 "/admin/execution-profiles/dry-run-submit",
                 data={
                     "target_ref": "develop",
-                    "code": "qws",
-                    "system": "RIKYU",
-                    "exp": "case0",
+                    "profile_id": "rikyu-qws-nightly",
                 },
             )
 
-        html = resp.data.decode()
         assert resp.status_code == 200
-        assert "Dry-run request #1" in html
-        assert "dry_run_ready" in html
-        assert "https://gitlab.example.org/api/v4/projects/group%2Fbenchkit/trigger/pipeline" in html
-        assert "gitlab.example.org/group/benchkit.git" in html
-        assert "Profile Exp is used for Portal profile matching" in html
-        assert "--account=site-local" in html
 
         with sqlite3.connect(db_path) as conn:
             row = conn.execute(
@@ -416,7 +776,9 @@ def test_admin_execution_profiles_dry_run_submit_renders_payload(tmp_path, monke
         payload_record = json.loads(row[4])
         variables = payload_record["payload"]["variables"]
         assert variables["code"] == "qws"
-        assert variables["BK_SCHEDULER_EXTRA_ARGS_RIKYU"] == "--account=site-local"
+        assert variables["BK_ALLOCATION_PROJECT_ID"] == "rkp00010"
+        assert variables["RESULT_SERVER"] == "http://localhost"
+        assert "BK_SCHEDULER_EXTRA_ARGS_RIKYU" not in variables
         assert "exp" not in variables
         assert payload_record["gitlab_project"] == "gitlab.example.org/group/benchkit.git"
     finally:
@@ -442,10 +804,7 @@ def test_admin_execution_profiles_dry_run_uses_profile_scope_values(
                 },
             )
 
-        html = resp.data.decode()
         assert resp.status_code == 200
-        assert "dry_run_ready" in html
-        assert "Profile Exp is used for Portal profile matching" in html
 
         with sqlite3.connect(db_path) as conn:
             row = conn.execute(
@@ -465,7 +824,55 @@ def test_admin_execution_profiles_dry_run_uses_profile_scope_values(
         variables = payload_record["payload"]["variables"]
         assert variables["code"] == "qws"
         assert variables["system"] == "RIKYU"
+        assert variables["BK_ALLOCATION_PROJECT_ID"] == "rkp00010"
+        assert variables["RESULT_SERVER"] == "http://localhost"
         assert "exp" not in variables
+    finally:
+        _cleanup(temp_dirs)
+
+
+def test_admin_execution_profiles_dry_run_uses_portal_prefix_for_result_server(
+    tmp_path,
+    monkeypatch,
+):
+    db_path = tmp_path / "cx_portal.sqlite3"
+    app, temp_dirs = _admin_app(db_path)
+    try:
+        with app.test_request_context(
+            "/dev2/admin/execution-profiles/dry-run-submit",
+            base_url="https://fncx.r-ccs.riken.jp",
+        ):
+            assert _portal_result_server_url() == "https://fncx.r-ccs.riken.jp/dev2"
+    finally:
+        _cleanup(temp_dirs)
+
+
+def test_admin_execution_profiles_dry_run_uses_configured_result_server_url(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("RESULT_SERVER_GITLAB_REPO", "gitlab.example.org/group/benchkit.git")
+    monkeypatch.setenv("RESULT_SERVER_PUBLIC_URL", "https://portal.example.org/dev2/")
+    db_path = tmp_path / "cx_portal.sqlite3"
+    ExecutionProfileStore(str(db_path)).upsert_profile(_profile(), actor="admin")
+    app, temp_dirs = _admin_app(db_path)
+    try:
+        with app.test_client() as client:
+            _login_admin(client)
+            resp = client.post(
+                "/admin/execution-profiles/dry-run-submit",
+                data={
+                    "target_ref": "develop",
+                    "profile_id": "rikyu-qws-nightly",
+                },
+            )
+
+        assert resp.status_code == 200
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute("SELECT payload_json FROM execution_requests").fetchone()
+        payload_record = json.loads(row[0])
+        variables = payload_record["payload"]["variables"]
+        assert variables["RESULT_SERVER"] == "https://portal.example.org/dev2"
     finally:
         _cleanup(temp_dirs)
 
@@ -482,13 +889,49 @@ def test_admin_execution_profiles_dry_run_blocks_without_matching_profile(
             _login_admin(client)
             resp = client.post(
                 "/admin/execution-profiles/dry-run-submit",
-                data={"target_ref": "develop", "code": "qws", "system": "RIKYU"},
+                data={"target_ref": "develop"},
             )
 
-        html = resp.data.decode()
         assert resp.status_code == 200
-        assert "dry_run_blocked" in html
-        assert "no approved execution profile matches target" in html
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT status, errors_json FROM execution_requests"
+            ).fetchone()
+        assert row[0] == "dry_run_blocked"
+        assert "profile_id is required" in json.loads(row[1])
+    finally:
+        _cleanup(temp_dirs)
+
+
+def test_admin_execution_profiles_dry_run_blocks_profile_without_allocation(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("RESULT_SERVER_GITLAB_REPO", "gitlab.example.org/group/benchkit.git")
+    db_path = tmp_path / "cx_portal.sqlite3"
+    ExecutionProfileStore(str(db_path)).upsert_profile(
+        _profile(allocation_project_id=""),
+        actor="admin",
+    )
+    app, temp_dirs = _admin_app(db_path)
+    try:
+        with app.test_client() as client:
+            _login_admin(client)
+            resp = client.post(
+                "/admin/execution-profiles/dry-run-submit",
+                data={
+                    "target_ref": "develop",
+                    "profile_id": "rikyu-qws-nightly",
+                },
+            )
+
+        assert resp.status_code == 200
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT status, errors_json FROM execution_requests"
+            ).fetchone()
+        assert row[0] == "dry_run_blocked"
+        assert "profile allocation_project_id is required" in json.loads(row[1])
     finally:
         _cleanup(temp_dirs)
 
@@ -597,9 +1040,7 @@ def test_admin_execution_profiles_submit_posts_pipeline_and_records_request(
                 "/admin/execution-profiles/submit",
                 data={
                     "target_ref": "develop",
-                    "code": "qws",
-                    "system": "RIKYU",
-                    "exp": "case0",
+                    "profile_id": "rikyu-qws-nightly",
                     "confirm_submit": "on",
                 },
             )
@@ -666,9 +1107,7 @@ def test_admin_execution_profiles_submit_uses_selected_gitlab_target(
                 data={
                     "gitlab_target": "gitlab_com",
                     "target_ref": "develop",
-                    "code": "qws",
-                    "system": "RIKYU",
-                    "exp": "case0",
+                    "profile_id": "rikyu-qws-nightly",
                     "confirm_submit": "on",
                 },
             )
@@ -698,7 +1137,7 @@ def test_admin_execution_profiles_submit_uses_profile_scope_values(
     monkeypatch.setenv("RESULT_SERVER_GITLAB_TRIGGER_TOKEN", "secret-token")
     db_path = tmp_path / "cx_portal.sqlite3"
     ExecutionProfileStore(str(db_path)).upsert_profile(
-        _profile(system=["Fugaku", "MiyabiG"]),
+        _profile(system=["Fugaku"]),
         actor="admin",
     )
     app, temp_dirs = _admin_app(db_path)
@@ -706,7 +1145,9 @@ def test_admin_execution_profiles_submit_uses_profile_scope_values(
     def fake_submit(plan, *, token):
         assert token == "secret-token"
         assert plan.payload["variables"]["code"] == "qws"
-        assert plan.payload["variables"]["system"] == "Fugaku,MiyabiG"
+        assert plan.payload["variables"]["system"] == "Fugaku"
+        assert plan.payload["variables"]["BK_ALLOCATION_PROJECT_ID"] == "rkp00010"
+        assert plan.payload["variables"]["RESULT_SERVER"] == "http://localhost"
         assert "exp" not in plan.payload["variables"]
         return GitLabPipelineSubmitResult(
             status_code=201,
@@ -742,7 +1183,7 @@ def test_admin_execution_profiles_submit_uses_profile_scope_values(
             "submitted",
             "rikyu-qws-nightly",
             "qws",
-            "Fugaku,MiyabiG",
+            "Fugaku",
             "case0",
         )
         payload_record = json.loads(row[5])
@@ -767,7 +1208,10 @@ def test_admin_execution_profiles_submit_requires_confirmation(tmp_path, monkeyp
             _login_admin(client)
             resp = client.post(
                 "/admin/execution-profiles/submit",
-                data={"target_ref": "develop", "code": "qws", "system": "RIKYU"},
+                data={
+                    "target_ref": "develop",
+                    "profile_id": "rikyu-qws-nightly",
+                },
             )
 
         html = resp.data.decode()

--- a/result_server/utils/execution_profiles.py
+++ b/result_server/utils/execution_profiles.py
@@ -13,7 +13,9 @@ from typing import Any
 
 
 PROFILE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
-SCHEMA_VERSION = 3
+TRIGGER_TYPES = {"manual_button", "scheduled", "watch_event"}
+MATCH_MODES = {"any", "all"}
+SCHEMA_VERSION = 5
 
 
 @dataclass(frozen=True)
@@ -33,6 +35,29 @@ class ExecutionProfileLoadResult:
     def disabled_count(self) -> int:
         return len(self.profiles) - self.enabled_count
 
+    @property
+    def approved_count(self) -> int:
+        return sum(1 for profile in self.profiles if profile.get("status") == "approved")
+
+    @property
+    def inactive_count(self) -> int:
+        inactive_statuses = {"paused", "retired"}
+        return sum(
+            1
+            for profile in self.profiles
+            if not profile.get("enabled", True)
+            or profile.get("status") in inactive_statuses
+        )
+
+    @property
+    def expired_count(self) -> int:
+        today = datetime.now(UTC).date().isoformat()
+        return sum(
+            1
+            for profile in self.profiles
+            if profile.get("valid_until") and profile.get("valid_until") < today
+        )
+
 
 @dataclass(frozen=True)
 class ExecutionProfileResolveResult:
@@ -46,6 +71,12 @@ class ExecutionProfileResolveResult:
         if not self.profile:
             return ""
         return str(self.profile.get("scheduler_extra_args", ""))
+
+    @property
+    def allocation_project_id(self) -> str:
+        if not self.profile:
+            return ""
+        return str(self.profile.get("allocation_project_id", ""))
 
 
 def _utc_now_iso() -> str:
@@ -71,6 +102,35 @@ def _as_text_list(value: Any) -> list[str]:
 
 def _json_dump(value: Any) -> str:
     return json.dumps(value or {}, ensure_ascii=False, sort_keys=True)
+
+
+def _json_dump_list(value: Any) -> str:
+    return json.dumps(value or [], ensure_ascii=False, sort_keys=True)
+
+
+def _as_watch_targets(value: Any) -> list[str]:
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return []
+        if stripped.startswith("["):
+            try:
+                decoded = json.loads(stripped)
+            except json.JSONDecodeError:
+                decoded = None
+            if isinstance(decoded, list):
+                return _as_text_list(decoded)
+        return _split_text_block(stripped)
+    return _as_text_list(value)
+
+
+def _split_text_block(value: str) -> list[str]:
+    items = []
+    for chunk in value.replace("\n", ",").split(","):
+        text = chunk.strip()
+        if text:
+            items.append(text)
+    return items
 
 
 def _scope_matches(scope_values: list[str], target: str) -> bool:
@@ -117,6 +177,7 @@ def normalize_profile(raw_profile: Any, index: int = 0) -> tuple[dict[str, Any] 
         "code": _as_text_list(raw_profile.get("code")),
         "system": _as_text_list(raw_profile.get("system")),
         "exp": _as_text_list(raw_profile.get("exp")),
+        "allocation_project_id": str(raw_profile.get("allocation_project_id", "")).strip(),
         "scheduler_extra_args": str(raw_profile.get("scheduler_extra_args", "")).strip(),
         "visibility": str(raw_profile.get("visibility", "")).strip(),
         "valid_from": str(raw_profile.get("valid_from", "")).strip(),
@@ -125,6 +186,75 @@ def normalize_profile(raw_profile: Any, index: int = 0) -> tuple[dict[str, Any] 
         "approved_by": str(raw_profile.get("approved_by", "")).strip(),
         "approved_at": str(raw_profile.get("approved_at", "")).strip(),
         "metadata_json": metadata,
+    }
+    return normalized, errors
+
+
+def normalize_trigger_definition(
+    raw_trigger: Any,
+    index: int = 0,
+) -> tuple[dict[str, Any] | None, list[str]]:
+    """Normalize a trigger definition from form input and return validation errors."""
+    errors: list[str] = []
+    if not isinstance(raw_trigger, dict):
+        return None, [f"trigger[{index}] must be an object"]
+
+    trigger_id = str(raw_trigger.get("id", "")).strip()
+    if not trigger_id:
+        errors.append(f"trigger[{index}] is missing id")
+    elif not PROFILE_ID_RE.match(trigger_id):
+        errors.append(f"trigger[{index}] has invalid id: {trigger_id}")
+
+    profile_id = str(raw_trigger.get("profile_id", "")).strip()
+    if not profile_id:
+        errors.append(f"trigger[{index}] profile_id is required")
+
+    trigger_type = str(raw_trigger.get("trigger_type") or "scheduled").strip()
+    if trigger_type not in TRIGGER_TYPES:
+        errors.append(f"trigger[{index}] trigger_type must be one of {sorted(TRIGGER_TYPES)}")
+
+    enabled = raw_trigger.get("enabled", True)
+    if not isinstance(enabled, bool):
+        errors.append(f"trigger[{index}] enabled must be boolean")
+        enabled = bool(enabled)
+
+    match_mode = str(raw_trigger.get("match_mode") or "any").strip()
+    if match_mode not in MATCH_MODES:
+        errors.append(f"trigger[{index}] match_mode must be one of {sorted(MATCH_MODES)}")
+
+    cron_expr = str(raw_trigger.get("cron_expr", "")).strip()
+    timezone = str(raw_trigger.get("timezone", "")).strip() or "Asia/Tokyo"
+    watch_kind = str(raw_trigger.get("watch_kind", "")).strip()
+    watch_targets = _as_watch_targets(
+        raw_trigger.get("watch_targets", raw_trigger.get("watch_targets_json", []))
+    )
+
+    if trigger_type == "scheduled" and not cron_expr:
+        errors.append(f"trigger[{index}] cron_expr is required for scheduled triggers")
+    if trigger_type == "watch_event":
+        if not watch_kind:
+            errors.append(f"trigger[{index}] watch_kind is required for watch_event triggers")
+        if not watch_targets:
+            errors.append(f"trigger[{index}] watch_targets is required for watch_event triggers")
+
+    normalized = {
+        "id": trigger_id,
+        "name": str(raw_trigger.get("name") or trigger_id).strip(),
+        "trigger_type": trigger_type,
+        "profile_id": profile_id,
+        "enabled": enabled,
+        "gitlab_target": str(raw_trigger.get("gitlab_target", "")).strip(),
+        "target_ref": str(raw_trigger.get("target_ref", "")).strip(),
+        "cron_expr": cron_expr,
+        "timezone": timezone,
+        "watch_kind": watch_kind,
+        "watch_targets": watch_targets,
+        "match_mode": match_mode,
+        "last_seen_fingerprint": str(raw_trigger.get("last_seen_fingerprint", "")).strip(),
+        "last_seen_at": str(raw_trigger.get("last_seen_at", "")).strip(),
+        "next_due_at": str(raw_trigger.get("next_due_at", "")).strip(),
+        "last_submitted_at": str(raw_trigger.get("last_submitted_at", "")).strip(),
+        "created_by": str(raw_trigger.get("created_by", "")).strip(),
     }
     return normalized, errors
 
@@ -165,6 +295,12 @@ class ExecutionProfileStore:
                 current = 2
             if current < 3:
                 self._apply_v3(conn)
+                current = 3
+            if current < 4:
+                self._apply_v4(conn)
+                current = 4
+            if current < 5:
+                self._apply_v5(conn)
 
     def _apply_v1(self, conn: sqlite3.Connection) -> None:
         now = _utc_now_iso()
@@ -179,6 +315,7 @@ class ExecutionProfileStore:
                 owner TEXT NOT NULL DEFAULT '',
                 purpose TEXT NOT NULL DEFAULT '',
                 visibility TEXT NOT NULL DEFAULT '',
+                allocation_project_id TEXT NOT NULL DEFAULT '',
                 scheduler_extra_args TEXT NOT NULL DEFAULT '',
                 valid_from TEXT NOT NULL DEFAULT '',
                 valid_until TEXT NOT NULL DEFAULT '',
@@ -274,23 +411,100 @@ class ExecutionProfileStore:
             (3, now),
         )
 
+    def _apply_v4(self, conn: sqlite3.Connection) -> None:
+        now = _utc_now_iso()
+        columns = {
+            row["name"]
+            for row in conn.execute("PRAGMA table_info(execution_profiles)").fetchall()
+        }
+        if "allocation_project_id" not in columns:
+            conn.execute(
+                """
+                ALTER TABLE execution_profiles
+                ADD COLUMN allocation_project_id TEXT NOT NULL DEFAULT ''
+                """
+            )
+        conn.execute(
+            "INSERT INTO schema_migrations(version, applied_at) VALUES (?, ?)",
+            (4, now),
+        )
+
+    def _apply_v5(self, conn: sqlite3.Connection) -> None:
+        now = _utc_now_iso()
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS trigger_definitions (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL DEFAULT '',
+                trigger_type TEXT NOT NULL CHECK(
+                    trigger_type IN ('manual_button', 'scheduled', 'watch_event')
+                ),
+                profile_id TEXT NOT NULL REFERENCES execution_profiles(id) ON DELETE CASCADE,
+                enabled INTEGER NOT NULL DEFAULT 1,
+                gitlab_target TEXT NOT NULL DEFAULT '',
+                target_ref TEXT NOT NULL DEFAULT '',
+                cron_expr TEXT NOT NULL DEFAULT '',
+                timezone TEXT NOT NULL DEFAULT '',
+                watch_kind TEXT NOT NULL DEFAULT '',
+                watch_targets_json TEXT NOT NULL DEFAULT '[]',
+                match_mode TEXT NOT NULL DEFAULT 'any' CHECK(match_mode IN ('any', 'all')),
+                last_seen_fingerprint TEXT NOT NULL DEFAULT '',
+                last_seen_at TEXT NOT NULL DEFAULT '',
+                next_due_at TEXT NOT NULL DEFAULT '',
+                last_submitted_at TEXT NOT NULL DEFAULT '',
+                created_by TEXT NOT NULL DEFAULT '',
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_trigger_definitions_profile
+                ON trigger_definitions(profile_id, enabled, trigger_type);
+            """
+        )
+        conn.execute(
+            "INSERT INTO schema_migrations(version, applied_at) VALUES (?, ?)",
+            (5, now),
+        )
+
     def upsert_profile(self, profile: dict[str, Any], *, actor: str = "") -> None:
         self.migrate()
         now = _utc_now_iso()
         with self.connect() as conn:
             existing = conn.execute(
-                "SELECT id, created_at FROM execution_profiles WHERE id = ?",
+                """
+                SELECT id, status, approved_by, approved_at, created_at
+                FROM execution_profiles
+                WHERE id = ?
+                """,
                 (profile["id"],),
             ).fetchone()
             created_at = existing["created_at"] if existing else now
+            approved_by = ""
+            approved_at = ""
+            if profile["status"] == "approved":
+                if (
+                    existing
+                    and existing["status"] == "approved"
+                    and existing["approved_by"]
+                    and existing["approved_at"]
+                ):
+                    approved_by = existing["approved_by"]
+                    approved_at = existing["approved_at"]
+                else:
+                    approved_by = actor
+                    approved_at = now
+            elif existing:
+                approved_by = existing["approved_by"]
+                approved_at = existing["approved_at"]
             conn.execute(
                 """
                 INSERT INTO execution_profiles (
                     id, display_name, enabled, status, activity, owner, purpose,
-                    visibility, scheduler_extra_args, valid_from, valid_until,
-                    created_by, approved_by, approved_at, metadata_json,
+                    visibility, allocation_project_id, scheduler_extra_args,
+                    valid_from, valid_until, created_by, approved_by, approved_at,
+                    metadata_json,
                     created_at, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(id) DO UPDATE SET
                     display_name=excluded.display_name,
                     enabled=excluded.enabled,
@@ -299,6 +513,7 @@ class ExecutionProfileStore:
                     owner=excluded.owner,
                     purpose=excluded.purpose,
                     visibility=excluded.visibility,
+                    allocation_project_id=excluded.allocation_project_id,
                     scheduler_extra_args=excluded.scheduler_extra_args,
                     valid_from=excluded.valid_from,
                     valid_until=excluded.valid_until,
@@ -317,12 +532,13 @@ class ExecutionProfileStore:
                     profile["owner"],
                     profile["purpose"],
                     profile["visibility"],
+                    profile["allocation_project_id"],
                     profile["scheduler_extra_args"],
                     profile["valid_from"],
                     profile["valid_until"],
                     profile["created_by"],
-                    profile["approved_by"],
-                    profile["approved_at"],
+                    approved_by,
+                    approved_at,
                     _json_dump(profile["metadata_json"]),
                     created_at,
                     now,
@@ -357,6 +573,213 @@ class ExecutionProfileStore:
                     now,
                 ),
             )
+
+    def upsert_trigger_definition(self, trigger: dict[str, Any], *, actor: str = "") -> None:
+        self.migrate()
+        now = _utc_now_iso()
+        with self.connect() as conn:
+            existing = conn.execute(
+                """
+                SELECT id, created_at, created_by
+                FROM trigger_definitions
+                WHERE id = ?
+                """,
+                (trigger["id"],),
+            ).fetchone()
+            created_at = existing["created_at"] if existing else now
+            created_by = (
+                existing["created_by"]
+                if existing and existing["created_by"]
+                else trigger.get("created_by") or actor
+            )
+            conn.execute(
+                """
+                INSERT INTO trigger_definitions (
+                    id, name, trigger_type, profile_id, enabled, gitlab_target,
+                    target_ref, cron_expr, timezone, watch_kind, watch_targets_json,
+                    match_mode, last_seen_fingerprint, last_seen_at, next_due_at,
+                    last_submitted_at, created_by, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    name=excluded.name,
+                    trigger_type=excluded.trigger_type,
+                    profile_id=excluded.profile_id,
+                    enabled=excluded.enabled,
+                    gitlab_target=excluded.gitlab_target,
+                    target_ref=excluded.target_ref,
+                    cron_expr=excluded.cron_expr,
+                    timezone=excluded.timezone,
+                    watch_kind=excluded.watch_kind,
+                    watch_targets_json=excluded.watch_targets_json,
+                    match_mode=excluded.match_mode,
+                    last_seen_fingerprint=excluded.last_seen_fingerprint,
+                    last_seen_at=excluded.last_seen_at,
+                    next_due_at=excluded.next_due_at,
+                    last_submitted_at=excluded.last_submitted_at,
+                    updated_at=excluded.updated_at
+                """,
+                (
+                    trigger["id"],
+                    trigger["name"],
+                    trigger["trigger_type"],
+                    trigger["profile_id"],
+                    1 if trigger["enabled"] else 0,
+                    trigger["gitlab_target"],
+                    trigger["target_ref"],
+                    trigger["cron_expr"],
+                    trigger["timezone"],
+                    trigger["watch_kind"],
+                    _json_dump_list(trigger["watch_targets"]),
+                    trigger["match_mode"],
+                    trigger["last_seen_fingerprint"],
+                    trigger["last_seen_at"],
+                    trigger["next_due_at"],
+                    trigger["last_submitted_at"],
+                    created_by,
+                    created_at,
+                    now,
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO execution_profile_events(
+                    profile_id, actor, event_type, payload_json, created_at
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    trigger["profile_id"],
+                    actor,
+                    "trigger_definition_upserted" if existing else "trigger_definition_created",
+                    _json_dump(
+                        {
+                            "trigger_id": trigger["id"],
+                            "trigger_type": trigger["trigger_type"],
+                        }
+                    ),
+                    now,
+                ),
+            )
+
+    def set_trigger_definition_enabled(
+        self,
+        trigger_id: str,
+        enabled: bool,
+        *,
+        actor: str = "",
+    ) -> bool:
+        self.migrate()
+        now = _utc_now_iso()
+        with self.connect() as conn:
+            existing = conn.execute(
+                """
+                SELECT id, profile_id
+                FROM trigger_definitions
+                WHERE id = ?
+                """,
+                (trigger_id,),
+            ).fetchone()
+            if not existing:
+                return False
+            conn.execute(
+                """
+                UPDATE trigger_definitions
+                SET enabled = ?, updated_at = ?
+                WHERE id = ?
+                """,
+                (1 if enabled else 0, now, trigger_id),
+            )
+            conn.execute(
+                """
+                INSERT INTO execution_profile_events(
+                    profile_id, actor, event_type, payload_json, created_at
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    existing["profile_id"],
+                    actor,
+                    "trigger_definition_resumed"
+                    if enabled
+                    else "trigger_definition_paused",
+                    _json_dump({"trigger_id": trigger_id}),
+                    now,
+                ),
+            )
+        return True
+
+    def delete_trigger_definition(self, trigger_id: str, *, actor: str = "") -> bool:
+        self.migrate()
+        now = _utc_now_iso()
+        with self.connect() as conn:
+            existing = conn.execute(
+                """
+                SELECT id, profile_id
+                FROM trigger_definitions
+                WHERE id = ?
+                """,
+                (trigger_id,),
+            ).fetchone()
+            if not existing:
+                return False
+            conn.execute("DELETE FROM trigger_definitions WHERE id = ?", (trigger_id,))
+            conn.execute(
+                """
+                INSERT INTO execution_profile_events(
+                    profile_id, actor, event_type, payload_json, created_at
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    existing["profile_id"],
+                    actor,
+                    "trigger_definition_deleted",
+                    _json_dump({"trigger_id": trigger_id}),
+                    now,
+                ),
+            )
+        return True
+
+    def list_trigger_definitions(self) -> list[dict[str, Any]]:
+        self.migrate()
+        with self.connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT *
+                FROM trigger_definitions
+                ORDER BY enabled DESC, trigger_type, id COLLATE NOCASE
+                """
+            ).fetchall()
+
+        triggers = []
+        for row in rows:
+            try:
+                watch_targets = json.loads(row["watch_targets_json"] or "[]")
+            except json.JSONDecodeError:
+                watch_targets = []
+            if not isinstance(watch_targets, list):
+                watch_targets = []
+            triggers.append(
+                {
+                    "id": row["id"],
+                    "name": row["name"],
+                    "trigger_type": row["trigger_type"],
+                    "profile_id": row["profile_id"],
+                    "enabled": bool(row["enabled"]),
+                    "gitlab_target": row["gitlab_target"],
+                    "target_ref": row["target_ref"],
+                    "cron_expr": row["cron_expr"],
+                    "timezone": row["timezone"],
+                    "watch_kind": row["watch_kind"],
+                    "watch_targets": _as_text_list(watch_targets),
+                    "match_mode": row["match_mode"],
+                    "last_seen_fingerprint": row["last_seen_fingerprint"],
+                    "last_seen_at": row["last_seen_at"],
+                    "next_due_at": row["next_due_at"],
+                    "last_submitted_at": row["last_submitted_at"],
+                    "created_by": row["created_by"],
+                    "created_at": row["created_at"],
+                    "updated_at": row["updated_at"],
+                }
+            )
+        return triggers
 
     def list_profiles(self) -> list[dict[str, Any]]:
         self.migrate()
@@ -404,6 +827,7 @@ class ExecutionProfileStore:
                     "code": profile_scopes["code"],
                     "system": profile_scopes["system"],
                     "exp": profile_scopes["exp"],
+                    "allocation_project_id": row["allocation_project_id"],
                     "scheduler_extra_args": row["scheduler_extra_args"],
                     "visibility": row["visibility"],
                     "valid_from": row["valid_from"],
@@ -417,6 +841,33 @@ class ExecutionProfileStore:
                 }
             )
         return profiles
+
+    def delete_profile(self, profile_id: str, *, actor: str = "") -> bool:
+        self.migrate()
+        now = _utc_now_iso()
+        with self.connect() as conn:
+            existing = conn.execute(
+                "SELECT id FROM execution_profiles WHERE id = ?",
+                (profile_id,),
+            ).fetchone()
+            if not existing:
+                return False
+            conn.execute(
+                """
+                INSERT INTO execution_profile_events(
+                    profile_id, actor, event_type, payload_json, created_at
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    profile_id,
+                    actor,
+                    "profile_deleted",
+                    _json_dump({"profile_id": profile_id}),
+                    now,
+                ),
+            )
+            conn.execute("DELETE FROM execution_profiles WHERE id = ?", (profile_id,))
+        return True
 
     def resolve_profile(
         self,

--- a/result_server/utils/gitlab_pipeline.py
+++ b/result_server/utils/gitlab_pipeline.py
@@ -179,7 +179,9 @@ def build_pipeline_plan(
     benchpark: bool = False,
     park_only: bool = False,
     park_send: bool = False,
+    allocation_project_id: str = "",
     scheduler_extra_args: str = "",
+    result_server_url: str = "",
     target_id: str = "",
 ) -> GitLabPipelinePlan:
     """Build the GitLab trigger API URL and form-like payload without sending it."""
@@ -207,6 +209,8 @@ def build_pipeline_plan(
         _add_variable(variables, "park_only", "true")
     if park_send:
         _add_variable(variables, "park_send", "true")
+    _add_variable(variables, "BK_ALLOCATION_PROJECT_ID", allocation_project_id)
+    _add_variable(variables, "RESULT_SERVER", result_server_url)
     if scheduler_extra_args:
         if system and "," not in system:
             _add_variable(variables, _scheduler_extra_args_key(system), scheduler_extra_args)


### PR DESCRIPTION
## Summary
- add site-local trigger definitions for scheduled and repo_ref watch triggers
- simplify execution profile governance UI and add edit/delete/pause/resume actions
- pass RESULT_SERVER from the originating Portal into GitLab trigger payloads
- forward parent pipeline variables into generated child pipelines

## Validation
- GitLab Manual CI checked by user
- /home/nakamura/fugakunext/venv/bin/python -m pytest result_server/tests/test_execution_profiles.py result_server/tests/test_api_routes.py result_server/tests/test_app_dev_security.py result_server/tests/test_preflight.py