### PR TITLE
Derive Slurm account args from allocation project

### DIFF
--- a/.github/workflows/result-server-tests.yml
+++ b/.github/workflows/result-server-tests.yml
@@ -19,6 +19,7 @@ on:
       - "scripts/tests/test_genesis_gpu_mlp_estimation.sh"
       - "scripts/tests/test_result_profile_data.sh"
       - "scripts/tests/test_process_and_send_results.sh"
+      - "scripts/tests/test_scheduler_extra_args.sh"
       - "scripts/tests/test_send_estimate_artifacts.sh"
       - "scripts/tests/test_send_results_profile_data.sh"
       - "scripts/test_estimate_submit.sh"
@@ -51,6 +52,7 @@ on:
       - "scripts/tests/test_genesis_gpu_mlp_estimation.sh"
       - "scripts/tests/test_result_profile_data.sh"
       - "scripts/tests/test_process_and_send_results.sh"
+      - "scripts/tests/test_scheduler_extra_args.sh"
       - "scripts/tests/test_send_estimate_artifacts.sh"
       - "scripts/tests/test_send_results_profile_data.sh"
       - "scripts/test_estimate_submit.sh"
@@ -130,6 +132,7 @@ jobs:
           bash scripts/tests/test_ncu_plan_generation.sh
           bash scripts/tests/test_result_profile_data.sh
           bash scripts/tests/test_process_and_send_results.sh
+          bash scripts/tests/test_scheduler_extra_args.sh
           bash scripts/tests/test_send_results_profile_data.sh
           bash scripts/tests/test_send_estimate_artifacts.sh
           bash scripts/tests/test_estimation_gpu_kernel_ensemble_average.sh

--- a/config/queue.csv
+++ b/config/queue.csv
@@ -2,7 +2,7 @@ queue,submit_cmd,template
 SLURM_RIKYU,sbatch,"-p ${queue_group} ${scheduler_extra_args} -t ${elapse} -N ${nodes} --ntasks-per-node=${numproc_node} --cpus-per-task=${nthreads} --gpus=${proc}"
 FJ,pjsub,"-L rscunit=rscunit_ft01,rscgrp=${queue_group},elapse=${elapse},node=${nodes} --mpi max-proc-per-node=${numproc_node} -x PJM_LLIO_GFSCACHE=/vol0002:/vol0003:/vol0004:/vol0005"
 PJM_GENKAI,pjsub,"-L rscgrp=${queue_group},elapse=${elapse},node=${nodes} --mpi proc=${proc}"
-SLURM_RC,sbatch,"-p ${queue_group} -t ${elapse} -N ${nodes} --ntasks-per-node=${numproc_node} --cpus-per-task=${nthreads}"
+SLURM_RC,sbatch,"-p ${queue_group} ${scheduler_extra_args} -t ${elapse} -N ${nodes} --ntasks-per-node=${numproc_node} --cpus-per-task=${nthreads}"
 PBS_Miyabi,qsub,"-q ${queue_group} -l select=${nodes}:mpiprocs=${numproc_node}:ompthreads=${nthreads} -l walltime=${elapse} -W group_list=jh260034"
 PBS_Grand_C,qsub,"-q ${queue_group} -l select=${nodes}:nsockets=${cpu_per_node},walltime=${elapse} -W group_list=d30992"
 PBS_Grand_G,qsub,"-q ${queue_group} -l select=${nodes}:ngpus=1,walltime=${elapse} -W group_list=d30992"

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -71,6 +71,7 @@ The workflow accepts these inputs:
 | `target_ref` | Branch, tag, or SHA in the upstream repository to test / upstreamリポジトリ内でテストするbranch、tag、SHA | `feature/my-change`, `ci/pr-123`, `develop` |
 | `code` | BenchKit program filter / BenchKitプログラムのフィルタ | `qws,genesis` |
 | `system` | BenchKit system filter. Legacy BenchPark bridge jobs in this repo do not honor this as a general system selector. / BenchKit systemフィルタ。このrepo内のlegacy BenchPark bridge jobは汎用system selectorとしては扱いません | `Fugaku,MiyabiG` |
+| `BK_ALLOCATION_PROJECT_ID` | Optional semantic project/allocation ID supplied by the Portal. BenchKit translates it to scheduler syntax only for systems that require it, for example Slurm `--account=<id>` on RIKYU. / Portal が渡す任意の意味的な project/allocation ID。BenchKit は必要な system に限って scheduler 書式へ変換します。例: RIKYU の Slurm `--account=<id>` | `rkp00010` |
 | `app` | Legacy BenchPark bridge app filter. Active BenchPark CI/CD/CB result handling is maintained in a separate project. / legacy BenchPark bridge appフィルタ。現行BenchPark CI/CD/CB結果受け取りは別プロジェクト側で管理します | `osu-micro-benchmarks` |
 | `benchpark` | Enable the legacy BenchPark bridge path together with BenchKit / legacy BenchPark bridge pathも有効化 | `true` |
 | `park_only` | Run only the legacy BenchPark bridge path / legacy BenchPark bridgeのみ実行 | `true` |

--- a/docs/guides/portal-execution-profiles-handoff.md
+++ b/docs/guides/portal-execution-profiles-handoff.md
@@ -69,8 +69,12 @@ The current GitLab CI entry point consumes `code`, `system`, and the resolved
 allocation project ID. Execution profile fields such as `exp` remain
 Portal-side matching and audit metadata until the GitLab matrix generator grows
 a matching selector. Scheduler-specific command-line formatting belongs to the
-BenchKit CI generation layer, not to Portal profile records. BenchPark bridge
-controls in this repository are legacy; active BenchPark CI/CD/CB result
+BenchKit CI generation layer, not to Portal profile records. Allocation project
+ID is optional. Slurm systems that require an explicit charged project, such as
+RIKYU, derive `--account=<BK_ALLOCATION_PROJECT_ID>` when the value is present,
+unless a site-local `BK_SCHEDULER_EXTRA_ARGS*` override is already set. Systems
+without such a scheduler requirement should leave the field empty. BenchPark
+bridge controls in this repository are legacy; active BenchPark CI/CD/CB result
 handling has moved to a separate project.
 
 ## GitLab Pipeline Trigger Configuration

--- a/result_server/routes/admin.py
+++ b/result_server/routes/admin.py
@@ -108,9 +108,6 @@ def _parse_execution_profile_form():
             f"got {len(system)} ({system_label}). "
             "Split the profile per system or keep only one system in this profile."
         )
-    if request.form.get("status", "").strip() == "approved" and not allocation_project_id:
-        errors.append("approved profiles require allocation_project_id")
-
     actor = session.get("user_email", "")
     raw_profile = {
         "id": request.form.get("id", "").strip(),
@@ -291,8 +288,6 @@ def _build_execution_pipeline_plan(store):
     request_errors = []
     if not profile_id:
         request_errors.append("profile_id is required")
-    if profile and not resolve_result.allocation_project_id:
-        request_errors.append("profile allocation_project_id is required")
     if effective_exp:
         plan.warnings.append(
             "Profile Exp is used for Portal profile matching and is not sent to GitLab CI."

--- a/result_server/templates/admin_execution_profiles.html
+++ b/result_server/templates/admin_execution_profiles.html
@@ -371,8 +371,8 @@
         </label>
         <label>
             Allocation Project ID
-            <input type="text" name="allocation_project_id" required placeholder="rkp00010" value="{{ edit_profile.allocation_project_id if edit_profile else '' }}">
-            <span class="field-help">This ID belongs to one system. Split multi-system profiles before assigning an allocation.</span>
+            <input type="text" name="allocation_project_id" placeholder="rkp00010" value="{{ edit_profile.allocation_project_id if edit_profile else '' }}">
+            <span class="field-help">Optional. When set, this ID belongs to one system. BenchKit enables scheduler-specific account options only where supported.</span>
         </label>
         <label>
             Valid From

--- a/result_server/tests/test_execution_profiles.py
+++ b/result_server/tests/test_execution_profiles.py
@@ -1283,7 +1283,7 @@ def test_admin_execution_profiles_edit_link_prefills_form(tmp_path):
         assert "Edit Profile" in html
         assert 'name="id" required placeholder="qws-fugaku-rkp00010" value="qws-fugaku"' in html
         assert 'name="activity" placeholder="FugakuNEXT" value="CX"' in html
-        assert 'name="allocation_project_id" required placeholder="rkp00010" value="rkp00010"' in html
+        assert 'name="allocation_project_id" placeholder="rkp00010" value="rkp00010"' in html
         assert 'name="system" placeholder="Fugaku" value="Fugaku"' in html
         assert "qws</textarea>" in html
         assert "Cancel Edit" in html
@@ -1329,7 +1329,7 @@ def test_admin_execution_profiles_rejects_allocation_without_single_system(tmp_p
         _cleanup(temp_dirs)
 
 
-def test_admin_execution_profiles_rejects_approved_profile_without_allocation(tmp_path):
+def test_admin_execution_profiles_allows_approved_profile_without_allocation(tmp_path):
     db_path = tmp_path / "cx_portal.sqlite3"
     app, temp_dirs = _admin_app(db_path)
     try:
@@ -1348,8 +1348,9 @@ def test_admin_execution_profiles_rejects_approved_profile_without_allocation(tm
 
         result = load_execution_profiles(str(db_path))
         assert resp.status_code == 200
-        assert b"approved profiles require allocation_project_id" in resp.data
-        assert result.profiles == []
+        assert b"approved profiles require allocation_project_id" not in resp.data
+        assert result.profiles[0]["id"] == "missing-allocation"
+        assert result.profiles[0]["allocation_project_id"] == ""
     finally:
         _cleanup(temp_dirs)
 
@@ -1507,7 +1508,7 @@ def test_admin_execution_profiles_dry_run_blocks_without_matching_profile(
         _cleanup(temp_dirs)
 
 
-def test_admin_execution_profiles_dry_run_blocks_profile_without_allocation(
+def test_admin_execution_profiles_dry_run_allows_profile_without_allocation(
     tmp_path,
     monkeypatch,
 ):
@@ -1532,10 +1533,12 @@ def test_admin_execution_profiles_dry_run_blocks_profile_without_allocation(
         assert resp.status_code == 200
         with sqlite3.connect(db_path) as conn:
             row = conn.execute(
-                "SELECT status, errors_json FROM execution_requests"
+                "SELECT status, errors_json, payload_json FROM execution_requests"
             ).fetchone()
-        assert row[0] == "dry_run_blocked"
-        assert "profile allocation_project_id is required" in json.loads(row[1])
+        assert row[0] == "dry_run_ready"
+        assert json.loads(row[1]) == []
+        variables = json.loads(row[2])["payload"]["variables"]
+        assert "BK_ALLOCATION_PROJECT_ID" not in variables
     finally:
         _cleanup(temp_dirs)
 

--- a/result_server/trigger_runner.py
+++ b/result_server/trigger_runner.py
@@ -215,8 +215,6 @@ def _build_trigger_plan(
         "payload": plan_payload,
     }
     errors = list(profile_result.errors) + target_errors + plan.errors
-    if profile and not profile_result.allocation_project_id:
-        errors.append("profile allocation_project_id is required")
     return payload, errors
 
 

--- a/scripts/job_functions.sh
+++ b/scripts/job_functions.sh
@@ -66,17 +66,37 @@ get_system_queue_group() {
 
 # Return optional site-local scheduler arguments.
 #
-# These values are intentionally not stored in system.csv/queue.csv because
-# project/account/group options can vary by deployment or runner. The variable
-# must be visible where matrix_generate.sh runs, because generated GitLab jobs
-# embed SCHEDULER_PARAMETERS before the target runner submits the scheduler job.
+# Explicit BK_SCHEDULER_EXTRA_ARGS values remain site-local overrides. When no
+# explicit override is set, BenchKit derives scheduler arguments only for
+# systems whose submit syntax is known to require the semantic allocation
+# project ID supplied by the Portal.
 get_scheduler_extra_args() {
     local system="$1"
     local system_key
     local system_var
+    local explicit_args
     system_key=$(printf '%s' "$system" | tr -c '[:alnum:]_' '_')
     system_var="BK_SCHEDULER_EXTRA_ARGS_${system_key}"
-    printf '%s\n' "${!system_var:-${BK_SCHEDULER_EXTRA_ARGS:-}}"
+    explicit_args="${!system_var:-${BK_SCHEDULER_EXTRA_ARGS:-}}"
+    if [[ -n "$explicit_args" ]]; then
+        printf '%s\n' "$explicit_args"
+        return 0
+    fi
+    scheduler_args_from_allocation_project "$system" "${BK_ALLOCATION_PROJECT_ID:-}"
+    return 0
+}
+
+scheduler_args_from_allocation_project() {
+    local system="$1"
+    local allocation_project_id="$2"
+    if [[ -z "$allocation_project_id" ]]; then
+        return 0
+    fi
+    case "$system" in
+      RIKYU)
+        printf '%s\n' "--account=${allocation_project_id}"
+        ;;
+    esac
     return 0
 }
 

--- a/scripts/test_submit.sh
+++ b/scripts/test_submit.sh
@@ -233,9 +233,9 @@ case "$system" in
 	   --wrap="bash programs/${code}/run.sh $system $nodes $numproc_node $nthreads"
     ;;
   RC_GH200|RC_DGXSP|RC_GENOA|RC_FX700)
-    echo sbatch -p $queue_group -N $nodes -t $elapse --ntasks-per-node=${numproc_node} --cpus-per-task=$nthreads \
+    echo sbatch -p $queue_group "${scheduler_extra_args_array[@]}" -N $nodes -t $elapse --ntasks-per-node=${numproc_node} --cpus-per-task=$nthreads \
 	 --wrap="bash programs/$code/run.sh $system $nodes $numproc_node $nthreads"
-    sbatch -p $queue_group -N $nodes -t $elapse --ntasks-per-node=${numproc_node} --cpus-per-task=$nthreads \
+    sbatch -p $queue_group "${scheduler_extra_args_array[@]}" -N $nodes -t $elapse --ntasks-per-node=${numproc_node} --cpus-per-task=$nthreads \
 	   --wrap="bash programs/${code}/run.sh $system $nodes $numproc_node $nthreads"
     ;;
   MiyabiC)

--- a/scripts/test_submit_build.sh
+++ b/scripts/test_submit_build.sh
@@ -84,6 +84,8 @@ fi
 
 mode=$(get_system_mode "$system")
 queue_group=$(get_system_queue_group "$system")
+scheduler_extra_args=$(get_scheduler_extra_args "$system")
+read -r -a scheduler_extra_args_array <<< "$scheduler_extra_args"
 
 if [[ -z "$mode" || -z "$queue_group" ]]; then
   echo "Error: mode or queue_group not found for system=$system in $SYSTEM_FILE"
@@ -102,12 +104,15 @@ echo "  run_nodes=$run_nodes, run_numproc_node=$run_numproc_node, run_nthreads=$
 echo ""
 echo "Build submission values:"
 echo "  nodes=$build_nodes, ntasks_per_node=1, cpus_per_task=$build_cpus_per_task"
+if [[ -n "$scheduler_extra_args" ]]; then
+    echo "  scheduler_extra_args=$scheduler_extra_args (from BK_SCHEDULER_EXTRA_ARGS*, or BK_ALLOCATION_PROJECT_ID for supported systems)"
+fi
 
 case "$system" in
   RC_GH200|RC_DGXSP|RC_GENOA)
-    echo sbatch -p "$queue_group" -N "$build_nodes" -t "$elapse" --ntasks-per-node=1 --cpus-per-task="$build_cpus_per_task" \
+    echo sbatch "${scheduler_extra_args_array[@]}" -p "$queue_group" -N "$build_nodes" -t "$elapse" --ntasks-per-node=1 --cpus-per-task="$build_cpus_per_task" \
       --wrap="bash programs/$code/build.sh $system"
-    sbatch -p "$queue_group" -N "$build_nodes" -t "$elapse" --ntasks-per-node=1 --cpus-per-task="$build_cpus_per_task" \
+    sbatch "${scheduler_extra_args_array[@]}" -p "$queue_group" -N "$build_nodes" -t "$elapse" --ntasks-per-node=1 --cpus-per-task="$build_cpus_per_task" \
       --wrap="bash programs/${code}/build.sh $system"
     ;;
   *)

--- a/scripts/tests/test_scheduler_extra_args.sh
+++ b/scripts/tests/test_scheduler_extra_args.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_DIR=$(cd "${SCRIPT_DIR}/../.." && pwd)
+
+pushd "${REPO_DIR}" >/dev/null
+source ./scripts/job_functions.sh
+
+export BK_ALLOCATION_PROJECT_ID="rkp00010"
+unset BK_SCHEDULER_EXTRA_ARGS
+unset BK_SCHEDULER_EXTRA_ARGS_RIKYU
+unset BK_SCHEDULER_EXTRA_ARGS_RC_GH200
+
+test "$(get_scheduler_extra_args RIKYU)" = "--account=rkp00010"
+test "$(get_scheduler_extra_args RC_GH200)" = ""
+test "$(get_scheduler_extra_args Fugaku)" = ""
+
+export BK_SCHEDULER_EXTRA_ARGS_RIKYU="--account=explicit-rikyu"
+test "$(get_scheduler_extra_args RIKYU)" = "--account=explicit-rikyu"
+
+unset BK_SCHEDULER_EXTRA_ARGS_RIKYU
+export BK_SCHEDULER_EXTRA_ARGS="--account=global"
+test "$(get_scheduler_extra_args RIKYU)" = "--account=global"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+cat >"$tmpdir/sbatch" <<'SCRIPT'
+#!/bin/bash
+printf '%s\n' "$*" >"${BK_TEST_SBATCH_ARGS_FILE:?}"
+SCRIPT
+chmod +x "$tmpdir/sbatch"
+
+export PATH="$tmpdir:$PATH"
+export BK_TEST_SBATCH_ARGS_FILE="$tmpdir/sbatch.args"
+export BK_ALLOCATION_PROJECT_ID="rkp00010"
+unset BK_SCHEDULER_EXTRA_ARGS
+unset BK_SCHEDULER_EXTRA_ARGS_RIKYU
+unset BK_SCHEDULER_EXTRA_ARGS_RC_GH200
+
+bash scripts/test_submit_build.sh qws 5 >/dev/null
+if grep -q -- "--account=rkp00010" "$BK_TEST_SBATCH_ARGS_FILE"; then
+    echo "RC_GH200 must not derive --account from BK_ALLOCATION_PROJECT_ID" >&2
+    exit 1
+fi
+
+export BK_SCHEDULER_EXTRA_ARGS_RC_GH200="--account=explicit-rc"
+bash scripts/test_submit_build.sh qws 5 >/dev/null
+grep -q -- "--account=explicit-rc" "$BK_TEST_SBATCH_ARGS_FILE"
+
+popd >/dev/null
+
+echo "scheduler extra args test passed"


### PR DESCRIPTION
## Summary

Derive scheduler account arguments from the Portal allocation project ID only where the system submit syntax is known to require it.

## Details

- Keep Portal execution profiles scheduler-agnostic: profiles store the semantic `allocation_project_id`, not scheduler command-line fragments.
- Translate `BK_ALLOCATION_PROJECT_ID` to Slurm `--account=<id>` for RIKYU.
- Leave RC cloud systems without derived `--account`; they can still use explicit site-local `BK_SCHEDULER_EXTRA_ARGS*` overrides if needed.
- Allow approved Portal profiles to leave `allocation_project_id` empty.
- Add shell coverage for derived RIKYU args, RC no-op behavior, and explicit RC override behavior.

## Validation

- `bash scripts/tests/test_scheduler_extra_args.sh`
- `shellcheck -S error scripts/job_functions.sh scripts/test_submit.sh scripts/test_submit_build.sh scripts/tests/test_scheduler_extra_args.sh scripts/tests/test_result_profile_data.sh scripts/tests/test_process_and_send_results.sh`
- `git diff --check`
- `/home/nakamura/fugakunext/venv/bin/python result_server/tests/run_result_server_tests.py -q`
- `BK_ALLOCATION_PROJECT_ID=test bash scripts/matrix_generate.sh`
