### PR TITLE
Deduplicate scheduled trigger due minutes

### DIFF
--- a/docs/guides/add-site.md
+++ b/docs/guides/add-site.md
@@ -626,9 +626,13 @@ scripts/site/setup_trigger_runner.sh \
 
 初回導入時は `--dry-run` のまま timer を作って動作を確認できます。`repo_ref`
 監視は初回観測では baseline を保存するだけで pipeline を投入せず、2回目以降
-の fingerprint 変化で発火します。runner は短命の SQLite lock を既定で使う
-ため、timer 実行が重なっても同じ trigger を二重評価しません。timer 間隔を
-変える場合は `--lock-ttl-seconds` で TTL を調整できます。
+の fingerprint 変化で発火します。scheduled trigger は cron の due minute
+単位で de-dup し、成功済みの同じ due minute は再 submit しません。また既定
+で5分 lookback するため、timer が少し遅れても直近の due minute を拾えます。
+timer 間隔を変える場合は `--schedule-lookback-minutes` を調整します。runner
+は短命の SQLite lock も既定で使うため、timer 実行が重なっても同じ trigger
+を二重評価しません。timer 間隔を変える場合は `--lock-ttl-seconds` で TTL も
+調整できます。
 
 Execution profile を実行要求へ適用する場合、Portal は `enabled=true` かつ
 `status=approved` の profile だけを候補にします。`code` / `system` / `exp`

--- a/docs/guides/portal-execution-profiles-handoff.md
+++ b/docs/guides/portal-execution-profiles-handoff.md
@@ -109,6 +109,13 @@ fingerprints when `--record-observations` is active through the setup script.
 The first observation of a `repo_ref` watch initializes the baseline and does
 not submit a pipeline; later fingerprint changes can submit.
 
+Scheduled triggers are de-duplicated by cron due minute. The runner records the
+due minute in the trigger run reason and does not submit the same due minute
+twice after a successful submission. It also looks back a short window, default
+5 minutes, so a slightly delayed timer tick can still catch a missed cron
+minute. Tune this with `--schedule-lookback-minutes` if the timer interval is
+changed.
+
 The runner uses a short-lived SQLite lock by default so overlapping timer
 invocations do not evaluate or submit the same triggers twice. Tune the lock
 TTL with `--lock-ttl-seconds` when the timer interval is changed.

--- a/result_server/tests/test_execution_profiles.py
+++ b/result_server/tests/test_execution_profiles.py
@@ -347,6 +347,184 @@ def test_trigger_runner_cron_matches_basic_fields():
     assert cron_matches("0 2 *", now) == (False, ["cron expression must have 5 fields"])
 
 
+def test_trigger_runner_scheduled_submit_is_deduped_per_due_minute(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("RESULT_SERVER_GITLAB_REPO", "gitlab.example.org/group/benchkit.git")
+    monkeypatch.setenv("RESULT_SERVER_GITLAB_TRIGGER_TOKEN", "trigger-token")
+    db_path = tmp_path / "cx_portal.sqlite3"
+    store = ExecutionProfileStore(str(db_path))
+    store.upsert_profile(_profile(system=["Fugaku"]), actor="admin@test.com")
+    trigger, errors = normalize_trigger_definition(
+        {
+            "id": "qws-fugaku-1400",
+            "trigger_type": "scheduled",
+            "profile_id": "rikyu-qws-nightly",
+            "enabled": True,
+            "cron_expr": "0 10 * * *",
+            "timezone": "Asia/Tokyo",
+        }
+    )
+    assert errors == []
+    assert trigger is not None
+    store.upsert_trigger_definition(trigger, actor="admin@test.com")
+    submitted = []
+
+    def fake_submit(plan, *, token):
+        submitted.append((plan, token))
+        return GitLabPipelineSubmitResult(
+            status_code=201,
+            response={"id": len(submitted)},
+            errors=[],
+        )
+
+    first = run_triggers(
+        db_path=str(db_path),
+        dry_run=False,
+        result_server_url="https://fncx.r-ccs.riken.jp/dev2",
+        submit=True,
+        now=datetime(2026, 8, 7, 1, 0, 15, tzinfo=UTC),
+        submit_pipeline=fake_submit,
+        use_lock=False,
+    )
+    second = run_triggers(
+        db_path=str(db_path),
+        dry_run=False,
+        result_server_url="https://fncx.r-ccs.riken.jp/dev2",
+        submit=True,
+        now=datetime(2026, 8, 7, 1, 0, 45, tzinfo=UTC),
+        submit_pipeline=fake_submit,
+        use_lock=False,
+    )
+
+    assert len(submitted) == 1
+    assert first[0].status == "submitted"
+    assert first[0].reason == "cron:0 10 * * *@2026-08-07T10:00+09:00"
+    assert first[0].payload["payload"]["variables"]["BK_TRIGGER_REASON"] == first[0].reason
+    assert second[0].status == "already_submitted"
+    assert second[0].reason == first[0].reason
+
+    runs = ExecutionProfileStore(str(db_path)).list_trigger_runs("qws-fugaku-1400")
+    assert [row["status"] for row in runs[:2]] == ["already_submitted", "submitted"]
+
+
+def test_trigger_runner_scheduled_submit_catches_late_timer_tick(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("RESULT_SERVER_GITLAB_REPO", "gitlab.example.org/group/benchkit.git")
+    monkeypatch.setenv("RESULT_SERVER_GITLAB_TRIGGER_TOKEN", "trigger-token")
+    db_path = tmp_path / "cx_portal.sqlite3"
+    store = ExecutionProfileStore(str(db_path))
+    store.upsert_profile(_profile(system=["Fugaku"]), actor="admin@test.com")
+    trigger, errors = normalize_trigger_definition(
+        {
+            "id": "qws-fugaku-1400",
+            "trigger_type": "scheduled",
+            "profile_id": "rikyu-qws-nightly",
+            "enabled": True,
+            "cron_expr": "0 10 * * *",
+            "timezone": "Asia/Tokyo",
+        }
+    )
+    assert errors == []
+    assert trigger is not None
+    store.upsert_trigger_definition(trigger, actor="admin@test.com")
+    submitted = []
+
+    def fake_submit(plan, *, token):
+        submitted.append((plan, token))
+        return GitLabPipelineSubmitResult(
+            status_code=201,
+            response={"id": 123},
+            errors=[],
+        )
+
+    evaluations = run_triggers(
+        db_path=str(db_path),
+        dry_run=False,
+        result_server_url="https://fncx.r-ccs.riken.jp/dev2",
+        submit=True,
+        now=datetime(2026, 8, 7, 1, 3, 0, tzinfo=UTC),
+        submit_pipeline=fake_submit,
+        use_lock=False,
+        schedule_lookback_minutes=5,
+    )
+
+    assert len(submitted) == 1
+    assert evaluations[0].status == "submitted"
+    assert evaluations[0].reason == "cron:0 10 * * *@2026-08-07T10:00+09:00"
+
+
+def test_trigger_runner_scheduled_dedup_accepts_recent_legacy_reason(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("RESULT_SERVER_GITLAB_REPO", "gitlab.example.org/group/benchkit.git")
+    monkeypatch.setenv("RESULT_SERVER_GITLAB_TRIGGER_TOKEN", "trigger-token")
+    db_path = tmp_path / "cx_portal.sqlite3"
+    store = ExecutionProfileStore(str(db_path))
+    store.upsert_profile(_profile(system=["Fugaku"]), actor="admin@test.com")
+    trigger, errors = normalize_trigger_definition(
+        {
+            "id": "qws-fugaku-1400",
+            "trigger_type": "scheduled",
+            "profile_id": "rikyu-qws-nightly",
+            "enabled": True,
+            "cron_expr": "0 10 * * *",
+            "timezone": "Asia/Tokyo",
+        }
+    )
+    assert errors == []
+    assert trigger is not None
+    store.upsert_trigger_definition(trigger, actor="admin@test.com")
+    store.create_trigger_run(
+        trigger_id="qws-fugaku-1400",
+        trigger_type="scheduled",
+        status="submitted",
+        dry_run=False,
+        reason="cron:0 10 * * *",
+    )
+    with store.connect() as conn:
+        conn.execute(
+            """
+            UPDATE trigger_runs
+            SET created_at = ?, updated_at = ?
+            WHERE trigger_id = ? AND status = ?
+            """,
+            (
+                "2026-08-07T01:00:30Z",
+                "2026-08-07T01:00:30Z",
+                "qws-fugaku-1400",
+                "submitted",
+            ),
+        )
+    submitted = []
+
+    def fake_submit(plan, *, token):
+        submitted.append((plan, token))
+        return GitLabPipelineSubmitResult(
+            status_code=201,
+            response={"id": 123},
+            errors=[],
+        )
+
+    evaluations = run_triggers(
+        db_path=str(db_path),
+        dry_run=False,
+        result_server_url="https://fncx.r-ccs.riken.jp/dev2",
+        submit=True,
+        now=datetime(2026, 8, 7, 1, 0, 45, tzinfo=UTC),
+        submit_pipeline=fake_submit,
+        use_lock=False,
+    )
+
+    assert submitted == []
+    assert evaluations[0].status == "already_submitted"
+    assert evaluations[0].reason == "cron:0 10 * * *@2026-08-07T10:00+09:00"
+
+
 def test_trigger_runner_dry_run_detects_repo_ref_change_and_records_run(
     tmp_path,
     monkeypatch,

--- a/result_server/tests/test_trigger_runner_setup_script.py
+++ b/result_server/tests/test_trigger_runner_setup_script.py
@@ -55,6 +55,8 @@ def test_setup_trigger_runner_writes_user_units(tmp_path):
             "*:0/5",
             "--lock-ttl-seconds",
             "120",
+            "--schedule-lookback-minutes",
+            "7",
             "--submit",
         ],
         check=True,
@@ -76,6 +78,7 @@ def test_setup_trigger_runner_writes_user_units(tmp_path):
     assert "--submit" in service_text
     assert "--record-observations" in service_text
     assert "--lock-ttl-seconds 120" in service_text
+    assert "--schedule-lookback-minutes 7" in service_text
     assert "https://fncx.r-ccs.riken.jp/dev2" in service_text
     assert "OnCalendar=*:0/5" in timer_text
     assert "Unit=benchkit-trigger-runner-dev2.service" in timer_text

--- a/result_server/trigger_runner.py
+++ b/result_server/trigger_runner.py
@@ -9,7 +9,7 @@ import socket
 import subprocess
 import sys
 from dataclasses import dataclass, replace
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -122,6 +122,35 @@ def cron_matches(cron_expr: str, now: datetime) -> tuple[bool, list[str]]:
     ), []
 
 
+def _minute_key(value: datetime) -> str:
+    return value.replace(second=0, microsecond=0).isoformat(timespec="minutes")
+
+
+def _utc_iso(value: datetime) -> str:
+    return value.astimezone(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _cron_due_slots(
+    cron_expr: str,
+    now: datetime,
+    *,
+    lookback_minutes: int,
+) -> tuple[list[datetime], list[str]]:
+    _, errors = cron_matches(cron_expr, now)
+    if errors:
+        return [], errors
+    current = now.replace(second=0, microsecond=0)
+    slots = []
+    for offset in range(max(0, lookback_minutes), -1, -1):
+        candidate = current - timedelta(minutes=offset)
+        matches, match_errors = cron_matches(cron_expr, candidate)
+        if match_errors:
+            return [], match_errors
+        if matches:
+            slots.append(candidate)
+    return slots, []
+
+
 def _trigger_now(trigger: dict, now: datetime) -> tuple[datetime, list[str]]:
     timezone_name = trigger.get("timezone") or "Asia/Tokyo"
     try:
@@ -182,10 +211,38 @@ def evaluate_scheduled_trigger(
     *,
     now: datetime,
     result_server_url: str,
+    schedule_lookback_minutes: int = 5,
 ) -> TriggerEvaluation:
     local_now, timezone_errors = _trigger_now(trigger, now)
-    matches, cron_errors = cron_matches(trigger.get("cron_expr", ""), local_now)
-    reason = f"cron:{trigger.get('cron_expr', '')}"
+    due_slots, cron_errors = _cron_due_slots(
+        trigger.get("cron_expr", ""),
+        local_now,
+        lookback_minutes=schedule_lookback_minutes,
+    )
+    due_slot = None
+    legacy_reason = f"cron:{trigger.get('cron_expr', '')}"
+    legacy_since = _utc_iso(now - timedelta(minutes=schedule_lookback_minutes + 1))
+    for slot in due_slots:
+        candidate_reason = f"cron:{trigger.get('cron_expr', '')}@{_minute_key(slot)}"
+        already_submitted = store.has_trigger_run(
+            trigger_id=trigger["id"],
+            status="submitted",
+            reason=candidate_reason,
+        ) or store.has_trigger_run(
+            trigger_id=trigger["id"],
+            status="submitted",
+            reason=legacy_reason,
+            created_at_since=legacy_since,
+        )
+        if not already_submitted:
+            due_slot = slot
+            break
+    reason_slot = due_slot or (due_slots[-1] if due_slots else None)
+    reason = (
+        f"cron:{trigger.get('cron_expr', '')}@{_minute_key(reason_slot)}"
+        if reason_slot
+        else f"cron:{trigger.get('cron_expr', '')}"
+    )
     payload, plan_errors = _build_trigger_plan(
         store,
         trigger,
@@ -193,8 +250,10 @@ def evaluate_scheduled_trigger(
         trigger_reason=reason,
     )
     errors = timezone_errors + cron_errors + plan_errors
-    should_fire = matches and not errors
+    should_fire = due_slot is not None and not errors
     status = "would_submit" if should_fire else "not_due"
+    if due_slots and due_slot is None:
+        status = "already_submitted"
     if errors:
         status = "blocked"
     return TriggerEvaluation(
@@ -290,6 +349,7 @@ def evaluate_trigger(
     now: datetime,
     result_server_url: str,
     ls_remote=_git_ls_remote,
+    schedule_lookback_minutes: int = 5,
 ) -> TriggerEvaluation:
     if trigger.get("trigger_type") == "scheduled":
         return evaluate_scheduled_trigger(
@@ -297,6 +357,7 @@ def evaluate_trigger(
             trigger,
             now=now,
             result_server_url=result_server_url,
+            schedule_lookback_minutes=schedule_lookback_minutes,
         )
     if trigger.get("trigger_type") == "watch_event" and trigger.get("watch_kind") == "repo_ref":
         return evaluate_repo_ref_trigger(
@@ -331,6 +392,7 @@ def run_triggers(
     use_lock: bool = True,
     lock_name: str = "default",
     lock_ttl_seconds: int = 300,
+    schedule_lookback_minutes: int = 5,
 ) -> list[TriggerEvaluation]:
     store = ExecutionProfileStore(db_path)
     current_time = now or _now_utc()
@@ -376,6 +438,7 @@ def run_triggers(
                 now=current_time,
                 result_server_url=result_url,
                 ls_remote=ls_remote,
+                schedule_lookback_minutes=schedule_lookback_minutes,
             )
             if record_observations:
                 observed_at = current_time.isoformat().replace("+00:00", "Z")
@@ -457,6 +520,12 @@ def main(argv: list[str] | None = None) -> int:
         default=300,
         help="SQLite runner lock TTL. Default: 300.",
     )
+    parser.add_argument(
+        "--schedule-lookback-minutes",
+        type=int,
+        default=5,
+        help="Look back this many minutes for missed scheduled cron slots. Default: 5.",
+    )
     parser.add_argument("--result-server-url", default="", help="RESULT_SERVER URL for submitted pipelines")
     args = parser.parse_args(argv)
 
@@ -471,6 +540,7 @@ def main(argv: list[str] | None = None) -> int:
         submit=args.submit,
         use_lock=not args.no_lock,
         lock_ttl_seconds=args.lock_ttl_seconds,
+        schedule_lookback_minutes=args.schedule_lookback_minutes,
     )
     print(json.dumps([_evaluation_to_dict(item) for item in evaluations], indent=2, sort_keys=True))
     return 1 if any(item.errors for item in evaluations) else 0

--- a/result_server/utils/execution_profiles.py
+++ b/result_server/utils/execution_profiles.py
@@ -1040,6 +1040,29 @@ class ExecutionProfileStore:
             )
         return runs
 
+    def has_trigger_run(
+        self,
+        *,
+        trigger_id: str,
+        status: str,
+        reason: str,
+        created_at_since: str = "",
+    ) -> bool:
+        self.migrate()
+        params: list[Any] = [trigger_id, status, reason]
+        query = """
+            SELECT 1
+            FROM trigger_runs
+            WHERE trigger_id = ? AND status = ? AND reason = ?
+        """
+        if created_at_since:
+            query += " AND created_at >= ?"
+            params.append(created_at_since)
+        query += " LIMIT 1"
+        with self.connect() as conn:
+            row = conn.execute(query, tuple(params)).fetchone()
+        return row is not None
+
     def list_profiles(self) -> list[dict[str, Any]]:
         self.migrate()
         with self.connect() as conn:

--- a/scripts/site/setup_trigger_runner.sh
+++ b/scripts/site/setup_trigger_runner.sh
@@ -14,6 +14,7 @@ record_observations=1
 start_service=1
 use_lock=1
 lock_ttl_seconds=300
+schedule_lookback_minutes=5
 
 usage() {
   cat <<'EOF'
@@ -36,6 +37,8 @@ Options:
   --no-record-observations Do not persist repo_ref fingerprints.
   --no-lock                Do not use the SQLite runner lock.
   --lock-ttl-seconds SEC   SQLite runner lock TTL. Default: 300.
+  --schedule-lookback-minutes MIN
+                           Scheduled trigger lookback window. Default: 5.
   --no-start               Write units but do not enable/start the timer.
   -h, --help               Show this help.
 
@@ -69,6 +72,7 @@ while [[ $# -gt 0 ]]; do
     --no-record-observations) record_observations=0; shift ;;
     --no-lock) use_lock=0; shift ;;
     --lock-ttl-seconds) lock_ttl_seconds="${2:-}"; shift 2 ;;
+    --schedule-lookback-minutes) schedule_lookback_minutes="${2:-}"; shift 2 ;;
     --no-start) start_service=0; shift ;;
     -h|--help) usage; exit 0 ;;
     *) die "Unknown option: $1" ;;
@@ -118,6 +122,7 @@ if [[ "$use_lock" -eq 0 ]]; then
 else
   runner_args+=(--lock-ttl-seconds "$lock_ttl_seconds")
 fi
+runner_args+=(--schedule-lookback-minutes "$schedule_lookback_minutes")
 
 info "Writing $service_path"
 {


### PR DESCRIPTION
## Summary
- de-duplicate scheduled trigger submissions by cron due minute
- add a short scheduled lookback window so delayed timer ticks can catch missed due minutes
- expose --schedule-lookback-minutes through the trigger runner CLI and systemd setup helper

## Verification
- /home/nakamura/fugakunext/venv/bin/python -m pytest result_server/tests/test_execution_profiles.py result_server/tests/test_trigger_runner_setup_script.py result_server/tests/test_api_routes.py result_server/tests/test_app_dev_security.py result_server/tests/test_preflight.py
- dev2 11:00 hourly scheduled test submitted once, then subsequent ticks recorded already_submitted for the same due minute
- dev2 watch_event trigger submitted on simulated repo/ref fingerprint change and returned results to dev2