### PR TITLE
Clarify profile allocation edit failures

### DIFF
--- a/result_server/routes/admin.py
+++ b/result_server/routes/admin.py
@@ -102,7 +102,12 @@ def _parse_execution_profile_form():
     system = _split_form_list(request.form.get("system", ""))
     allocation_project_id = request.form.get("allocation_project_id", "").strip()
     if allocation_project_id and len(system) != 1:
-        errors.append("allocation_project_id requires exactly one system")
+        system_label = ", ".join(system) if system else "none"
+        errors.append(
+            "allocation_project_id requires exactly one system; "
+            f"got {len(system)} ({system_label}). "
+            "Split the profile per system or keep only one system in this profile."
+        )
     if request.form.get("status", "").strip() == "approved" and not allocation_project_id:
         errors.append("approved profiles require allocation_project_id")
 
@@ -522,6 +527,9 @@ def upsert_execution_profile():
             details={"errors": errors},
         )
         flash("Execution profile was not saved: " + "; ".join(errors))
+        edit_profile_id = raw_profile.get("id", "").strip()
+        if edit_profile_id:
+            return redirect(url_for("admin.execution_profiles", edit=edit_profile_id))
         return redirect(url_for("admin.execution_profiles"))
 
     try:

--- a/result_server/templates/admin_execution_profiles.html
+++ b/result_server/templates/admin_execution_profiles.html
@@ -64,6 +64,12 @@
         width: 100%;
         box-sizing: border-box;
     }
+    .field-help {
+        color: #64748b;
+        font-size: 12px;
+        font-weight: 500;
+        line-height: 1.35;
+    }
     .profile-form .profile-form-wide {
         grid-column: 1 / -1;
     }
@@ -366,6 +372,7 @@
         <label>
             Allocation Project ID
             <input type="text" name="allocation_project_id" required placeholder="rkp00010" value="{{ edit_profile.allocation_project_id if edit_profile else '' }}">
+            <span class="field-help">This ID belongs to one system. Split multi-system profiles before assigning an allocation.</span>
         </label>
         <label>
             Valid From
@@ -382,6 +389,7 @@
         <label class="profile-form-wide">
             System
             <input type="text" name="system" placeholder="Fugaku" value="{{ edit_profile.system | join(', ') if edit_profile else '' }}">
+            <span class="field-help">Use a single system when Allocation Project ID is set.</span>
         </label>
         <label class="profile-form-wide">
             Exp Scope
@@ -506,7 +514,12 @@
                         / <span class="profile-mono">{{ profile.allocation_project_id or '-' }}</span>
                     </td>
                     <td class="profile-col-governance">
-                        {{ profile.activity or '-' }} / {{ profile.approved_by or '-' }} / {{ profile.valid_from or '-' }} to {{ profile.valid_until or '-' }}
+                        {{ profile.activity or '-' }} / {{ profile.approved_by or '-' }} /
+                        {% if profile.valid_from or profile.valid_until %}
+                        {{ profile.valid_from or 'open' }} to {{ profile.valid_until or 'open' }}
+                        {% else %}
+                        open-ended
+                        {% endif %}
                     </td>
                     <td>
                         <div class="profile-mini-actions">

--- a/result_server/tests/test_execution_profiles.py
+++ b/result_server/tests/test_execution_profiles.py
@@ -83,7 +83,7 @@ def _profile(**overrides):
         "allocation_project_id": "rkp00010",
         "scheduler_extra_args": "--account=site-local",
         "visibility": "public-results",
-        "valid_from": "2026-09-01",
+        "valid_from": "2026-01-01",
         "valid_until": "2027-03-31",
         "approved_by": "admin@test.com",
         "approved_at": "2026-09-01T00:00:00Z",
@@ -345,6 +345,48 @@ def test_trigger_runner_cron_matches_basic_fields():
     assert cron_matches("*/15 * * * *", now) == (True, [])
     assert cron_matches("0 2 * * *", now) == (False, [])
     assert cron_matches("0 2 *", now) == (False, ["cron expression must have 5 fields"])
+
+
+def test_trigger_runner_blocks_scheduled_trigger_outside_profile_period(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("RESULT_SERVER_GITLAB_REPO", "gitlab.example.org/group/benchkit.git")
+    db_path = tmp_path / "cx_portal.sqlite3"
+    store = ExecutionProfileStore(str(db_path))
+    store.upsert_profile(
+        _profile(system=["Fugaku"], valid_until="2000-01-01"),
+        actor="admin@test.com",
+    )
+    trigger, errors = normalize_trigger_definition(
+        {
+            "id": "qws-fugaku-1400",
+            "trigger_type": "scheduled",
+            "profile_id": "rikyu-qws-nightly",
+            "enabled": True,
+            "cron_expr": "0 10 * * *",
+            "timezone": "Asia/Tokyo",
+        }
+    )
+    assert errors == []
+    assert trigger is not None
+    store.upsert_trigger_definition(trigger, actor="admin@test.com")
+
+    evaluations = run_triggers(
+        db_path=str(db_path),
+        dry_run=False,
+        result_server_url="https://fncx.r-ccs.riken.jp/dev2",
+        submit=True,
+        now=datetime(2026, 8, 7, 1, 0, 15, tzinfo=UTC),
+        submit_pipeline=lambda plan, *, token: (_ for _ in ()).throw(AssertionError("submitted")),
+        use_lock=False,
+    )
+
+    assert evaluations[0].should_fire is False
+    assert evaluations[0].status == "blocked"
+    assert evaluations[0].errors == [
+        "execution profile expired on 2000-01-01: rikyu-qws-nightly"
+    ]
 
 
 def test_trigger_runner_scheduled_submit_is_deduped_per_due_minute(
@@ -794,6 +836,30 @@ def test_execution_profile_store_rejects_unapproved_or_disabled_matches(tmp_path
     assert result.errors == ["no approved execution profile matches target"]
 
 
+def test_execution_profile_store_rejects_profiles_outside_valid_period(tmp_path):
+    db_path = tmp_path / "cx_portal.sqlite3"
+    store = ExecutionProfileStore(str(db_path))
+    store.upsert_profile(
+        _profile(id="expired", valid_until="2000-01-01"),
+        actor="admin",
+    )
+    store.upsert_profile(
+        _profile(id="future", valid_from="2999-01-01"),
+        actor="admin",
+    )
+
+    expired = store.resolve_profile(profile_id="expired", code="qws", system="RIKYU")
+    future = store.resolve_profile(profile_id="future", code="qws", system="RIKYU")
+    inferred = store.resolve_profile(code="qws", system="RIKYU")
+
+    assert expired.profile is None
+    assert expired.errors == ["execution profile expired on 2000-01-01: expired"]
+    assert future.profile is None
+    assert future.errors == ["execution profile is not active until 2999-01-01: future"]
+    assert inferred.profile is None
+    assert inferred.errors == ["no approved execution profile matches target"]
+
+
 def test_execution_profile_store_reports_ambiguous_matching_profiles(tmp_path):
     db_path = tmp_path / "cx_portal.sqlite3"
     store = ExecutionProfileStore(str(db_path))
@@ -930,6 +996,15 @@ def test_admin_execution_profiles_renders_profile_summary(tmp_path):
         _profile(),
         actor="admin@test.com",
     )
+    ExecutionProfileStore(str(db_path)).upsert_profile(
+        _profile(
+            id="qws-fugaku",
+            allocation_project_id="test",
+            valid_from="",
+            valid_until="",
+        ),
+        actor="admin@test.com",
+    )
     app, temp_dirs = _admin_app(db_path)
     try:
         with app.test_client() as client:
@@ -948,6 +1023,7 @@ def test_admin_execution_profiles_renders_profile_summary(tmp_path):
         assert "admin@test.com" in html
         assert "qws" in html
         assert "RIKYU" in html
+        assert "open-ended" in html
         assert 'href="/admin/execution-profiles?edit=rikyu-qws-nightly"' in html
         assert 'name="profile_id" value="rikyu-qws-nightly"' in html
         assert 'name="target_ref" value="main"' in html
@@ -1217,6 +1293,16 @@ def test_admin_execution_profiles_edit_link_prefills_form(tmp_path):
 
 def test_admin_execution_profiles_rejects_allocation_without_single_system(tmp_path):
     db_path = tmp_path / "cx_portal.sqlite3"
+    store = ExecutionProfileStore(str(db_path))
+    store.upsert_profile(
+        _profile(
+            id="bad-allocation-scope",
+            status="draft",
+            allocation_project_id="",
+            system=["Fugaku", "MiyabiG"],
+        ),
+        actor="admin@test.com",
+    )
     app, temp_dirs = _admin_app(db_path)
     try:
         with app.test_client() as client:
@@ -1235,8 +1321,10 @@ def test_admin_execution_profiles_rejects_allocation_without_single_system(tmp_p
 
         result = load_execution_profiles(str(db_path))
         assert resp.status_code == 200
-        assert b"allocation_project_id requires exactly one system" in resp.data
-        assert result.profiles == []
+        assert b"allocation_project_id requires exactly one system; got 2 (Fugaku, MiyabiG)" in resp.data
+        assert b"Split the profile per system or keep only one system in this profile" in resp.data
+        assert b'name="id" required placeholder="qws-fugaku-rkp00010" value="bad-allocation-scope"' in resp.data
+        assert result.profiles[0]["allocation_project_id"] == ""
     finally:
         _cleanup(temp_dirs)
 

--- a/result_server/trigger_runner.py
+++ b/result_server/trigger_runner.py
@@ -182,8 +182,12 @@ def _build_trigger_plan(
     *,
     result_server_url: str,
     trigger_reason: str,
+    now: datetime,
 ) -> tuple[dict, list[str]]:
-    profile_result = store.resolve_profile(profile_id=trigger.get("profile_id", ""))
+    profile_result = store.resolve_profile(
+        profile_id=trigger.get("profile_id", ""),
+        today=now.date().isoformat(),
+    )
     profile = profile_result.profile
     gitlab_target, target_errors = configured_gitlab_target(trigger.get("gitlab_target", ""))
     target_ref = trigger.get("target_ref") or os.environ.get("RESULT_SERVER_GITLAB_REF", "develop")
@@ -259,6 +263,7 @@ def evaluate_scheduled_trigger(
         trigger,
         result_server_url=result_server_url,
         trigger_reason=reason,
+        now=now,
     )
     errors = timezone_errors + cron_errors + plan_errors
     should_fire = due_slot is not None and not errors
@@ -334,6 +339,7 @@ def evaluate_repo_ref_trigger(
         trigger,
         result_server_url=result_server_url,
         trigger_reason=reason,
+        now=now,
     )
     errors.extend(plan_errors)
     status = "would_submit" if should_fire and not errors else "unchanged"

--- a/result_server/utils/execution_profiles.py
+++ b/result_server/utils/execution_profiles.py
@@ -108,6 +108,21 @@ def _json_dump_list(value: Any) -> str:
     return json.dumps(value or [], ensure_ascii=False, sort_keys=True)
 
 
+def _profile_validity_error(profile: dict[str, Any], *, today: str | None = None) -> str:
+    current = today or datetime.now(UTC).date().isoformat()
+    valid_from = str(profile.get("valid_from") or "").strip()
+    valid_until = str(profile.get("valid_until") or "").strip()
+    if valid_from and valid_from > current:
+        return f"execution profile is not active until {valid_from}: {profile.get('id', '')}"
+    if valid_until and valid_until < current:
+        return f"execution profile expired on {valid_until}: {profile.get('id', '')}"
+    return ""
+
+
+def _profile_is_current(profile: dict[str, Any], *, today: str | None = None) -> bool:
+    return not _profile_validity_error(profile, today=today)
+
+
 def _as_watch_targets(value: Any) -> list[str]:
     if isinstance(value, str):
         stripped = value.strip()
@@ -1198,6 +1213,7 @@ class ExecutionProfileStore:
         code: str = "",
         system: str = "",
         exp: str = "",
+        today: str | None = None,
     ) -> ExecutionProfileResolveResult:
         """Resolve one enabled and approved profile for a target execution."""
         target_id = profile_id.strip()
@@ -1207,7 +1223,7 @@ class ExecutionProfileStore:
             if profile.get("enabled", True) and profile.get("status") == "approved"
         ]
         if target_id:
-            matches = [
+            scoped_matches = [
                 profile
                 for profile in profiles
                 if profile.get("id") == target_id
@@ -1215,6 +1231,20 @@ class ExecutionProfileStore:
                 and _scope_matches(profile.get("system", []), system)
                 and _scope_matches(profile.get("exp", []), exp)
             ]
+            validity_errors = [
+                error
+                for error in (
+                    _profile_validity_error(profile, today=today)
+                    for profile in scoped_matches
+                )
+                if error
+            ]
+            if validity_errors:
+                return ExecutionProfileResolveResult(
+                    profile=None,
+                    errors=validity_errors,
+                )
+            matches = [profile for profile in scoped_matches if _profile_is_current(profile, today=today)]
             if not matches:
                 return ExecutionProfileResolveResult(
                     profile=None,
@@ -1225,7 +1255,8 @@ class ExecutionProfileStore:
         matches = [
             profile
             for profile in profiles
-            if _scope_matches(profile.get("code", []), code)
+            if _profile_is_current(profile, today=today)
+            and _scope_matches(profile.get("code", []), code)
             and _scope_matches(profile.get("system", []), system)
             and _scope_matches(profile.get("exp", []), exp)
         ]


### PR DESCRIPTION
## Summary
- explain that allocation_project_id can only be saved for a single-system profile
- redirect rejected profile updates back to the edited profile instead of the profile list
- add inline help around allocation/system fields

## Validation
- /home/nakamura/fugakunext/venv/bin/python -m pytest result_server/tests/test_execution_profiles.py -q
- /home/nakamura/fugakunext/venv/bin/python result_server/tests/run_result_server_tests.py -q
- git diff --check