### PR TITLE
Add portal trigger runner

### DIFF
--- a/docs/guides/add-site.md
+++ b/docs/guides/add-site.md
@@ -608,6 +608,28 @@ JSON は、初期投入や移行 seed の補助形式として使えます。例
 
 この JSON や SQLite DB には account や project group の実値が入り得るため、公開 OSS repo には commit しないでください。Portal では admin user だけが `/admin/execution-profiles` から確認できます。
 
+Portal で作成した定期実行や repo/ref 監視トリガーは、Portal の実行環境で
+site-local trigger runner を常駐させて評価します。GitLab schedule ではなく
+Portal が governance と `RESULT_SERVER` の戻し先を決め、GitLab には pipeline
+trigger として渡します。例:
+
+```bash
+scripts/site/setup_trigger_runner.sh \
+  --site dev2 \
+  --repo-dir /home/nakamura/ChatGPT/benchkit \
+  --venv /home/nakamura/fugakunext/venv \
+  --db /home/nakamura/fugakunext/dev2/cx_portal.sqlite3 \
+  --env-file /home/nakamura/.config/fncx/dev2.env \
+  --result-server-url https://fncx.r-ccs.riken.jp/dev2 \
+  --submit
+```
+
+初回導入時は `--dry-run` のまま timer を作って動作を確認できます。`repo_ref`
+監視は初回観測では baseline を保存するだけで pipeline を投入せず、2回目以降
+の fingerprint 変化で発火します。runner は短命の SQLite lock を既定で使う
+ため、timer 実行が重なっても同じ trigger を二重評価しません。timer 間隔を
+変える場合は `--lock-ttl-seconds` で TTL を調整できます。
+
 Execution profile を実行要求へ適用する場合、Portal は `enabled=true` かつ
 `status=approved` の profile だけを候補にします。`code` / `system` / `exp`
 scope は空なら wildcard、値が入っていればその値だけに一致します。profile ID

--- a/docs/guides/portal-execution-profiles-handoff.md
+++ b/docs/guides/portal-execution-profiles-handoff.md
@@ -33,11 +33,15 @@ Recommended order:
    reviewed. Keep the trigger token in the site-local service environment as
    `RESULT_SERVER_GITLAB_TRIGGER_TOKEN`; do not store it in SQLite, logs, or
    the OSS repository.
-6. Index received benchmark and estimation JSON metadata into SQLite while
+6. Add a site-local trigger runner timer. The runner should evaluate Portal
+   trigger definitions, keep `repo_ref` fingerprints in the Portal SQLite DB,
+   and pass the Portal-specific `RESULT_SERVER` URL to GitLab pipelines so
+   dev Portal triggers return results to the same dev Portal.
+7. Index received benchmark and estimation JSON metadata into SQLite while
    keeping JSON/tgz artifacts as raw records. The first index should be an
    auxiliary lookup table populated at ingest time; existing result and
    estimate pages can remain file-backed until the indexed views are reviewed.
-7. Add environment snapshot storage after deciding which host/runtime metadata
+8. Add environment snapshot storage after deciding which host/runtime metadata
    should define an environment identity.
 
 GitLab schedules should not be the primary governance point. The Portal should
@@ -81,6 +85,41 @@ Target IDs may contain letters, digits, `_`, `.`, and `-`. The token variable is
 `RESULT_SERVER_GITLAB_TRIGGER_TOKEN_<TARGET_ID>` with non-alphanumeric
 characters converted to `_` and uppercased. Store these variables in the Portal
 systemd `EnvironmentFile`, not in the repository.
+
+## Portal Trigger Runner
+
+Portal-managed scheduled and event triggers are evaluated by a site-local
+runner, not by GitLab schedules. Install it as a systemd user timer from the
+Portal checkout:
+
+```bash
+scripts/site/setup_trigger_runner.sh \
+  --site dev2 \
+  --repo-dir /home/nakamura/ChatGPT/benchkit \
+  --venv /home/nakamura/fugakunext/venv \
+  --db /home/nakamura/fugakunext/dev2/cx_portal.sqlite3 \
+  --env-file /home/nakamura/.config/fncx/dev2.env \
+  --result-server-url https://fncx.r-ccs.riken.jp/dev2 \
+  --submit
+```
+
+For initial bring-up, omit `--submit` or pass `--dry-run`. In dry-run mode the
+runner still records run audit rows and, by default, records repo/ref
+fingerprints when `--record-observations` is active through the setup script.
+The first observation of a `repo_ref` watch initializes the baseline and does
+not submit a pipeline; later fingerprint changes can submit.
+
+The runner uses a short-lived SQLite lock by default so overlapping timer
+invocations do not evaluate or submit the same triggers twice. Tune the lock
+TTL with `--lock-ttl-seconds` when the timer interval is changed.
+
+The generated service reads GitLab trigger configuration from the
+`EnvironmentFile`. The token must remain site-local:
+
+```text
+RESULT_SERVER_GITLAB_TARGETS=swc=gitlab.swc.example.org/group/project
+RESULT_SERVER_GITLAB_TRIGGER_TOKEN_SWC=<site-local GitLab pipeline trigger token>
+```
 
 ## Compatibility Expectations
 

--- a/result_server/tests/test_execution_profiles.py
+++ b/result_server/tests/test_execution_profiles.py
@@ -9,6 +9,7 @@ import sqlite3
 import sys
 import tempfile
 import urllib.parse
+from datetime import UTC, datetime
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -32,6 +33,10 @@ from utils.gitlab_pipeline import (  # noqa: E402
     submit_pipeline_plan,
 )
 from routes.admin import _portal_result_server_url  # noqa: E402
+from trigger_runner import (  # noqa: E402
+    cron_matches,
+    run_triggers,
+)
 
 
 class _Store:
@@ -240,6 +245,295 @@ def test_execution_profile_store_creates_watch_event_trigger_definition(tmp_path
         "https://github.com/RIKEN-LQCD/qws.git@develop",
     ]
     assert triggers[0]["match_mode"] == "any"
+
+
+def test_execution_profile_store_records_trigger_observations_and_runs(tmp_path):
+    db_path = tmp_path / "cx_portal.sqlite3"
+    store = ExecutionProfileStore(str(db_path))
+    store.upsert_profile(_profile(), actor="admin@test.com")
+    trigger, errors = normalize_trigger_definition(
+        {
+            "id": "rikyu-qws-watch",
+            "trigger_type": "watch_event",
+            "profile_id": "rikyu-qws-nightly",
+            "enabled": True,
+            "watch_kind": "repo_ref",
+            "watch_targets": "https://github.com/RIKEN-LQCD/qws.git@master",
+            "match_mode": "any",
+        }
+    )
+    assert errors == []
+    assert trigger is not None
+    store.upsert_trigger_definition(trigger, actor="admin@test.com")
+
+    store.upsert_trigger_observation(
+        "rikyu-qws-watch",
+        "https://github.com/RIKEN-LQCD/qws.git@master",
+        "abc123",
+        observed_at="2026-08-06T00:00:00Z",
+    )
+    run_id = store.create_trigger_run(
+        trigger_id="rikyu-qws-watch",
+        trigger_type="watch_event",
+        status="would_submit",
+        dry_run=True,
+        reason="repo_ref:https://github.com/RIKEN-LQCD/qws.git@master",
+        payload={"payload": {"variables": {"BK_TRIGGER_ID": "rikyu-qws-watch"}}},
+        errors=[],
+        actor="trigger_runner",
+    )
+
+    observations = store.list_trigger_observations("rikyu-qws-watch")
+    runs = store.list_trigger_runs("rikyu-qws-watch")
+    assert observations == [
+        {
+            "trigger_id": "rikyu-qws-watch",
+            "target": "https://github.com/RIKEN-LQCD/qws.git@master",
+            "fingerprint": "abc123",
+            "observed_at": "2026-08-06T00:00:00Z",
+        }
+    ]
+    assert runs[0]["id"] == run_id
+    assert runs[0]["status"] == "would_submit"
+    assert runs[0]["payload_json"]["payload"]["variables"]["BK_TRIGGER_ID"] == "rikyu-qws-watch"
+
+
+def test_execution_profile_store_acquires_and_releases_trigger_runner_lock(tmp_path):
+    db_path = tmp_path / "cx_portal.sqlite3"
+    store = ExecutionProfileStore(str(db_path))
+
+    assert store.acquire_trigger_runner_lock(
+        "default",
+        owner="runner-a",
+        ttl_seconds=60,
+        now="2026-08-06T00:00:00Z",
+    )
+    assert not store.acquire_trigger_runner_lock(
+        "default",
+        owner="runner-b",
+        ttl_seconds=60,
+        now="2026-08-06T00:00:30Z",
+    )
+    assert store.acquire_trigger_runner_lock(
+        "default",
+        owner="runner-b",
+        ttl_seconds=60,
+        now="2026-08-06T00:01:01Z",
+    )
+    assert not store.release_trigger_runner_lock(
+        "default",
+        owner="runner-a",
+        now="2026-08-06T00:01:02Z",
+    )
+    assert store.release_trigger_runner_lock(
+        "default",
+        owner="runner-b",
+        now="2026-08-06T00:01:02Z",
+    )
+    assert store.acquire_trigger_runner_lock(
+        "default",
+        owner="runner-a",
+        ttl_seconds=60,
+        now="2026-08-06T00:01:02Z",
+    )
+
+
+def test_trigger_runner_cron_matches_basic_fields():
+    now = datetime(2026, 8, 10, 1, 30, tzinfo=UTC)
+
+    assert cron_matches("30 1 * * 1", now) == (True, [])
+    assert cron_matches("*/15 * * * *", now) == (True, [])
+    assert cron_matches("0 2 * * *", now) == (False, [])
+    assert cron_matches("0 2 *", now) == (False, ["cron expression must have 5 fields"])
+
+
+def test_trigger_runner_dry_run_detects_repo_ref_change_and_records_run(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("RESULT_SERVER_GITLAB_REPO", "gitlab.example.org/group/benchkit.git")
+    db_path = tmp_path / "cx_portal.sqlite3"
+    store = ExecutionProfileStore(str(db_path))
+    store.upsert_profile(_profile(system=["Fugaku"]), actor="admin@test.com")
+    trigger, errors = normalize_trigger_definition(
+        {
+            "id": "rikyu-qws-watch",
+            "trigger_type": "watch_event",
+            "profile_id": "rikyu-qws-nightly",
+            "enabled": True,
+            "watch_kind": "repo_ref",
+            "watch_targets": (
+                "https://github.com/RIKEN-LQCD/qws.git@master\n"
+                "https://github.com/RIKEN-LQCD/qws.git@develop"
+            ),
+            "match_mode": "any",
+        }
+    )
+    assert errors == []
+    assert trigger is not None
+    store.upsert_trigger_definition(trigger, actor="admin@test.com")
+
+    fingerprint_suffix = "initial"
+
+    def fake_ls_remote(repo, ref):
+        return f"{repo}:{ref}:{fingerprint_suffix}"
+
+    evaluations = run_triggers(
+        db_path=str(db_path),
+        dry_run=True,
+        result_server_url="https://fncx.r-ccs.riken.jp/dev2",
+        record_observations=True,
+        ls_remote=fake_ls_remote,
+    )
+
+    assert len(evaluations) == 1
+    evaluation = evaluations[0]
+    assert evaluation.should_fire is False
+    assert evaluation.status == "would_initialize"
+    assert all(item["initialized"] is True for item in evaluation.observations)
+    assert all(item["changed"] is False for item in evaluation.observations)
+    variables = evaluation.payload["payload"]["variables"]
+    assert variables["code"] == "qws"
+    assert variables["system"] == "Fugaku"
+    assert variables["RESULT_SERVER"] == "https://fncx.r-ccs.riken.jp/dev2"
+    assert variables["BK_TRIGGER_ID"] == "rikyu-qws-watch"
+    assert variables["BK_TRIGGER_TYPE"] == "watch_event"
+    assert variables["BK_TRIGGER_REASON"].startswith("repo_ref:")
+
+    stored = ExecutionProfileStore(str(db_path))
+    observations = stored.list_trigger_observations("rikyu-qws-watch")
+    runs = stored.list_trigger_runs("rikyu-qws-watch")
+    assert len(observations) == 2
+    assert runs[0]["status"] == "would_initialize"
+
+    second = run_triggers(
+        db_path=str(db_path),
+        dry_run=True,
+        result_server_url="https://fncx.r-ccs.riken.jp/dev2",
+        record_observations=True,
+        ls_remote=fake_ls_remote,
+    )
+    assert second[0].should_fire is False
+    assert second[0].status == "unchanged"
+
+    fingerprint_suffix = "changed"
+    third = run_triggers(
+        db_path=str(db_path),
+        dry_run=True,
+        result_server_url="https://fncx.r-ccs.riken.jp/dev2",
+        record_observations=True,
+        ls_remote=fake_ls_remote,
+    )
+    assert third[0].should_fire is True
+    assert third[0].status == "would_submit"
+
+
+def test_trigger_runner_submit_records_submitted_run(tmp_path, monkeypatch):
+    monkeypatch.setenv("RESULT_SERVER_GITLAB_REPO", "gitlab.example.org/group/benchkit.git")
+    monkeypatch.setenv("RESULT_SERVER_GITLAB_TRIGGER_TOKEN", "trigger-token")
+    db_path = tmp_path / "cx_portal.sqlite3"
+    store = ExecutionProfileStore(str(db_path))
+    store.upsert_profile(_profile(system=["Fugaku"]), actor="admin@test.com")
+    trigger, errors = normalize_trigger_definition(
+        {
+            "id": "rikyu-qws-watch",
+            "trigger_type": "watch_event",
+            "profile_id": "rikyu-qws-nightly",
+            "enabled": True,
+            "watch_kind": "repo_ref",
+            "watch_targets": "https://github.com/RIKEN-LQCD/qws.git@master",
+            "match_mode": "any",
+        }
+    )
+    assert errors == []
+    assert trigger is not None
+    store.upsert_trigger_definition(trigger, actor="admin@test.com")
+    store.upsert_trigger_observation(
+        "rikyu-qws-watch",
+        "https://github.com/RIKEN-LQCD/qws.git@master",
+        "old-fingerprint",
+    )
+    submitted = []
+
+    def fake_ls_remote(repo, ref):
+        return f"{repo}:{ref}:new-fingerprint"
+
+    def fake_submit(plan, *, token):
+        submitted.append((plan, token))
+        return GitLabPipelineSubmitResult(
+            status_code=201,
+            response={"id": 123},
+            errors=[],
+        )
+
+    evaluations = run_triggers(
+        db_path=str(db_path),
+        dry_run=False,
+        result_server_url="https://fncx.r-ccs.riken.jp/dev2",
+        record_observations=True,
+        submit=True,
+        ls_remote=fake_ls_remote,
+        submit_pipeline=fake_submit,
+    )
+
+    assert len(submitted) == 1
+    plan, token = submitted[0]
+    assert token == "trigger-token"
+    assert plan.api_url == "https://gitlab.example.org/api/v4/projects/group%2Fbenchkit/trigger/pipeline"
+    assert plan.payload["ref"] == "develop"
+    assert plan.payload["variables"]["RESULT_SERVER"] == "https://fncx.r-ccs.riken.jp/dev2"
+    assert evaluations[0].status == "submitted"
+    assert evaluations[0].errors == []
+
+    stored = ExecutionProfileStore(str(db_path))
+    runs = stored.list_trigger_runs("rikyu-qws-watch")
+    assert runs[0]["status"] == "submitted"
+    assert runs[0]["dry_run"] is False
+    assert runs[0]["errors"] == []
+
+
+def test_trigger_runner_skips_when_lock_is_held(tmp_path, monkeypatch):
+    monkeypatch.setenv("RESULT_SERVER_GITLAB_REPO", "gitlab.example.org/group/benchkit.git")
+    db_path = tmp_path / "cx_portal.sqlite3"
+    store = ExecutionProfileStore(str(db_path))
+    store.upsert_profile(_profile(system=["Fugaku"]), actor="admin@test.com")
+    trigger, errors = normalize_trigger_definition(
+        {
+            "id": "rikyu-qws-watch",
+            "trigger_type": "watch_event",
+            "profile_id": "rikyu-qws-nightly",
+            "enabled": True,
+            "watch_kind": "repo_ref",
+            "watch_targets": "https://github.com/RIKEN-LQCD/qws.git@master",
+            "match_mode": "any",
+        }
+    )
+    assert errors == []
+    assert trigger is not None
+    store.upsert_trigger_definition(trigger, actor="admin@test.com")
+    assert store.acquire_trigger_runner_lock(
+        "default",
+        owner="other-runner",
+        ttl_seconds=300,
+        now="2026-08-06T00:00:00Z",
+    )
+
+    def fail_ls_remote(repo, ref):
+        raise AssertionError("locked runner must not observe watch targets")
+
+    evaluations = run_triggers(
+        db_path=str(db_path),
+        dry_run=True,
+        result_server_url="https://fncx.r-ccs.riken.jp/dev2",
+        now=datetime(2026, 8, 6, 0, 1, tzinfo=UTC),
+        ls_remote=fail_ls_remote,
+    )
+
+    assert len(evaluations) == 1
+    assert evaluations[0].trigger_id == "__runner__"
+    assert evaluations[0].status == "runner_locked"
+    runs = ExecutionProfileStore(str(db_path)).list_trigger_runs("__runner__")
+    assert runs[0]["status"] == "runner_locked"
 
 
 def test_execution_profile_store_resolves_approved_matching_profile(tmp_path):

--- a/result_server/tests/test_trigger_runner_setup_script.py
+++ b/result_server/tests/test_trigger_runner_setup_script.py
@@ -1,0 +1,84 @@
+"""Tests for the Portal trigger runner systemd setup helper."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+
+def test_setup_trigger_runner_writes_user_units(tmp_path):
+    repo_dir = Path(__file__).resolve().parents[2]
+    home = tmp_path / "home"
+    fake_bin = tmp_path / "bin"
+    venv = tmp_path / "venv"
+    db_path = tmp_path / "cx_portal.sqlite3"
+    env_file = home / ".config" / "fncx" / "dev2.env"
+    systemctl_log = tmp_path / "systemctl.log"
+    script = repo_dir / "scripts" / "site" / "setup_trigger_runner.sh"
+
+    fake_bin.mkdir(parents=True)
+    venv.joinpath("bin").mkdir(parents=True)
+    env_file.parent.mkdir(parents=True)
+    home.mkdir(exist_ok=True)
+    db_path.write_text("", encoding="utf-8")
+    env_file.write_text("RESULT_SERVER_GITLAB_TARGETS=swc=example/group\n", encoding="utf-8")
+    venv.joinpath("bin", "python").write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    fake_bin.joinpath("systemctl").write_text(
+        "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"$SYSTEMCTL_LOG\"\n",
+        encoding="utf-8",
+    )
+    for executable in (venv / "bin" / "python", fake_bin / "systemctl"):
+        executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
+
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["SYSTEMCTL_LOG"] = str(systemctl_log)
+    subprocess.run(
+        [
+            str(script),
+            "--site",
+            "dev2",
+            "--repo-dir",
+            str(repo_dir),
+            "--venv",
+            str(venv),
+            "--db",
+            str(db_path),
+            "--env-file",
+            str(env_file),
+            "--result-server-url",
+            "https://fncx.r-ccs.riken.jp/dev2",
+            "--on-calendar",
+            "*:0/5",
+            "--lock-ttl-seconds",
+            "120",
+            "--submit",
+        ],
+        check=True,
+        cwd=repo_dir,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    service = home / ".config" / "systemd" / "user" / "benchkit-trigger-runner-dev2.service"
+    timer = home / ".config" / "systemd" / "user" / "benchkit-trigger-runner-dev2.timer"
+    service_text = service.read_text(encoding="utf-8")
+    timer_text = timer.read_text(encoding="utf-8")
+    log_text = systemctl_log.read_text(encoding="utf-8")
+
+    assert f"WorkingDirectory={repo_dir}" in service_text
+    assert f"EnvironmentFile={env_file}" in service_text
+    assert "-m result_server.trigger_runner" in service_text
+    assert "--submit" in service_text
+    assert "--record-observations" in service_text
+    assert "--lock-ttl-seconds 120" in service_text
+    assert "https://fncx.r-ccs.riken.jp/dev2" in service_text
+    assert "OnCalendar=*:0/5" in timer_text
+    assert "Unit=benchkit-trigger-runner-dev2.service" in timer_text
+    assert "daemon-reload" in log_text
+    assert "enable benchkit-trigger-runner-dev2.timer" in log_text
+    assert "restart benchkit-trigger-runner-dev2.timer" in log_text

--- a/result_server/trigger_runner.py
+++ b/result_server/trigger_runner.py
@@ -1,0 +1,480 @@
+"""Site-local trigger runner for CX Portal execution profiles."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import subprocess
+import sys
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+try:
+    from utils.execution_profiles import ExecutionProfileStore
+    from utils.gitlab_pipeline import (
+        build_pipeline_plan,
+        configured_gitlab_target,
+        configured_gitlab_trigger_token,
+        submit_pipeline_plan,
+    )
+except ModuleNotFoundError:  # pragma: no cover - supports python -m result_server.trigger_runner
+    from result_server.utils.execution_profiles import ExecutionProfileStore
+    from result_server.utils.gitlab_pipeline import (
+        build_pipeline_plan,
+        configured_gitlab_target,
+        configured_gitlab_trigger_token,
+        submit_pipeline_plan,
+    )
+
+
+@dataclass(frozen=True)
+class TriggerEvaluation:
+    """Dry-run or submit evaluation result for one trigger definition."""
+
+    trigger_id: str
+    trigger_type: str
+    should_fire: bool
+    reason: str
+    status: str
+    payload: dict
+    errors: list[str]
+    observations: list[dict]
+
+
+def _now_utc() -> datetime:
+    return datetime.now(UTC).replace(second=0, microsecond=0)
+
+
+def _parse_repo_ref_target(target: str) -> tuple[str, str] | None:
+    repo, sep, ref = target.strip().rpartition("@")
+    if not sep or not repo.strip() or not ref.strip():
+        return None
+    return repo.strip(), ref.strip()
+
+
+def _git_ls_remote(repo: str, ref: str, *, timeout: float = 20.0) -> str:
+    completed = subprocess.run(
+        ["git", "ls-remote", repo, ref],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    first_line = completed.stdout.strip().splitlines()[0] if completed.stdout.strip() else ""
+    return first_line.split()[0] if first_line.split() else ""
+
+
+def _cron_field_matches(field: str, value: int, minimum: int, maximum: int) -> bool:
+    for part in field.split(","):
+        item = part.strip()
+        if not item:
+            continue
+        step = 1
+        base = item
+        if "/" in item:
+            base, step_text = item.split("/", 1)
+            try:
+                step = int(step_text)
+            except ValueError:
+                return False
+            if step <= 0:
+                return False
+        if base == "*":
+            start, end = minimum, maximum
+        elif "-" in base:
+            start_text, end_text = base.split("-", 1)
+            try:
+                start, end = int(start_text), int(end_text)
+            except ValueError:
+                return False
+        else:
+            try:
+                start = end = int(base)
+            except ValueError:
+                return False
+        if start < minimum or end > maximum or start > end:
+            return False
+        if start <= value <= end and (value - start) % step == 0:
+            return True
+    return False
+
+
+def cron_matches(cron_expr: str, now: datetime) -> tuple[bool, list[str]]:
+    """Return whether a 5-field cron expression matches the given aware datetime."""
+    fields = cron_expr.split()
+    if len(fields) != 5:
+        return False, ["cron expression must have 5 fields"]
+    minute, hour, day, month, weekday = fields
+    checks = [
+        (minute, now.minute, 0, 59),
+        (hour, now.hour, 0, 23),
+        (day, now.day, 1, 31),
+        (month, now.month, 1, 12),
+        (weekday, (now.weekday() + 1) % 7, 0, 6),
+    ]
+    return all(
+        _cron_field_matches(field, value, minimum, maximum)
+        for field, value, minimum, maximum in checks
+    ), []
+
+
+def _trigger_now(trigger: dict, now: datetime) -> tuple[datetime, list[str]]:
+    timezone_name = trigger.get("timezone") or "Asia/Tokyo"
+    try:
+        return now.astimezone(ZoneInfo(timezone_name)), []
+    except ZoneInfoNotFoundError:
+        return now, [f"unknown timezone: {timezone_name}"]
+
+
+def _profile_scope_csv(profile: dict | None, key: str) -> str:
+    if not profile:
+        return ""
+    return ",".join(str(value).strip() for value in profile.get(key, []) if str(value).strip())
+
+
+def _build_trigger_plan(
+    store: ExecutionProfileStore,
+    trigger: dict,
+    *,
+    result_server_url: str,
+    trigger_reason: str,
+) -> tuple[dict, list[str]]:
+    profile_result = store.resolve_profile(profile_id=trigger.get("profile_id", ""))
+    profile = profile_result.profile
+    gitlab_target, target_errors = configured_gitlab_target(trigger.get("gitlab_target", ""))
+    target_ref = trigger.get("target_ref") or os.environ.get("RESULT_SERVER_GITLAB_REF", "develop")
+    code = _profile_scope_csv(profile, "code")
+    system = _profile_scope_csv(profile, "system")
+    plan = build_pipeline_plan(
+        gitlab_repo=gitlab_target.repo if gitlab_target else "",
+        target_ref=target_ref,
+        code=code,
+        system=system,
+        allocation_project_id=profile_result.allocation_project_id,
+        scheduler_extra_args="",
+        result_server_url=result_server_url,
+        target_id=gitlab_target.id if gitlab_target else trigger.get("gitlab_target", ""),
+    )
+    variables = dict(plan.payload.get("variables", {}))
+    variables["BK_TRIGGER_ID"] = trigger.get("id", "")
+    variables["BK_TRIGGER_TYPE"] = trigger.get("trigger_type", "")
+    variables["BK_TRIGGER_REASON"] = trigger_reason
+    plan_payload = {"ref": plan.payload.get("ref", target_ref), "variables": variables}
+    payload = {
+        "api_url": plan.api_url,
+        "gitlab_target": gitlab_target.id if gitlab_target else trigger.get("gitlab_target", ""),
+        "gitlab_project": gitlab_target.repo if gitlab_target else "",
+        "payload": plan_payload,
+    }
+    errors = list(profile_result.errors) + target_errors + plan.errors
+    if profile and not profile_result.allocation_project_id:
+        errors.append("profile allocation_project_id is required")
+    return payload, errors
+
+
+def evaluate_scheduled_trigger(
+    store: ExecutionProfileStore,
+    trigger: dict,
+    *,
+    now: datetime,
+    result_server_url: str,
+) -> TriggerEvaluation:
+    local_now, timezone_errors = _trigger_now(trigger, now)
+    matches, cron_errors = cron_matches(trigger.get("cron_expr", ""), local_now)
+    reason = f"cron:{trigger.get('cron_expr', '')}"
+    payload, plan_errors = _build_trigger_plan(
+        store,
+        trigger,
+        result_server_url=result_server_url,
+        trigger_reason=reason,
+    )
+    errors = timezone_errors + cron_errors + plan_errors
+    should_fire = matches and not errors
+    status = "would_submit" if should_fire else "not_due"
+    if errors:
+        status = "blocked"
+    return TriggerEvaluation(
+        trigger_id=trigger["id"],
+        trigger_type=trigger["trigger_type"],
+        should_fire=should_fire,
+        reason=reason,
+        status=status,
+        payload=payload,
+        errors=errors,
+        observations=[],
+    )
+
+
+def evaluate_repo_ref_trigger(
+    store: ExecutionProfileStore,
+    trigger: dict,
+    *,
+    now: datetime,
+    result_server_url: str,
+    ls_remote=_git_ls_remote,
+) -> TriggerEvaluation:
+    observations = []
+    errors: list[str] = []
+    changed_targets = []
+    initialized_targets = []
+    for target in trigger.get("watch_targets", []):
+        parsed = _parse_repo_ref_target(target)
+        if parsed is None:
+            errors.append(f"invalid repo_ref target: {target}")
+            continue
+        repo, ref = parsed
+        try:
+            fingerprint = ls_remote(repo, ref)
+        except (subprocess.SubprocessError, OSError) as exc:
+            errors.append(f"failed to observe {target}: {exc}")
+            continue
+        if not fingerprint:
+            errors.append(f"empty fingerprint for {target}")
+            continue
+        previous = store.get_trigger_observation(trigger["id"], target)
+        initialized = previous is None
+        changed = not initialized and previous.get("fingerprint") != fingerprint
+        if initialized:
+            initialized_targets.append(target)
+        if changed:
+            changed_targets.append(target)
+        observations.append(
+            {
+                "target": target,
+                "fingerprint": fingerprint,
+                "previous_fingerprint": previous.get("fingerprint") if previous else "",
+                "initialized": initialized,
+                "changed": changed,
+            }
+        )
+
+    match_mode = trigger.get("match_mode") or "any"
+    if match_mode == "all":
+        should_fire = bool(observations) and all(item["changed"] for item in observations)
+    else:
+        should_fire = any(item["changed"] for item in observations)
+    reason_targets = changed_targets or initialized_targets
+    reason = "repo_ref:" + ",".join(reason_targets)
+    payload, plan_errors = _build_trigger_plan(
+        store,
+        trigger,
+        result_server_url=result_server_url,
+        trigger_reason=reason,
+    )
+    errors.extend(plan_errors)
+    status = "would_submit" if should_fire and not errors else "unchanged"
+    if initialized_targets and not should_fire and not errors:
+        status = "would_initialize"
+    if errors:
+        status = "blocked"
+    return TriggerEvaluation(
+        trigger_id=trigger["id"],
+        trigger_type=trigger["trigger_type"],
+        should_fire=should_fire and not errors,
+        reason=reason,
+        status=status,
+        payload=payload,
+        errors=errors,
+        observations=observations,
+    )
+
+
+def evaluate_trigger(
+    store: ExecutionProfileStore,
+    trigger: dict,
+    *,
+    now: datetime,
+    result_server_url: str,
+    ls_remote=_git_ls_remote,
+) -> TriggerEvaluation:
+    if trigger.get("trigger_type") == "scheduled":
+        return evaluate_scheduled_trigger(
+            store,
+            trigger,
+            now=now,
+            result_server_url=result_server_url,
+        )
+    if trigger.get("trigger_type") == "watch_event" and trigger.get("watch_kind") == "repo_ref":
+        return evaluate_repo_ref_trigger(
+            store,
+            trigger,
+            now=now,
+            result_server_url=result_server_url,
+            ls_remote=ls_remote,
+        )
+    return TriggerEvaluation(
+        trigger_id=trigger.get("id", ""),
+        trigger_type=trigger.get("trigger_type", ""),
+        should_fire=False,
+        reason="unsupported",
+        status="blocked",
+        payload={},
+        errors=[f"unsupported trigger: {trigger.get('trigger_type')}/{trigger.get('watch_kind')}"],
+        observations=[],
+    )
+
+
+def run_triggers(
+    *,
+    db_path: str,
+    dry_run: bool = True,
+    result_server_url: str = "",
+    now: datetime | None = None,
+    record_observations: bool = False,
+    submit: bool = False,
+    ls_remote=_git_ls_remote,
+    submit_pipeline=submit_pipeline_plan,
+    use_lock: bool = True,
+    lock_name: str = "default",
+    lock_ttl_seconds: int = 300,
+) -> list[TriggerEvaluation]:
+    store = ExecutionProfileStore(db_path)
+    current_time = now or _now_utc()
+    result_url = result_server_url or os.environ.get("RESULT_SERVER_PUBLIC_URL", "").rstrip("/")
+    owner = f"{socket.gethostname()}:{os.getpid()}"
+    if use_lock:
+        locked = store.acquire_trigger_runner_lock(
+            lock_name,
+            owner=owner,
+            ttl_seconds=lock_ttl_seconds,
+            now=current_time.isoformat().replace("+00:00", "Z"),
+        )
+        if not locked:
+            evaluation = TriggerEvaluation(
+                trigger_id="__runner__",
+                trigger_type="runner",
+                should_fire=False,
+                reason=f"lock:{lock_name}",
+                status="runner_locked",
+                payload={"lock_name": lock_name},
+                errors=[],
+                observations=[],
+            )
+            store.create_trigger_run(
+                trigger_id=evaluation.trigger_id,
+                trigger_type=evaluation.trigger_type,
+                status=evaluation.status,
+                dry_run=dry_run,
+                reason=evaluation.reason,
+                payload=evaluation.payload,
+                errors=[],
+                actor="trigger_runner",
+            )
+            return [evaluation]
+    evaluations = []
+    try:
+        for trigger in store.list_trigger_definitions():
+            if not trigger.get("enabled", True):
+                continue
+            evaluation = evaluate_trigger(
+                store,
+                trigger,
+                now=current_time,
+                result_server_url=result_url,
+                ls_remote=ls_remote,
+            )
+            if record_observations:
+                observed_at = current_time.isoformat().replace("+00:00", "Z")
+                for item in evaluation.observations:
+                    store.upsert_trigger_observation(
+                        evaluation.trigger_id,
+                        item["target"],
+                        item["fingerprint"],
+                        observed_at=observed_at,
+                    )
+            status = evaluation.status
+            errors = list(evaluation.errors)
+            if submit and evaluation.should_fire:
+                plan_payload = evaluation.payload.get("payload", {})
+                plan = SimpleNamespace(
+                    api_url=evaluation.payload.get("api_url", ""),
+                    payload=plan_payload,
+                    errors=[],
+                    target_id=evaluation.payload.get("gitlab_target", ""),
+                )
+                gitlab_target, _target_errors = configured_gitlab_target(
+                    evaluation.payload.get("gitlab_target", "")
+                )
+                result = submit_pipeline(
+                    plan,
+                    token=configured_gitlab_trigger_token(gitlab_target),
+                )
+                errors.extend(result.errors)
+                status = "submitted" if result.ok else "submit_failed"
+            reported = replace(evaluation, status=status, errors=errors)
+            evaluations.append(reported)
+            store.create_trigger_run(
+                trigger_id=evaluation.trigger_id,
+                trigger_type=evaluation.trigger_type,
+                status=status,
+                dry_run=dry_run,
+                reason=evaluation.reason,
+                payload=evaluation.payload,
+                errors=errors,
+                actor="trigger_runner",
+            )
+    finally:
+        if use_lock:
+            store.release_trigger_runner_lock(
+                lock_name,
+                owner=owner,
+                now=current_time.isoformat().replace("+00:00", "Z"),
+            )
+    return evaluations
+
+
+def _evaluation_to_dict(evaluation: TriggerEvaluation) -> dict:
+    return {
+        "trigger_id": evaluation.trigger_id,
+        "trigger_type": evaluation.trigger_type,
+        "should_fire": evaluation.should_fire,
+        "reason": evaluation.reason,
+        "status": evaluation.status,
+        "payload": evaluation.payload,
+        "errors": evaluation.errors,
+        "observations": evaluation.observations,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run CX Portal trigger definitions.")
+    parser.add_argument("--db", required=True, help="Path to cx_portal.sqlite3")
+    parser.add_argument("--dry-run", action="store_true", help="Evaluate without submitting GitLab pipelines")
+    parser.add_argument("--submit", action="store_true", help="Submit due/changed triggers")
+    parser.add_argument(
+        "--record-observations",
+        action="store_true",
+        help="Persist observed repo_ref fingerprints",
+    )
+    parser.add_argument("--no-lock", action="store_true", help="Do not use the SQLite runner lock")
+    parser.add_argument(
+        "--lock-ttl-seconds",
+        type=int,
+        default=300,
+        help="SQLite runner lock TTL. Default: 300.",
+    )
+    parser.add_argument("--result-server-url", default="", help="RESULT_SERVER URL for submitted pipelines")
+    args = parser.parse_args(argv)
+
+    if args.submit and args.dry_run:
+        parser.error("--submit and --dry-run are mutually exclusive")
+
+    evaluations = run_triggers(
+        db_path=args.db,
+        dry_run=not args.submit,
+        result_server_url=args.result_server_url,
+        record_observations=args.record_observations,
+        submit=args.submit,
+        use_lock=not args.no_lock,
+        lock_ttl_seconds=args.lock_ttl_seconds,
+    )
+    print(json.dumps([_evaluation_to_dict(item) for item in evaluations], indent=2, sort_keys=True))
+    return 1 if any(item.errors for item in evaluations) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/result_server/utils/execution_profiles.py
+++ b/result_server/utils/execution_profiles.py
@@ -8,14 +8,14 @@ import re
 import sqlite3
 from collections.abc import Iterable
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 
 PROFILE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
 TRIGGER_TYPES = {"manual_button", "scheduled", "watch_event"}
 MATCH_MODES = {"any", "all"}
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6
 
 
 @dataclass(frozen=True)
@@ -301,6 +301,9 @@ class ExecutionProfileStore:
                 current = 4
             if current < 5:
                 self._apply_v5(conn)
+                current = 5
+            if current < 6:
+                self._apply_v6(conn)
 
     def _apply_v1(self, conn: sqlite3.Connection) -> None:
         now = _utc_now_iso()
@@ -464,6 +467,48 @@ class ExecutionProfileStore:
         conn.execute(
             "INSERT INTO schema_migrations(version, applied_at) VALUES (?, ?)",
             (5, now),
+        )
+
+    def _apply_v6(self, conn: sqlite3.Connection) -> None:
+        now = _utc_now_iso()
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS trigger_runner_lock (
+                name TEXT PRIMARY KEY,
+                owner TEXT NOT NULL DEFAULT '',
+                locked_until TEXT NOT NULL DEFAULT '',
+                updated_at TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS trigger_observations (
+                trigger_id TEXT NOT NULL REFERENCES trigger_definitions(id) ON DELETE CASCADE,
+                target TEXT NOT NULL,
+                fingerprint TEXT NOT NULL DEFAULT '',
+                observed_at TEXT NOT NULL,
+                PRIMARY KEY (trigger_id, target)
+            );
+
+            CREATE TABLE IF NOT EXISTS trigger_runs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                trigger_id TEXT NOT NULL,
+                trigger_type TEXT NOT NULL DEFAULT '',
+                status TEXT NOT NULL,
+                dry_run INTEGER NOT NULL DEFAULT 1,
+                reason TEXT NOT NULL DEFAULT '',
+                payload_json TEXT NOT NULL DEFAULT '{}',
+                errors_json TEXT NOT NULL DEFAULT '[]',
+                actor TEXT NOT NULL DEFAULT '',
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_trigger_runs_trigger
+                ON trigger_runs(trigger_id, created_at);
+            """
+        )
+        conn.execute(
+            "INSERT INTO schema_migrations(version, applied_at) VALUES (?, ?)",
+            (6, now),
         )
 
     def upsert_profile(self, profile: dict[str, Any], *, actor: str = "") -> None:
@@ -780,6 +825,220 @@ class ExecutionProfileStore:
                 }
             )
         return triggers
+
+    def acquire_trigger_runner_lock(
+        self,
+        name: str,
+        *,
+        owner: str,
+        ttl_seconds: int = 300,
+        now: str | None = None,
+    ) -> bool:
+        self.migrate()
+        current = now or _utc_now_iso()
+        locked_until = (
+            datetime.fromisoformat(current.replace("Z", "+00:00"))
+            + timedelta(seconds=ttl_seconds)
+        ).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+        with self.connect() as conn:
+            row = conn.execute(
+                """
+                SELECT owner, locked_until
+                FROM trigger_runner_lock
+                WHERE name = ?
+                """,
+                (name,),
+            ).fetchone()
+            if row and row["locked_until"] > current:
+                return False
+            conn.execute(
+                """
+                INSERT INTO trigger_runner_lock(name, owner, locked_until, updated_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(name) DO UPDATE SET
+                    owner=excluded.owner,
+                    locked_until=excluded.locked_until,
+                    updated_at=excluded.updated_at
+                """,
+                (name, owner, locked_until, current),
+            )
+        return True
+
+    def release_trigger_runner_lock(
+        self,
+        name: str,
+        *,
+        owner: str,
+        now: str | None = None,
+    ) -> bool:
+        self.migrate()
+        current = now or _utc_now_iso()
+        with self.connect() as conn:
+            cur = conn.execute(
+                """
+                UPDATE trigger_runner_lock
+                SET locked_until = ?, updated_at = ?
+                WHERE name = ? AND owner = ?
+                """,
+                (current, current, name, owner),
+            )
+        return cur.rowcount > 0
+
+    def list_trigger_observations(
+        self,
+        trigger_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        self.migrate()
+        query = """
+            SELECT trigger_id, target, fingerprint, observed_at
+            FROM trigger_observations
+        """
+        params: tuple[Any, ...] = ()
+        if trigger_id:
+            query += " WHERE trigger_id = ?"
+            params = (trigger_id,)
+        query += " ORDER BY trigger_id COLLATE NOCASE, target COLLATE NOCASE"
+        with self.connect() as conn:
+            rows = conn.execute(query, params).fetchall()
+        return [
+            {
+                "trigger_id": row["trigger_id"],
+                "target": row["target"],
+                "fingerprint": row["fingerprint"],
+                "observed_at": row["observed_at"],
+            }
+            for row in rows
+        ]
+
+    def get_trigger_observation(
+        self,
+        trigger_id: str,
+        target: str,
+    ) -> dict[str, Any] | None:
+        self.migrate()
+        with self.connect() as conn:
+            row = conn.execute(
+                """
+                SELECT trigger_id, target, fingerprint, observed_at
+                FROM trigger_observations
+                WHERE trigger_id = ? AND target = ?
+                """,
+                (trigger_id, target),
+            ).fetchone()
+        if not row:
+            return None
+        return {
+            "trigger_id": row["trigger_id"],
+            "target": row["target"],
+            "fingerprint": row["fingerprint"],
+            "observed_at": row["observed_at"],
+        }
+
+    def upsert_trigger_observation(
+        self,
+        trigger_id: str,
+        target: str,
+        fingerprint: str,
+        *,
+        observed_at: str | None = None,
+    ) -> None:
+        self.migrate()
+        observed = observed_at or _utc_now_iso()
+        with self.connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO trigger_observations(
+                    trigger_id, target, fingerprint, observed_at
+                ) VALUES (?, ?, ?, ?)
+                ON CONFLICT(trigger_id, target) DO UPDATE SET
+                    fingerprint=excluded.fingerprint,
+                    observed_at=excluded.observed_at
+                """,
+                (trigger_id, target, fingerprint, observed),
+            )
+
+    def create_trigger_run(
+        self,
+        *,
+        trigger_id: str,
+        trigger_type: str,
+        status: str,
+        dry_run: bool,
+        reason: str = "",
+        payload: dict[str, Any] | None = None,
+        errors: list[str] | None = None,
+        actor: str = "",
+    ) -> int:
+        self.migrate()
+        now = _utc_now_iso()
+        with self.connect() as conn:
+            cur = conn.execute(
+                """
+                INSERT INTO trigger_runs (
+                    trigger_id, trigger_type, status, dry_run, reason,
+                    payload_json, errors_json, actor, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    trigger_id,
+                    trigger_type,
+                    status,
+                    1 if dry_run else 0,
+                    reason,
+                    _json_dump(payload or {}),
+                    json.dumps(errors or [], ensure_ascii=False),
+                    actor,
+                    now,
+                    now,
+                ),
+            )
+            return int(cur.lastrowid)
+
+    def list_trigger_runs(
+        self,
+        trigger_id: str | None = None,
+        *,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        self.migrate()
+        query = """
+            SELECT *
+            FROM trigger_runs
+        """
+        params: list[Any] = []
+        if trigger_id:
+            query += " WHERE trigger_id = ?"
+            params.append(trigger_id)
+        query += " ORDER BY id DESC LIMIT ?"
+        params.append(limit)
+        with self.connect() as conn:
+            rows = conn.execute(query, tuple(params)).fetchall()
+        runs = []
+        for row in rows:
+            try:
+                payload = json.loads(row["payload_json"] or "{}")
+            except json.JSONDecodeError:
+                payload = {"_invalid_payload_json": row["payload_json"]}
+            try:
+                errors = json.loads(row["errors_json"] or "[]")
+            except json.JSONDecodeError:
+                errors = [row["errors_json"]]
+            runs.append(
+                {
+                    "id": row["id"],
+                    "trigger_id": row["trigger_id"],
+                    "trigger_type": row["trigger_type"],
+                    "status": row["status"],
+                    "dry_run": bool(row["dry_run"]),
+                    "reason": row["reason"],
+                    "payload_json": payload,
+                    "errors": errors,
+                    "actor": row["actor"],
+                    "created_at": row["created_at"],
+                    "updated_at": row["updated_at"],
+                }
+            )
+        return runs
 
     def list_profiles(self) -> list[dict[str, Any]]:
         self.migrate()

--- a/scripts/site/setup_trigger_runner.sh
+++ b/scripts/site/setup_trigger_runner.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+site=""
+repo_dir=""
+venv_dir=""
+db_path=""
+env_file=""
+result_server_url=""
+on_calendar="minutely"
+service_host=""
+mode="dry-run"
+record_observations=1
+start_service=1
+use_lock=1
+lock_ttl_seconds=300
+
+usage() {
+  cat <<'EOF'
+Usage:
+  setup_trigger_runner.sh --site SITE --result-server-url URL [options]
+
+Options:
+  --site SITE              Site suffix used for the systemd unit name.
+  --repo-dir DIR           BenchKit checkout. Default: current directory.
+  --venv DIR               Python venv. Default: $HOME/fugakunext/venv.
+  --db PATH                cx_portal.sqlite3 path.
+                           Default: $HOME/fugakunext/$SITE/cx_portal.sqlite3.
+  --env-file PATH          systemd EnvironmentFile.
+                           Default: $HOME/.config/fncx/$SITE.env.
+  --result-server-url URL  RESULT_SERVER URL passed to triggered pipelines.
+  --on-calendar EXPR       systemd timer calendar. Default: minutely.
+  --service-host HOST      Add ConditionHost=HOST for shared home directories.
+  --submit                 Submit due/changed triggers.
+  --dry-run                Evaluate only. Default.
+  --no-record-observations Do not persist repo_ref fingerprints.
+  --no-lock                Do not use the SQLite runner lock.
+  --lock-ttl-seconds SEC   SQLite runner lock TTL. Default: 300.
+  --no-start               Write units but do not enable/start the timer.
+  -h, --help               Show this help.
+
+The generated user timer evaluates Portal trigger definitions with
+result_server.trigger_runner. Keep GitLab trigger tokens in the EnvironmentFile,
+not in this repository.
+EOF
+}
+
+info() {
+  echo "[setup-trigger-runner] $*"
+}
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --site) site="${2:-}"; shift 2 ;;
+    --repo-dir) repo_dir="${2:-}"; shift 2 ;;
+    --venv) venv_dir="${2:-}"; shift 2 ;;
+    --db) db_path="${2:-}"; shift 2 ;;
+    --env-file) env_file="${2:-}"; shift 2 ;;
+    --result-server-url) result_server_url="${2:-}"; shift 2 ;;
+    --on-calendar) on_calendar="${2:-}"; shift 2 ;;
+    --service-host) service_host="${2:-}"; shift 2 ;;
+    --submit) mode="submit"; shift ;;
+    --dry-run) mode="dry-run"; shift ;;
+    --no-record-observations) record_observations=0; shift ;;
+    --no-lock) use_lock=0; shift ;;
+    --lock-ttl-seconds) lock_ttl_seconds="${2:-}"; shift 2 ;;
+    --no-start) start_service=0; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "Unknown option: $1" ;;
+  esac
+done
+
+[[ -n "$site" ]] || die "--site is required"
+[[ -n "$result_server_url" ]] || die "--result-server-url is required"
+
+if [[ -z "$repo_dir" ]]; then
+  repo_dir="$PWD"
+fi
+if [[ -z "$venv_dir" ]]; then
+  venv_dir="$HOME/fugakunext/venv"
+fi
+if [[ -z "$db_path" ]]; then
+  db_path="$HOME/fugakunext/$site/cx_portal.sqlite3"
+fi
+if [[ -z "$env_file" ]]; then
+  env_file="$HOME/.config/fncx/$site.env"
+fi
+
+[[ -d "$repo_dir/.git" ]] || die "--repo-dir must point at a BenchKit checkout"
+[[ -x "$venv_dir/bin/python" ]] || die "Python not found: $venv_dir/bin/python"
+[[ -f "$db_path" ]] || die "DB not found: $db_path"
+[[ -f "$env_file" ]] || die "EnvironmentFile not found: $env_file"
+
+unit_dir="$HOME/.config/systemd/user"
+service_name="benchkit-trigger-runner-${site}.service"
+timer_name="benchkit-trigger-runner-${site}.timer"
+service_path="$unit_dir/$service_name"
+timer_path="$unit_dir/$timer_name"
+
+mkdir -p "$unit_dir"
+
+runner_args=(--db "$db_path" --result-server-url "$result_server_url")
+if [[ "$mode" == "submit" ]]; then
+  runner_args+=(--submit)
+else
+  runner_args+=(--dry-run)
+fi
+if [[ "$record_observations" -eq 1 ]]; then
+  runner_args+=(--record-observations)
+fi
+if [[ "$use_lock" -eq 0 ]]; then
+  runner_args+=(--no-lock)
+else
+  runner_args+=(--lock-ttl-seconds "$lock_ttl_seconds")
+fi
+
+info "Writing $service_path"
+{
+  printf '[Unit]\n'
+  printf 'Description=BenchKit Portal trigger runner (%s)\n' "$site"
+  printf 'After=network-online.target\n'
+  if [[ -n "$service_host" ]]; then
+    printf 'ConditionHost=%s\n' "$service_host"
+  fi
+  printf '\n[Service]\n'
+  printf 'Type=oneshot\n'
+  printf 'WorkingDirectory=%s\n' "$repo_dir"
+  printf 'EnvironmentFile=%s\n' "$env_file"
+  printf 'ExecStart=%s/bin/python -m result_server.trigger_runner' "$venv_dir"
+  printf ' %q' "${runner_args[@]}"
+  printf '\n'
+  printf 'StandardOutput=journal\n'
+  printf 'StandardError=journal\n'
+} > "$service_path"
+
+info "Writing $timer_path"
+{
+  printf '[Unit]\n'
+  printf 'Description=Run BenchKit Portal trigger runner (%s)\n' "$site"
+  printf '\n[Timer]\n'
+  printf 'OnCalendar=%s\n' "$on_calendar"
+  printf 'Persistent=true\n'
+  printf 'Unit=%s\n' "$service_name"
+  printf '\n[Install]\n'
+  printf 'WantedBy=timers.target\n'
+} > "$timer_path"
+
+systemctl --user daemon-reload
+
+if [[ "$start_service" -eq 1 ]]; then
+  systemctl --user enable "$timer_name"
+  systemctl --user restart "$timer_name"
+  info "Started $timer_name"
+  systemctl --user list-timers "$timer_name" --no-pager
+else
+  info "Wrote units without starting. Enable with: systemctl --user enable --now $timer_name"
+fi


### PR DESCRIPTION
## Summary
- add a site-local Portal trigger runner for scheduled and repo/ref triggers
- record trigger observations and run audit rows in the Portal SQLite DB
- add a setup helper for systemd user timers with dry-run/submit modes and SQLite locking

## Verification
- /home/nakamura/fugakunext/venv/bin/python -m pytest result_server/tests/test_execution_profiles.py result_server/tests/test_trigger_runner_setup_script.py result_server/tests/test_api_routes.py result_server/tests/test_app_dev_security.py result_server/tests/test_preflight.py
- dev2 dry-run timer initialized repo/ref baseline and recorded not_due/unchanged with errors=0
- dev2 submit timer records not_due/unchanged with errors=0 without launching pipelines while conditions are not due/changed