### PR TITLE
Show portal trigger run causes

### DIFF
--- a/docs/guides/portal-execution-profiles-handoff.md
+++ b/docs/guides/portal-execution-profiles-handoff.md
@@ -18,6 +18,8 @@ path:
 - Admin dry-run and confirmed GitLab trigger submit paths.
 - Portal-managed scheduled and repo/ref trigger definitions.
 - A site-local trigger runner for scheduled and event-triggered execution.
+- Trigger decision visibility in the admin profile page and result-level run
+  cause visibility for results produced by Portal-triggered pipelines.
 
 The registry can contain scheduler account or project-group values. Do not
 commit real site-local values to the OSS repository.
@@ -45,6 +47,10 @@ Completed:
   keeps fingerprints in the Portal SQLite DB, and passes the Portal-specific
   `RESULT_SERVER` URL to GitLab pipelines so dev Portal triggers return results
   to the same dev Portal.
+- Triggered pipelines receive `BK_TRIGGER_ID`, `BK_TRIGGER_TYPE`, and
+  `BK_TRIGGER_REASON`. `scripts/result.sh` stores these values under
+  `execution_trigger` in Result JSON, and the Portal shows them as the result
+  `Run Cause`.
 
 Remaining follow-up:
 
@@ -133,6 +139,21 @@ changed.
 The runner uses a short-lived SQLite lock by default so overlapping timer
 invocations do not evaluate or submit the same triggers twice. Tune the lock
 TTL with `--lock-ttl-seconds` when the timer interval is changed.
+
+The admin execution-profile page shows recent trigger runner decisions,
+including `not_due`, `already_submitted`, `unchanged`, `blocked`,
+`submitted`, and `submit_failed`. For `repo_ref` watches it also shows the
+latest observed target fingerprint. Results produced by Portal-triggered
+pipelines show a `Run Cause` column in the results table and a matching detail
+row when the Result JSON contains `execution_trigger`.
+
+Routine non-submit decisions such as `not_due`, `unchanged`,
+`already_submitted`, and `runner_locked` are rate-limited in `trigger_runs`.
+The default interval is 60 minutes, so a one-minute timer does not write a
+routine history row on every tick. Use `--routine-log-interval-minutes 0` only
+when intentionally debugging every runner tick.
+Repo/ref observations are only persisted when a fingerprint is first initialized
+or changes; unchanged checks do not update `observed_at` on every timer tick.
 
 The generated service reads GitLab trigger configuration from the
 `EnvironmentFile`. The token must remain site-local:

--- a/result_server/routes/admin.py
+++ b/result_server/routes/admin.py
@@ -37,6 +37,7 @@ from utils.gitlab_pipeline import (
     submit_pipeline_plan,
 )
 from utils.rate_limit import rate_limited
+from utils.trigger_display import build_trigger_result_links, summarize_trigger_run
 from utils.user_store import get_user_store
 
 admin_bp = Blueprint("admin", __name__, url_prefix="/admin")
@@ -213,6 +214,32 @@ def _list_trigger_definitions(db_path):
         return []
 
 
+def _list_trigger_runs(db_path):
+    try:
+        runs = ExecutionProfileStore(db_path).list_trigger_runs(limit=80)
+    except sqlite3.Error as exc:
+        flash(f"Trigger run history could not be loaded: {exc}")
+        return []
+    result_links = build_trigger_result_links(
+        current_app.config.get("RECEIVED_DIR", ""),
+        runs,
+    )
+    summaries = []
+    for run in runs:
+        summary = summarize_trigger_run(run)
+        summary["result_links"] = result_links.get(int(run.get("id") or 0), [])
+        summaries.append(summary)
+    return summaries
+
+
+def _list_trigger_observations(db_path):
+    try:
+        return ExecutionProfileStore(db_path).list_trigger_observations()
+    except sqlite3.Error as exc:
+        flash(f"Trigger observations could not be loaded: {exc}")
+        return []
+
+
 def _find_trigger_definition(triggers, trigger_id):
     if not trigger_id:
         return None
@@ -346,6 +373,8 @@ def execution_profiles():
         profile_result=profile_result,
         registered_profiles=registered_profiles,
         trigger_definitions=trigger_definitions,
+        trigger_runs=_list_trigger_runs(db_path),
+        trigger_observations=_list_trigger_observations(db_path),
         profile_filter="all",
         profile_filter_options=_profile_filter_options(),
         today=datetime.now(UTC).date().isoformat(),
@@ -607,6 +636,8 @@ def dry_run_execution_profile_submit():
         profile_result=profile_result,
         registered_profiles=profile_result.profiles,
         trigger_definitions=_list_trigger_definitions(db_path),
+        trigger_runs=_list_trigger_runs(db_path),
+        trigger_observations=_list_trigger_observations(db_path),
         profile_filter="all",
         profile_filter_options=_profile_filter_options(),
         today=datetime.now(UTC).date().isoformat(),
@@ -715,6 +746,8 @@ def submit_execution_profile_pipeline():
         profile_result=profile_result,
         registered_profiles=profile_result.profiles,
         trigger_definitions=_list_trigger_definitions(db_path),
+        trigger_runs=_list_trigger_runs(db_path),
+        trigger_observations=_list_trigger_observations(db_path),
         profile_filter="all",
         profile_filter_options=_profile_filter_options(),
         today=datetime.now(UTC).date().isoformat(),

--- a/result_server/routes/results_detail_routes.py
+++ b/result_server/routes/results_detail_routes.py
@@ -7,6 +7,7 @@ from utils.result_file import (
     serve_permitted_result_file,
 )
 from utils.result_records import summarize_result_quality
+from utils.trigger_display import load_trigger_run_lookup
 
 
 def register_results_detail_routes(results_bp):
@@ -29,7 +30,11 @@ def register_results_detail_routes(results_bp):
             not_found_message="Result file not found",
         )
         quality = summarize_result_quality(result)
-        detail_context = build_result_detail_context(result, quality)
+        detail_context = build_result_detail_context(
+            result,
+            quality,
+            load_trigger_run_lookup(current_app.config.get("EXECUTION_PROFILE_DB_PATH")),
+        )
         return render_template("result_detail.html", result=result, quality=quality, **detail_context)
 
     @results_bp.route("/<filename>")

--- a/result_server/routes/results_list_routes.py
+++ b/result_server/routes/results_list_routes.py
@@ -28,6 +28,7 @@ def _render_results_list(public_only, template_name, redirect_endpoint):
         filter_code=params["filter_code"],
         filter_exp=params["filter_exp"],
         padata_directory=received_padata_dir,
+        execution_profile_db_path=current_app.config.get("EXECUTION_PROFILE_DB_PATH"),
     )
     filter_kwargs = dict(public_only=public_only)
     template_extra = {}

--- a/result_server/templates/_results_table.html
+++ b/result_server/templates/_results_table.html
@@ -9,7 +9,7 @@
     border-radius: 14px;
 }
 .results-table {
-    min-width: 1340px;
+    min-width: 1500px;
     border-collapse: collapse;
 }
 .results-table-note {
@@ -77,6 +77,23 @@
     min-width: 88px;
     white-space: normal;
     line-height: 1.25;
+}
+.run-cause-cell {
+    min-width: 140px;
+    max-width: 220px;
+    white-space: normal;
+    line-height: 1.25;
+}
+.run-cause-headline {
+    display: block;
+    font-weight: 600;
+}
+.run-cause-subline {
+    display: block;
+    color: #607282;
+    font-size: 0.82em;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 .ci-trigger,
 .ci-pipeline {
@@ -183,6 +200,13 @@
                     {% include "_results_table_cell_profile.html" %}
                 {% elif key == "ci_summary" %}
                     {% include "_results_table_cell_ci.html" %}
+                {% elif key == "execution_trigger_summary" %}
+                    <td class="run-cause-cell" title="{{ row.execution_trigger_summary.title }}">
+                        <span class="run-cause-headline">{{ row.execution_trigger_summary.headline }}</span>
+                        {% if row.execution_trigger_summary.subline %}
+                        <span class="run-cause-subline">{{ row.execution_trigger_summary.subline }}</span>
+                        {% endif %}
+                    </td>
                 {% elif key == "timestamp" %}
                     {% set ts_parts = row[key].split(' ') %}
                     <td class="ts-cell">{{ ts_parts[0] }}<br>{{ ts_parts[1] if ts_parts|length > 1 else '' }}</td>

--- a/result_server/templates/admin_execution_profiles.html
+++ b/result_server/templates/admin_execution_profiles.html
@@ -154,6 +154,46 @@
     .trigger-definition-table td {
         vertical-align: middle;
     }
+    .trigger-history-table {
+        table-layout: fixed;
+        min-width: 1180px;
+    }
+    .trigger-history-table td {
+        vertical-align: top;
+        white-space: normal;
+    }
+    .trigger-history-table th:nth-child(1) { width: 150px; }
+    .trigger-history-table th:nth-child(2) { width: 160px; }
+    .trigger-history-table th:nth-child(3) { width: 120px; }
+    .trigger-history-table th:nth-child(4) { width: 240px; }
+    .trigger-history-table th:nth-child(5) { width: 220px; }
+    .trigger-history-table th:nth-child(6) { width: 150px; }
+    .trigger-history-table th:nth-child(7) { width: 180px; }
+    .trigger-run-subline {
+        display: block;
+        margin-top: 2px;
+        color: #64748b;
+        font-size: 12px;
+        line-height: 1.25;
+    }
+    .trigger-run-reason {
+        display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    .trigger-run-error {
+        color: #991b1b;
+        font-weight: 700;
+    }
+    .trigger-observation-table {
+        table-layout: fixed;
+        min-width: 900px;
+    }
+    .trigger-observation-table td {
+        vertical-align: top;
+        white-space: normal;
+    }
     .trigger-condition {
         max-width: 46ch;
     }
@@ -629,6 +669,108 @@
             {% else %}
                 <tr>
                     <td colspan="7">No trigger definitions are registered.</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</section>
+<section class="page-card table-card">
+    <h2 class="section-title">Trigger Run History</h2>
+    <p class="help-text">Recent trigger runner decisions, including why scheduled and repo/ref triggers did or did not submit a GitLab pipeline.</p>
+    <div class="table-wrap">
+        <table class="trigger-history-table">
+            <thead>
+                <tr>
+                    <th>Time</th>
+                    <th>Trigger</th>
+                    <th>Status</th>
+                    <th>Reason</th>
+                    <th>Target</th>
+                    <th>Scope</th>
+                    <th>Results</th>
+                    <th>Errors</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for run in trigger_runs %}
+                <tr>
+                    <td>
+                        <span class="profile-mono">{{ run.created_at }}</span>
+                        <span class="trigger-run-subline">{{ run.actor }}{% if run.dry_run %} / dry-run{% endif %}</span>
+                    </td>
+                    <td>
+                        <span class="profile-mono">{{ run.trigger_id }}</span>
+                        <span class="trigger-run-subline">{{ run.trigger_type }}</span>
+                    </td>
+                    <td>{{ run.status }}</td>
+                    <td title="{{ run.reason }}">
+                        <span class="trigger-run-reason">{{ run.reason_label or run.reason }}</span>
+                    </td>
+                    <td>
+                        <span class="profile-mono">{{ run.gitlab_target }}</span>
+                        <span class="trigger-run-subline">{{ run.target_ref }}</span>
+                    </td>
+                    <td>
+                        <span class="profile-mono">{{ run.code }}</span>
+                        / <span class="profile-mono">{{ run.system }}</span>
+                        <span class="trigger-run-subline">{{ run.allocation_project_id }}</span>
+                    </td>
+                    <td>
+                        {% if run.result_links %}
+                        {% for result_link in run.result_links[:4] %}
+                        <a href="{{ url_for('results.result_detail', filename=result_link.filename) }}">{{ result_link.label }}</a>{% if not loop.last %}<br>{% endif %}
+                        {% endfor %}
+                        {% if run.result_links|length > 4 %}
+                        <span class="trigger-run-subline">+{{ run.result_links|length - 4 }} more</span>
+                        {% endif %}
+                        {% else %}
+                        -
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if run.error_summary %}
+                        <span class="trigger-run-error" title="{{ run.error_summary }}">error</span>
+                        <span class="trigger-run-subline">{{ run.error_summary }}</span>
+                        {% else %}
+                        -
+                        {% endif %}
+                    </td>
+                </tr>
+            {% else %}
+                <tr>
+                    <td colspan="8">No trigger runner decisions have been recorded.</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</section>
+
+<section class="page-card table-card">
+    <h2 class="section-title">Trigger Observations</h2>
+    <p class="help-text">Latest repo/ref fingerprints recorded by watch-event triggers.</p>
+    <div class="table-wrap">
+        <table class="trigger-observation-table">
+            <thead>
+                <tr>
+                    <th>Trigger</th>
+                    <th>Target</th>
+                    <th>Fingerprint</th>
+                    <th>Observed At</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for observation in trigger_observations %}
+                <tr>
+                    <td><span class="profile-mono">{{ observation.trigger_id }}</span></td>
+                    <td title="{{ observation.target }}">{{ observation.target }}</td>
+                    <td><span class="profile-mono">{{ observation.fingerprint[:12] }}{% if observation.fingerprint|length > 12 %}...{% endif %}</span></td>
+                    <td><span class="profile-mono">{{ observation.observed_at }}</span></td>
+                </tr>
+            {% else %}
+                <tr>
+                    <td colspan="4">No repo/ref observations have been recorded.</td>
                 </tr>
             {% endfor %}
             </tbody>

--- a/result_server/tests/test_execution_profiles.py
+++ b/result_server/tests/test_execution_profiles.py
@@ -404,9 +404,20 @@ def test_trigger_runner_scheduled_submit_is_deduped_per_due_minute(
     assert first[0].payload["payload"]["variables"]["BK_TRIGGER_REASON"] == first[0].reason
     assert second[0].status == "already_submitted"
     assert second[0].reason == first[0].reason
+    third = run_triggers(
+        db_path=str(db_path),
+        dry_run=False,
+        result_server_url="https://fncx.r-ccs.riken.jp/dev2",
+        submit=True,
+        now=datetime(2026, 8, 7, 1, 0, 50, tzinfo=UTC),
+        submit_pipeline=fake_submit,
+        use_lock=False,
+    )
+    assert third[0].status == "already_submitted"
 
     runs = ExecutionProfileStore(str(db_path)).list_trigger_runs("qws-fugaku-1400")
     assert [row["status"] for row in runs[:2]] == ["already_submitted", "submitted"]
+    assert sum(1 for row in runs if row["status"] == "already_submitted") == 1
 
 
 def test_trigger_runner_scheduled_submit_catches_late_timer_tick(
@@ -561,6 +572,7 @@ def test_trigger_runner_dry_run_detects_repo_ref_change_and_records_run(
         dry_run=True,
         result_server_url="https://fncx.r-ccs.riken.jp/dev2",
         record_observations=True,
+        now=datetime(2026, 8, 7, 1, 0, tzinfo=UTC),
         ls_remote=fake_ls_remote,
     )
 
@@ -582,6 +594,10 @@ def test_trigger_runner_dry_run_detects_repo_ref_change_and_records_run(
     observations = stored.list_trigger_observations("rikyu-qws-watch")
     runs = stored.list_trigger_runs("rikyu-qws-watch")
     assert len(observations) == 2
+    observed_at_by_target = {
+        observation["target"]: observation["observed_at"]
+        for observation in observations
+    }
     assert runs[0]["status"] == "would_initialize"
 
     second = run_triggers(
@@ -589,10 +605,32 @@ def test_trigger_runner_dry_run_detects_repo_ref_change_and_records_run(
         dry_run=True,
         result_server_url="https://fncx.r-ccs.riken.jp/dev2",
         record_observations=True,
+        now=datetime(2026, 8, 7, 1, 1, tzinfo=UTC),
         ls_remote=fake_ls_remote,
     )
     assert second[0].should_fire is False
     assert second[0].status == "unchanged"
+    after_second_store = ExecutionProfileStore(str(db_path))
+    second_observations = after_second_store.list_trigger_observations("rikyu-qws-watch")
+    assert {
+        observation["target"]: observation["observed_at"]
+        for observation in second_observations
+    } == observed_at_by_target
+    runs_after_second = after_second_store.list_trigger_runs("rikyu-qws-watch")
+    assert sum(1 for row in runs_after_second if row["status"] == "unchanged") == 1
+
+    repeated = run_triggers(
+        db_path=str(db_path),
+        dry_run=True,
+        result_server_url="https://fncx.r-ccs.riken.jp/dev2",
+        record_observations=True,
+        now=datetime(2026, 8, 7, 1, 2, tzinfo=UTC),
+        ls_remote=fake_ls_remote,
+    )
+    assert repeated[0].should_fire is False
+    assert repeated[0].status == "unchanged"
+    runs_after_repeated = ExecutionProfileStore(str(db_path)).list_trigger_runs("rikyu-qws-watch")
+    assert sum(1 for row in runs_after_repeated if row["status"] == "unchanged") == 1
 
     fingerprint_suffix = "changed"
     third = run_triggers(
@@ -600,10 +638,16 @@ def test_trigger_runner_dry_run_detects_repo_ref_change_and_records_run(
         dry_run=True,
         result_server_url="https://fncx.r-ccs.riken.jp/dev2",
         record_observations=True,
+        now=datetime(2026, 8, 7, 1, 3, tzinfo=UTC),
         ls_remote=fake_ls_remote,
     )
     assert third[0].should_fire is True
     assert third[0].status == "would_submit"
+    changed_observations = ExecutionProfileStore(str(db_path)).list_trigger_observations("rikyu-qws-watch")
+    assert any(
+        observation["observed_at"] != observed_at_by_target[observation["target"]]
+        for observation in changed_observations
+    )
 
 
 def test_trigger_runner_submit_records_submitted_run(tmp_path, monkeypatch):

--- a/result_server/tests/test_results_loader.py
+++ b/result_server/tests/test_results_loader.py
@@ -279,6 +279,7 @@ class TestLoadResultsTableExtension:
             {"label": "P/N", "key": "numproc_node", "tooltip": "Number of processes per node"},
             {"label": "T/P", "key": "nthreads", "tooltip": "Number of threads per process"},
             {"label": "Profiler / PA", "key": "profile_summary", "tooltip": "Profiler tool, level, report summary, and PA data download access"},
+            {"label": "Run Cause", "key": "execution_trigger_summary", "tooltip": "Portal trigger metadata explaining why this benchmark run was launched"},
             {"label": "JSON", "key": "json_link", "tooltip": "Detailed benchmark results in JSON format", "tooltip_class": "tooltip-right"},
             {"label": "CI", "key": "ci_summary", "tooltip": "CI trigger source and pipeline ID"},
         ]
@@ -307,6 +308,7 @@ class TestLoadResultsTableExtension:
         assert row["numproc_node"] == "48"
         assert row["nthreads"] == "12"
         assert row["profile_summary"] == "-"
+        assert row["execution_trigger_summary"]["headline"] == "-"
 
     def test_profile_summary_is_built_from_profile_data(self, flask_app, tmp_dir):
         uid = str(uuid.uuid4())

--- a/result_server/tests/test_trigger_display.py
+++ b/result_server/tests/test_trigger_display.py
@@ -1,0 +1,226 @@
+import os
+import sys
+import json
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from test_support import build_results_route_app, install_portal_test_stubs
+
+install_portal_test_stubs()
+
+from utils.result_table_rows import build_result_table_row
+from utils.execution_profiles import ExecutionProfileStore
+from utils.trigger_display import (
+    build_trigger_result_links,
+    build_trigger_run_lookup,
+    load_trigger_run_lookup,
+    summarize_execution_trigger,
+    summarize_trigger_run,
+)
+
+
+@pytest.fixture
+def flask_app(tmp_path):
+    return build_results_route_app(
+        received_dir=str(tmp_path),
+        estimated_dir=str(tmp_path),
+        templates_dir=os.path.join(os.path.dirname(__file__), "..", "templates"),
+    )
+
+
+def test_summarize_execution_trigger_formats_portal_metadata(flask_app):
+    result = {
+        "code": "qws",
+        "system": "Fugaku",
+        "Exp": "case0",
+        "FOM": 1.0,
+        "execution_trigger": {
+            "id": "qws-fugaku-watch",
+            "type": "watch_event",
+            "reason": "repo_ref:https://github.com/RIKEN-LQCD/qws.git@master",
+        },
+    }
+
+    summary = summarize_execution_trigger(result)
+
+    assert summary["has_trigger"] is True
+    assert summary["headline"] == "Watch event / qws-fugaku-watch"
+    assert summary["subline"] == "repo/ref changed: https://github.com/RIKEN-LQCD/qws.git@master"
+    with flask_app.test_request_context("/results/"):
+        row = build_result_table_row("20260807_030000_aaaaaaaa.json", result, [])
+    assert row["execution_trigger_summary"]["headline"] == summary["headline"]
+
+
+def test_summarize_execution_trigger_handles_older_results():
+    summary = summarize_execution_trigger({"code": "qws"})
+
+    assert summary == {
+        "has_trigger": False,
+        "headline": "-",
+        "subline": "",
+        "title": "No Portal trigger metadata was recorded for this result.",
+    }
+
+
+def test_summarize_execution_trigger_falls_back_to_pipeline_lookup():
+    runs = [
+        {
+            "trigger_id": "qws-fugaku-watch",
+            "trigger_type": "watch_event",
+            "status": "submitted",
+            "reason": "repo_ref:https://github.com/RIKEN-LQCD/qws.git@master",
+            "payload_json": {
+                "submit": {"response": {"id": 3186}},
+            },
+        }
+    ]
+
+    summary = summarize_execution_trigger(
+        {"pipeline_id": 3186},
+        build_trigger_run_lookup(runs),
+    )
+
+    assert summary["headline"] == "Watch event / qws-fugaku-watch"
+    assert summary["subline"] == "repo/ref changed: https://github.com/RIKEN-LQCD/qws.git@master"
+
+
+def test_load_trigger_run_lookup_ignores_newer_routine_runs(tmp_path):
+    db_path = tmp_path / "cx_portal.sqlite3"
+    store = ExecutionProfileStore(str(db_path))
+    store.create_trigger_run(
+        trigger_id="qws-fugaku-watch",
+        trigger_type="watch_event",
+        status="submitted",
+        dry_run=False,
+        reason="repo_ref:https://github.com/RIKEN-LQCD/qws.git@master",
+        payload={"submit": {"response": {"id": 3186}}},
+    )
+    for index in range(20):
+        store.create_trigger_run(
+            trigger_id="qws-fugaku-watch",
+            trigger_type="watch_event",
+            status="unchanged",
+            dry_run=False,
+            reason=f"repo_ref:{index}",
+            payload={},
+        )
+
+    lookup = load_trigger_run_lookup(str(db_path), limit=1)
+
+    assert lookup["3186"]["status"] == "submitted"
+
+
+def test_summarize_execution_trigger_falls_back_to_child_pipeline_lookup():
+    runs = [
+        {
+            "trigger_id": "qws-fugaku-watch",
+            "trigger_type": "watch_event",
+            "status": "submitted",
+            "reason": "repo_ref:https://github.com/RIKEN-LQCD/qws.git@master",
+            "payload_json": {
+                "submit": {"response": {"id": 3187, "child_pipeline_ids": [3188]}},
+            },
+        }
+    ]
+
+    summary = summarize_execution_trigger(
+        {"pipeline_id": 3188},
+        build_trigger_run_lookup(runs),
+    )
+
+    assert summary["headline"] == "Watch event / qws-fugaku-watch"
+
+
+def test_summarize_trigger_run_extracts_payload_context():
+    run = {
+        "id": 3,
+        "trigger_id": "qws-fugaku-1400",
+        "trigger_type": "scheduled",
+        "status": "submitted",
+        "dry_run": False,
+        "reason": "cron:0 14 * * *@2026-08-07T14:00+09:00",
+        "payload_json": {
+            "gitlab_target": "site_ci",
+            "gitlab_project": "gitlab.example.org/group/project",
+            "submit": {"response": {"id": 3186}},
+            "payload": {
+                "ref": "develop",
+                "variables": {
+                    "code": "qws",
+                    "system": "Fugaku",
+                    "BK_ALLOCATION_PROJECT_ID": "rkp00010",
+                    "RESULT_SERVER": "https://portal.example.org/dev",
+                },
+            },
+        },
+        "errors": [],
+        "actor": "trigger_runner",
+        "created_at": "2026-08-07T05:00:00Z",
+    }
+
+    summary = summarize_trigger_run(run)
+
+    assert summary["target_ref"] == "develop"
+    assert summary["code"] == "qws"
+    assert summary["system"] == "Fugaku"
+    assert summary["allocation_project_id"] == "rkp00010"
+    assert summary["pipeline_id"] == "3186"
+    assert summary["reason_label"] == "cron 0 14 * * * / 2026-08-07T14:00+09:00"
+
+
+def test_build_trigger_result_links_matches_direct_trigger_metadata(tmp_path):
+    result_file = tmp_path / "result_20260807_140000_aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.json"
+    result_file.write_text(
+        json.dumps(
+            {
+                "code": "qws",
+                "Exp": "CASE0",
+                "execution_trigger": {
+                    "id": "qws-fugaku-watch",
+                    "type": "watch_event",
+                    "reason": "repo_ref:https://github.com/RIKEN-LQCD/qws.git@master",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    runs = [
+        {
+            "id": 7,
+            "trigger_id": "qws-fugaku-watch",
+            "trigger_type": "watch_event",
+            "reason": "repo_ref:https://github.com/RIKEN-LQCD/qws.git@master",
+            "payload_json": {},
+        }
+    ]
+
+    links = build_trigger_result_links(str(tmp_path), runs)
+
+    assert links[7][0]["filename"] == result_file.name
+    assert links[7][0]["label"] == "2026-08-07 14:00:00 / CASE0"
+
+
+def test_build_trigger_result_links_matches_child_pipeline_fallback(tmp_path):
+    result_file = tmp_path / "result_20260807_140611_aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.json"
+    result_file.write_text(
+        json.dumps({"code": "qws", "Exp": "CASE1", "pipeline_id": 3190}),
+        encoding="utf-8",
+    )
+    runs = [
+        {
+            "id": 8,
+            "trigger_id": "qws-fugaku-1400",
+            "trigger_type": "scheduled",
+            "reason": "cron:0 14 * * *@2026-08-07T14:00+09:00",
+            "payload_json": {
+                "submit": {"response": {"id": 3189, "child_pipeline_ids": [3190]}},
+            },
+        }
+    ]
+
+    links = build_trigger_result_links(str(tmp_path), runs)
+
+    assert links[8][0]["filename"] == result_file.name
+    assert links[8][0]["pipeline_id"] == "3190"

--- a/result_server/trigger_runner.py
+++ b/result_server/trigger_runner.py
@@ -45,6 +45,17 @@ class TriggerEvaluation:
     observations: list[dict]
 
 
+ROUTINE_TRIGGER_STATUSES = frozenset(
+    {
+        "not_due",
+        "unchanged",
+        "already_submitted",
+        "runner_locked",
+        "would_initialize",
+    }
+)
+
+
 def _now_utc() -> datetime:
     return datetime.now(UTC).replace(second=0, microsecond=0)
 
@@ -393,6 +404,7 @@ def run_triggers(
     lock_name: str = "default",
     lock_ttl_seconds: int = 300,
     schedule_lookback_minutes: int = 5,
+    routine_log_interval_minutes: int = 60,
 ) -> list[TriggerEvaluation]:
     store = ExecutionProfileStore(db_path)
     current_time = now or _now_utc()
@@ -416,15 +428,15 @@ def run_triggers(
                 errors=[],
                 observations=[],
             )
-            store.create_trigger_run(
-                trigger_id=evaluation.trigger_id,
-                trigger_type=evaluation.trigger_type,
+            _record_trigger_run_if_needed(
+                store,
+                evaluation,
                 status=evaluation.status,
                 dry_run=dry_run,
-                reason=evaluation.reason,
                 payload=evaluation.payload,
                 errors=[],
-                actor="trigger_runner",
+                now=current_time,
+                routine_log_interval_minutes=routine_log_interval_minutes,
             )
             return [evaluation]
     evaluations = []
@@ -443,10 +455,10 @@ def run_triggers(
             if record_observations:
                 observed_at = current_time.isoformat().replace("+00:00", "Z")
                 for item in evaluation.observations:
-                    store.upsert_trigger_observation(
+                    _record_trigger_observation_if_needed(
+                        store,
                         evaluation.trigger_id,
-                        item["target"],
-                        item["fingerprint"],
+                        item,
                         observed_at=observed_at,
                     )
             status = evaluation.status
@@ -468,17 +480,29 @@ def run_triggers(
                 )
                 errors.extend(result.errors)
                 status = "submitted" if result.ok else "submit_failed"
-            reported = replace(evaluation, status=status, errors=errors)
+                evaluation_payload = dict(evaluation.payload)
+                evaluation_payload["submit"] = {
+                    "status_code": result.status_code,
+                    "response": result.response,
+                }
+            else:
+                evaluation_payload = evaluation.payload
+            reported = replace(
+                evaluation,
+                status=status,
+                errors=errors,
+                payload=evaluation_payload,
+            )
             evaluations.append(reported)
-            store.create_trigger_run(
-                trigger_id=evaluation.trigger_id,
-                trigger_type=evaluation.trigger_type,
+            _record_trigger_run_if_needed(
+                store,
+                evaluation,
                 status=status,
                 dry_run=dry_run,
-                reason=evaluation.reason,
-                payload=evaluation.payload,
+                payload=evaluation_payload,
                 errors=errors,
-                actor="trigger_runner",
+                now=current_time,
+                routine_log_interval_minutes=routine_log_interval_minutes,
             )
     finally:
         if use_lock:
@@ -488,6 +512,79 @@ def run_triggers(
                 now=current_time.isoformat().replace("+00:00", "Z"),
             )
     return evaluations
+
+
+def _record_trigger_observation_if_needed(
+    store: ExecutionProfileStore,
+    trigger_id: str,
+    observation: dict,
+    *,
+    observed_at: str,
+) -> bool:
+    if not observation.get("initialized") and not observation.get("changed"):
+        return False
+    store.upsert_trigger_observation(
+        trigger_id,
+        observation["target"],
+        observation["fingerprint"],
+        observed_at=observed_at,
+    )
+    return True
+
+
+def _record_trigger_run_if_needed(
+    store: ExecutionProfileStore,
+    evaluation: TriggerEvaluation,
+    *,
+    status: str,
+    dry_run: bool,
+    payload: dict,
+    errors: list[str],
+    now: datetime,
+    routine_log_interval_minutes: int,
+) -> bool:
+    if not _should_record_trigger_run(
+        store,
+        evaluation,
+        status=status,
+        errors=errors,
+        now=now,
+        routine_log_interval_minutes=routine_log_interval_minutes,
+    ):
+        return False
+    store.create_trigger_run(
+        trigger_id=evaluation.trigger_id,
+        trigger_type=evaluation.trigger_type,
+        status=status,
+        dry_run=dry_run,
+        reason=evaluation.reason,
+        payload=payload,
+        errors=errors,
+        actor="trigger_runner",
+    )
+    return True
+
+
+def _should_record_trigger_run(
+    store: ExecutionProfileStore,
+    evaluation: TriggerEvaluation,
+    *,
+    status: str,
+    errors: list[str],
+    now: datetime,
+    routine_log_interval_minutes: int,
+) -> bool:
+    if errors or status not in ROUTINE_TRIGGER_STATUSES:
+        return True
+    if routine_log_interval_minutes <= 0:
+        return True
+    since = _utc_iso(now - timedelta(minutes=routine_log_interval_minutes))
+    return not store.has_trigger_run(
+        trigger_id=evaluation.trigger_id,
+        status=status,
+        reason=evaluation.reason,
+        created_at_since=since,
+    )
 
 
 def _evaluation_to_dict(evaluation: TriggerEvaluation) -> dict:
@@ -526,6 +623,15 @@ def main(argv: list[str] | None = None) -> int:
         default=5,
         help="Look back this many minutes for missed scheduled cron slots. Default: 5.",
     )
+    parser.add_argument(
+        "--routine-log-interval-minutes",
+        type=int,
+        default=60,
+        help=(
+            "Minimum minutes between repeated routine trigger-run records "
+            "such as not_due or unchanged. Use 0 to record every tick. Default: 60."
+        ),
+    )
     parser.add_argument("--result-server-url", default="", help="RESULT_SERVER URL for submitted pipelines")
     args = parser.parse_args(argv)
 
@@ -541,6 +647,7 @@ def main(argv: list[str] | None = None) -> int:
         use_lock=not args.no_lock,
         lock_ttl_seconds=args.lock_ttl_seconds,
         schedule_lookback_minutes=args.schedule_lookback_minutes,
+        routine_log_interval_minutes=args.routine_log_interval_minutes,
     )
     print(json.dumps([_evaluation_to_dict(item) for item in evaluations], indent=2, sort_keys=True))
     return 1 if any(item.errors for item in evaluations) else 0

--- a/result_server/utils/execution_profiles.py
+++ b/result_server/utils/execution_profiles.py
@@ -304,6 +304,12 @@ class ExecutionProfileStore:
                 current = 5
             if current < 6:
                 self._apply_v6(conn)
+                current = 6
+            if current < 7:
+                self._apply_v7(conn)
+                current = 7
+            if current < 8:
+                self._apply_v8(conn)
 
     def _apply_v1(self, conn: sqlite3.Connection) -> None:
         now = _utc_now_iso()
@@ -509,6 +515,32 @@ class ExecutionProfileStore:
         conn.execute(
             "INSERT INTO schema_migrations(version, applied_at) VALUES (?, ?)",
             (6, now),
+        )
+
+    def _apply_v7(self, conn: sqlite3.Connection) -> None:
+        now = _utc_now_iso()
+        conn.executescript(
+            """
+            CREATE INDEX IF NOT EXISTS idx_trigger_runs_routine_lookup
+                ON trigger_runs(trigger_id, status, reason, created_at);
+            """
+        )
+        conn.execute(
+            "INSERT INTO schema_migrations(version, applied_at) VALUES (?, ?)",
+            (7, now),
+        )
+
+    def _apply_v8(self, conn: sqlite3.Connection) -> None:
+        now = _utc_now_iso()
+        conn.executescript(
+            """
+            CREATE INDEX IF NOT EXISTS idx_trigger_runs_status_id
+                ON trigger_runs(status, id);
+            """
+        )
+        conn.execute(
+            "INSERT INTO schema_migrations(version, applied_at) VALUES (?, ?)",
+            (8, now),
         )
 
     def upsert_profile(self, profile: dict[str, Any], *, actor: str = "") -> None:
@@ -998,6 +1030,7 @@ class ExecutionProfileStore:
         self,
         trigger_id: str | None = None,
         *,
+        statuses: list[str] | tuple[str, ...] | None = None,
         limit: int = 50,
     ) -> list[dict[str, Any]]:
         self.migrate()
@@ -1006,9 +1039,16 @@ class ExecutionProfileStore:
             FROM trigger_runs
         """
         params: list[Any] = []
+        conditions = []
         if trigger_id:
-            query += " WHERE trigger_id = ?"
+            conditions.append("trigger_id = ?")
             params.append(trigger_id)
+        if statuses:
+            placeholders = ", ".join("?" for _status in statuses)
+            conditions.append(f"status IN ({placeholders})")
+            params.extend(statuses)
+        if conditions:
+            query += " WHERE " + " AND ".join(conditions)
         query += " ORDER BY id DESC LIMIT ?"
         params.append(limit)
         with self.connect() as conn:

--- a/result_server/utils/result_detail_view.py
+++ b/result_server/utils/result_detail_view.py
@@ -1,14 +1,15 @@
 from utils.result_records import build_labeled_value_rows, format_numeric_value
+from utils.trigger_display import summarize_execution_trigger
 
 
-def build_result_detail_context(result, quality):
+def build_result_detail_context(result, quality, trigger_runs_by_pipeline=None):
     profile_data = result.get("profile_data") or {}
     build_data = result.get("build") or {}
     vector_metrics = (result.get("metrics") or {}).get("vector")
     scalar_metrics = (result.get("metrics") or {}).get("scalar") or {}
 
     return {
-        "meta_rows": _build_meta_rows(result),
+        "meta_rows": _build_meta_rows(result, trigger_runs_by_pipeline),
         "profile_rows": _build_profile_rows(profile_data),
         "quality_rows": _build_quality_rows(quality),
         "vector_metrics": vector_metrics,
@@ -17,7 +18,8 @@ def build_result_detail_context(result, quality):
     }
 
 
-def _build_meta_rows(result):
+def _build_meta_rows(result, trigger_runs_by_pipeline=None):
+    trigger_summary = summarize_execution_trigger(result, trigger_runs_by_pipeline)
     rows = build_labeled_value_rows([
         ("Code", result.get("code", "N/A")),
         ("System", result.get("system", "N/A")),
@@ -25,6 +27,14 @@ def _build_meta_rows(result):
         ("FOM", format_numeric_value(result.get("FOM", "N/A"))),
         ("FOM Unit", result.get("FOM_unit") or "not specified"),
         ("Node Count", result.get("node_count", "N/A")),
+        (
+            "Run Cause",
+            (
+                f"{trigger_summary['headline']} ({trigger_summary['subline']})"
+                if trigger_summary.get("subline")
+                else trigger_summary["headline"]
+            ),
+        ),
     ])
 
     optional_rows = [

--- a/result_server/utils/result_table_rows.py
+++ b/result_server/utils/result_table_rows.py
@@ -8,9 +8,15 @@ from utils.result_records import (
     format_result_timestamp,
     summarize_result_quality,
 )
+from utils.trigger_display import summarize_execution_trigger
 
 
-def build_result_table_row(json_filename, result_data, padata_filenames):
+def build_result_table_row(
+    json_filename,
+    result_data,
+    padata_filenames,
+    trigger_runs_by_pipeline=None,
+):
     """Build a single row for the public/confidential results index table."""
     timestamp = format_result_timestamp(json_filename)
     matched_padata = _find_matching_padata_archive(json_filename, result_data, padata_filenames)
@@ -48,6 +54,10 @@ def build_result_table_row(json_filename, result_data, padata_filenames):
         "execution_mode": result_data.get("execution_mode", "-") or "-",
         "ci_trigger": ci_trigger,
         "ci_summary": f"{ci_trigger} / {pipeline_id}",
+        "execution_trigger_summary": summarize_execution_trigger(
+            result_data,
+            trigger_runs_by_pipeline,
+        ),
         "build_job": result_data.get("build_job", "-") or "-",
         "run_job": result_data.get("run_job", "-") or "-",
         "pipeline_id": pipeline_id,

--- a/result_server/utils/results_loader.py
+++ b/result_server/utils/results_loader.py
@@ -11,6 +11,7 @@ from utils.result_records import (
 from utils.result_table_rows import build_result_table_row
 from utils.table_filters import filters_are_active, matches_table_filters
 from utils.table_pagination import DEFAULT_PER_PAGE, normalize_per_page, paginate_list
+from utils.trigger_display import load_trigger_run_lookup
 
 RESULT_FIELD_MAP = {"system": "system", "code": "code", "exp": "Exp"}
 ESTIMATED_FIELD_MAP = {"system": "current_system.system", "code": "code", "exp": "exp"}
@@ -27,6 +28,7 @@ RESULT_TABLE_COLUMNS = [
     {"label": "P/N", "key": "numproc_node", "tooltip": "Number of processes per node"},
     {"label": "T/P", "key": "nthreads", "tooltip": "Number of threads per process"},
     {"label": "Profiler / PA", "key": "profile_summary", "tooltip": "Profiler tool, level, report summary, and PA data download access"},
+    {"label": "Run Cause", "key": "execution_trigger_summary", "tooltip": "Portal trigger metadata explaining why this benchmark run was launched"},
     {"label": "JSON", "key": "json_link", "tooltip": "Detailed benchmark results in JSON format", "tooltip_class": "tooltip-right"},
     {"label": "CI", "key": "ci_summary", "tooltip": "CI trigger source and pipeline ID"},
 ]
@@ -43,6 +45,7 @@ def load_results_table(
     filter_code=None,
     filter_exp=None,
     padata_directory=None,
+    execution_profile_db_path=None,
 ):
     per_page = normalize_per_page(per_page)
 
@@ -53,6 +56,7 @@ def load_results_table(
     padata_filenames = [filename for filename in os.listdir(padata_dir) if filename.endswith(".tgz")]
 
     columns = RESULT_TABLE_COLUMNS
+    trigger_runs_by_pipeline = load_trigger_run_lookup(execution_profile_db_path)
 
     has_filters = filters_are_active(filter_system, filter_code, filter_exp)
 
@@ -78,7 +82,14 @@ def load_results_table(
             result_data = load_result_json(filename, directory)
             if result_data is None:
                 continue
-            rows.append(build_result_table_row(filename, result_data, padata_filenames))
+            rows.append(
+                build_result_table_row(
+                    filename,
+                    result_data,
+                    padata_filenames,
+                    trigger_runs_by_pipeline,
+                )
+            )
 
         return rows, columns, pagination_info
 
@@ -101,7 +112,14 @@ def load_results_table(
             field_map=RESULT_FIELD_MAP,
         ):
             continue
-        rows.append(build_result_table_row(filename, result_data, padata_filenames))
+        rows.append(
+            build_result_table_row(
+                filename,
+                result_data,
+                padata_filenames,
+                trigger_runs_by_pipeline,
+            )
+        )
 
     paginated_rows, pagination_info = paginate_list(rows, page, per_page)
     return paginated_rows, columns, pagination_info

--- a/result_server/utils/trigger_display.py
+++ b/result_server/utils/trigger_display.py
@@ -1,0 +1,254 @@
+"""Display helpers for Portal-triggered benchmark execution metadata."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+
+def extract_execution_trigger(result: dict[str, Any] | None) -> dict[str, str]:
+    """Return a stable trigger metadata shape from a result JSON object."""
+    data = result if isinstance(result, dict) else {}
+    raw = data.get("execution_trigger") if isinstance(data, dict) else {}
+    raw = raw if isinstance(raw, dict) else {}
+    return {
+        "id": str(raw.get("id") or "").strip(),
+        "type": str(raw.get("type") or "").strip(),
+        "reason": str(raw.get("reason") or "").strip(),
+    }
+
+
+def load_trigger_run_lookup(db_path: str | None, *, limit: int = 500) -> dict[str, dict[str, Any]]:
+    """Load trigger runs keyed by GitLab pipeline id, when the Portal DB is available."""
+    if not db_path:
+        return {}
+    try:
+        try:
+            from utils.execution_profiles import ExecutionProfileStore
+        except ModuleNotFoundError:  # pragma: no cover - package import fallback
+            from result_server.utils.execution_profiles import ExecutionProfileStore
+
+        runs = ExecutionProfileStore(db_path).list_trigger_runs(
+            statuses=("submitted",),
+            limit=limit,
+        )
+    except (sqlite3.Error, OSError):
+        return {}
+    return build_trigger_run_lookup(runs)
+
+
+def build_trigger_run_lookup(runs: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Return latest trigger run by GitLab pipeline id."""
+    lookup: dict[str, dict[str, Any]] = {}
+    for run in runs:
+        for pipeline_id in _trigger_run_pipeline_ids(run):
+            if pipeline_id and pipeline_id not in lookup:
+                lookup[pipeline_id] = run
+    return lookup
+
+
+def build_trigger_result_links(
+    results_dir: str,
+    runs: list[dict[str, Any]],
+) -> dict[int, list[dict[str, str]]]:
+    """Return result summaries keyed by trigger run id."""
+    if not results_dir:
+        return {}
+    try:
+        filenames = sorted(
+            [name for name in _os_listdir(results_dir) if name.endswith(".json")],
+            reverse=True,
+        )
+    except OSError:
+        return {}
+
+    by_run_id: dict[int, list[dict[str, str]]] = {}
+    indexed_runs = [_index_trigger_run(run) for run in runs]
+    for filename in filenames:
+        result = _load_result_json(filename, results_dir)
+        if not isinstance(result, dict):
+            continue
+        for indexed in indexed_runs:
+            if _result_matches_trigger_run(result, indexed):
+                by_run_id.setdefault(indexed["id"], []).append(
+                    {
+                        "filename": filename,
+                        "label": _format_result_link_label(filename, result),
+                        "pipeline_id": str(result.get("pipeline_id") or ""),
+                    }
+                )
+    return by_run_id
+
+
+def summarize_execution_trigger(
+    result: dict[str, Any] | None,
+    trigger_runs_by_pipeline: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, str | bool]:
+    """Build a compact display summary for why a benchmark run was launched."""
+    trigger = extract_execution_trigger(result)
+    if not any(trigger.values()):
+        trigger = _execution_trigger_from_pipeline(result, trigger_runs_by_pipeline or {})
+    trigger_id = trigger["id"]
+    trigger_type = trigger["type"]
+    reason = trigger["reason"]
+    if not any((trigger_id, trigger_type, reason)):
+        return {
+            "has_trigger": False,
+            "headline": "-",
+            "subline": "",
+            "title": "No Portal trigger metadata was recorded for this result.",
+        }
+
+    headline = _format_trigger_type(trigger_type)
+    if trigger_id:
+        headline = f"{headline} / {trigger_id}" if headline != "Portal trigger" else trigger_id
+
+    subline = _format_trigger_reason(reason)
+    title_parts = []
+    if trigger_type:
+        title_parts.append(f"type={trigger_type}")
+    if trigger_id:
+        title_parts.append(f"id={trigger_id}")
+    if reason:
+        title_parts.append(f"reason={reason}")
+    return {
+        "has_trigger": True,
+        "headline": headline,
+        "subline": subline,
+        "title": "; ".join(title_parts),
+    }
+
+
+def summarize_trigger_run(run: dict[str, Any]) -> dict[str, Any]:
+    """Return template-ready trigger-run context extracted from run payload."""
+    payload = run.get("payload_json") if isinstance(run.get("payload_json"), dict) else {}
+    plan_payload = payload.get("payload") if isinstance(payload.get("payload"), dict) else {}
+    variables = plan_payload.get("variables") if isinstance(plan_payload.get("variables"), dict) else {}
+    errors = run.get("errors") if isinstance(run.get("errors"), list) else []
+    return {
+        "id": run.get("id"),
+        "trigger_id": run.get("trigger_id") or "-",
+        "trigger_type": run.get("trigger_type") or "-",
+        "status": run.get("status") or "-",
+        "dry_run": bool(run.get("dry_run")),
+        "reason": run.get("reason") or "-",
+        "reason_label": _format_trigger_reason(run.get("reason") or ""),
+        "created_at": run.get("created_at") or "-",
+        "actor": run.get("actor") or "-",
+        "gitlab_target": payload.get("gitlab_target") or "-",
+        "gitlab_project": payload.get("gitlab_project") or "-",
+        "target_ref": plan_payload.get("ref") or "-",
+        "code": variables.get("code") or "-",
+        "system": variables.get("system") or "-",
+        "allocation_project_id": variables.get("BK_ALLOCATION_PROJECT_ID") or "-",
+        "result_server": variables.get("RESULT_SERVER") or "-",
+        "pipeline_id": _trigger_run_pipeline_ids(run)[0] if _trigger_run_pipeline_ids(run) else "-",
+        "errors": errors,
+        "error_summary": "; ".join(str(error) for error in errors) if errors else "",
+    }
+
+
+def _index_trigger_run(run: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": int(run.get("id") or 0),
+        "trigger_id": str(run.get("trigger_id") or "").strip(),
+        "trigger_type": str(run.get("trigger_type") or "").strip(),
+        "reason": str(run.get("reason") or "").strip(),
+        "pipeline_ids": set(_trigger_run_pipeline_ids(run)),
+    }
+
+
+def _result_matches_trigger_run(result: dict[str, Any], run: dict[str, Any]) -> bool:
+    pipeline_id = str(result.get("pipeline_id") or "").strip()
+    if pipeline_id and pipeline_id in run["pipeline_ids"]:
+        return True
+    trigger = extract_execution_trigger(result)
+    if not trigger["id"]:
+        return False
+    if trigger["id"] != run["trigger_id"]:
+        return False
+    if trigger["type"] and trigger["type"] != run["trigger_type"]:
+        return False
+    return not trigger["reason"] or trigger["reason"] == run["reason"]
+
+
+def _format_result_link_label(filename: str, result: dict[str, Any]) -> str:
+    try:
+        from utils.result_records import format_result_timestamp
+    except ModuleNotFoundError:  # pragma: no cover - package import fallback
+        from result_server.utils.result_records import format_result_timestamp
+
+    parts = [
+        format_result_timestamp(filename),
+        str(result.get("Exp") or "").strip(),
+    ]
+    return " / ".join(part for part in parts if part)
+
+
+def _load_result_json(filename: str, results_dir: str) -> dict[str, Any] | None:
+    try:
+        from utils.result_records import load_result_json
+    except ModuleNotFoundError:  # pragma: no cover - package import fallback
+        from result_server.utils.result_records import load_result_json
+
+    return load_result_json(filename, results_dir)
+
+
+def _os_listdir(path: str) -> list[str]:
+    import os
+
+    return os.listdir(path)
+
+
+def _execution_trigger_from_pipeline(
+    result: dict[str, Any] | None,
+    trigger_runs_by_pipeline: dict[str, dict[str, Any]],
+) -> dict[str, str]:
+    data = result if isinstance(result, dict) else {}
+    pipeline_id = str(data.get("pipeline_id") or "").strip()
+    run = trigger_runs_by_pipeline.get(pipeline_id) if pipeline_id else None
+    if not run:
+        return {"id": "", "type": "", "reason": ""}
+    return {
+        "id": str(run.get("trigger_id") or "").strip(),
+        "type": str(run.get("trigger_type") or "").strip(),
+        "reason": str(run.get("reason") or "").strip(),
+    }
+
+
+def _trigger_run_pipeline_ids(run: dict[str, Any]) -> list[str]:
+    payload = run.get("payload_json") if isinstance(run.get("payload_json"), dict) else {}
+    submit = payload.get("submit") if isinstance(payload.get("submit"), dict) else {}
+    response = submit.get("response") if isinstance(submit.get("response"), dict) else {}
+    values = [response.get("id")]
+    child_ids = response.get("child_pipeline_ids")
+    if isinstance(child_ids, list):
+        values.extend(child_ids)
+    return [
+        str(value).strip()
+        for value in values
+        if value not in (None, "") and str(value).strip()
+    ]
+
+
+def _format_trigger_type(trigger_type: str) -> str:
+    mapping = {
+        "manual_button": "Manual",
+        "scheduled": "Scheduled",
+        "watch_event": "Watch event",
+    }
+    return mapping.get(trigger_type, "Portal trigger")
+
+
+def _format_trigger_reason(reason: str) -> str:
+    if not reason:
+        return ""
+    if reason.startswith("cron:"):
+        expr, _, due_minute = reason.removeprefix("cron:").partition("@")
+        return f"cron {expr} / {due_minute}" if due_minute else f"cron {expr}"
+    if reason.startswith("repo_ref:"):
+        target = reason.removeprefix("repo_ref:")
+        return f"repo/ref changed: {target}" if target else "repo/ref watch"
+    if reason.startswith("lock:"):
+        return f"runner lock: {reason.removeprefix('lock:')}"
+    return reason

--- a/scripts/result.sh
+++ b/scripts/result.sh
@@ -209,6 +209,18 @@ write_result_json() {
   \"pipeline_id\": $pipeline_id"
   fi
 
+  local execution_trigger_block=""
+  if [ -n "${BK_TRIGGER_ID:-}" ] || [ -n "${BK_TRIGGER_TYPE:-}" ] || [ -n "${BK_TRIGGER_REASON:-}" ]; then
+    local execution_trigger_json
+    execution_trigger_json=$(jq -n \
+      --arg id "${BK_TRIGGER_ID:-}" \
+      --arg type "${BK_TRIGGER_TYPE:-}" \
+      --arg reason "${BK_TRIGGER_REASON:-}" \
+      '{id: $id, type: $type, reason: $reason}')
+    execution_trigger_block=",
+  \"execution_trigger\": ${execution_trigger_json}"
+  fi
+
   # Attach the profiler summary that matches this FOM index. fapp exposes
   # counter events, while ncu exposes the Nsight Compute option preset.
   local profile_data_block=""
@@ -260,7 +272,7 @@ write_result_json() {
   "nthreads": "$nthreads",
   "description": "$description",
   "confidential": "$confidential",
-  "source_info": $source_info_block${profile_data_block}${fom_breakdown_block}${timing_block}${mode_block}${trigger_block}${build_job_block}${run_job_block}${pipeline_id_block}
+  "source_info": $source_info_block${profile_data_block}${fom_breakdown_block}${timing_block}${mode_block}${trigger_block}${build_job_block}${run_job_block}${pipeline_id_block}${execution_trigger_block}
 }
 EOF
 

--- a/scripts/tests/test_process_and_send_results.sh
+++ b/scripts/tests/test_process_and_send_results.sh
@@ -45,6 +45,9 @@ export PATH="${TMP_DIR}/bin:${PATH}"
 export RESULT_SERVER="https://example.invalid"
 export RESULT_SERVER_CLIENT_CERT="${TMP_DIR}/client.crt"
 export RESULT_SERVER_CLIENT_KEY="${TMP_DIR}/client.key"
+export BK_TRIGGER_ID="qws-fugaku-1400"
+export BK_TRIGGER_TYPE="scheduled"
+export BK_TRIGGER_REASON="cron:0 14 * * *@2026-08-07T14:00+09:00"
 
 pushd "${TMP_DIR}/project" >/dev/null
 bash scripts/result_server/process_and_send_results.sh qws Fugaku cross qws_Fugaku_build qws_Fugaku_N1_P2_T3_run 12345
@@ -56,6 +59,8 @@ test -f "${TMP_DIR}/project/send_results_workspace/results/server_result_meta.js
 test -f "${TMP_DIR}/project/send_results_workspace/results/pipeline_timing.json"
 
 jq -e '._server_uuid == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"' \
+  "${TMP_DIR}/project/send_results_workspace/results/result0.json" >/dev/null
+jq -e '.execution_trigger.id == "qws-fugaku-1400" and .execution_trigger.type == "scheduled"' \
   "${TMP_DIR}/project/send_results_workspace/results/result0.json" >/dev/null
 jq -e '."result0.json".uuid == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"' \
   "${TMP_DIR}/project/send_results_workspace/results/server_result_meta.json" >/dev/null

--- a/scripts/tests/test_result_profile_data.sh
+++ b/scripts/tests/test_result_profile_data.sh
@@ -87,7 +87,11 @@ EOF
 tar -czf "${TMP_DIR}/ncu/results/padata0.tgz" -C "${TMP_DIR}/ncu" bk_profiler_artifact
 
 pushd "${TMP_DIR}" >/dev/null
+export BK_TRIGGER_ID="qws-fugaku-watch"
+export BK_TRIGGER_TYPE="watch_event"
+export BK_TRIGGER_REASON="repo_ref:https://github.com/RIKEN-LQCD/qws.git@master"
 bash "${REPO_DIR}/scripts/result.sh" qws Fugaku cross build run 999 >/dev/null
+unset BK_TRIGGER_ID BK_TRIGGER_TYPE BK_TRIGGER_REASON
 popd >/dev/null
 
 pushd "${TMP_DIR}/ncu" >/dev/null
@@ -110,6 +114,9 @@ jq -e '
   .pipeline_timing.build_time == 12 and
   .pipeline_timing.queue_time == 0 and
   .pipeline_timing.run_time == 34 and
+  .execution_trigger.id == "qws-fugaku-watch" and
+  .execution_trigger.type == "watch_event" and
+  .execution_trigger.reason == "repo_ref:https://github.com/RIKEN-LQCD/qws.git@master" and
   (.profile_data.events | index("pa1") != null) and
   (.profile_data.report_kinds | index("summary_text") != null)
 ' "${RESULT_JSON}" >/dev/null


### PR DESCRIPTION
## Summary
- show Portal trigger causes in result tables and result details
- record trigger metadata in Result JSON and fall back to submitted trigger runs by pipeline id during rollout
- add admin trigger run history and repo/ref observations
- reduce routine trigger-run DB churn and avoid updating unchanged observations every timer tick

## Validation
- /home/nakamura/fugakunext/venv/bin/python result_server/tests/run_result_server_tests.py -q
- /home/nakamura/fugakunext/venv/bin/python -m pytest result_server/tests/test_execution_profiles.py result_server/tests/test_trigger_display.py result_server/tests/test_results_loader.py
- shellcheck -S error scripts/result.sh scripts/tests/test_result_profile_data.sh scripts/tests/test_process_and_send_results.sh
- dev2 DB migration to schema v8
- dev2 trigger runner routine check: trigger_runs unchanged and trigger_observations unchanged
- dev2 service restarted and active