### PR TITLE
Show missing trigger target refs

### DIFF
--- a/result_server/templates/admin_execution_profiles.html
+++ b/result_server/templates/admin_execution_profiles.html
@@ -192,6 +192,13 @@
         color: #991b1b;
         font-weight: 700;
     }
+    .trigger-target-warning {
+        display: block;
+        margin-top: 2px;
+        color: #991b1b;
+        font-size: 12px;
+        font-weight: 700;
+    }
     .trigger-observation-table {
         table-layout: fixed;
         min-width: 900px;
@@ -661,6 +668,9 @@
                     <td>
                         <span class="profile-mono">{{ trigger.gitlab_target or 'default' }}</span>
                         / <span class="profile-mono">{{ trigger.target_ref or default_target_ref }}</span>
+                        {% if not trigger.target_ref %}
+                        <span class="trigger-target-warning">ref not set</span>
+                        {% endif %}
                     </td>
                     <td>{% if trigger.enabled %}enabled{% else %}disabled{% endif %}</td>
                     <td>

--- a/result_server/tests/test_execution_profiles.py
+++ b/result_server/tests/test_execution_profiles.py
@@ -1346,6 +1346,7 @@ def test_admin_execution_profiles_edits_pauses_resumes_and_deletes_trigger(tmp_p
         assert edit_resp.status_code == 200
         assert "Edit Trigger" in edit_html
         assert 'name="id" required placeholder="qws-fugaku-nightly" value="rikyu-qws-nightly"' in edit_html
+        assert "ref not set" in edit_html
         assert pause_resp.status_code == 200
         assert b"Trigger definition rikyu-qws-nightly paused." in pause_resp.data
         assert resume_resp.status_code == 200


### PR DESCRIPTION
## Summary

- Show a warning in Registered Triggers when a trigger has no stored `target_ref`.
- Add a regression assertion for the admin trigger table warning.

## Why

The previous safety fix blocks missing trigger refs at runner time. This makes the same configuration issue visible in the admin UI before a trigger run reaches the runner.

## Validation

- `.venv/bin/python result_server/tests/run_result_server_tests.py result_server/tests/test_execution_profiles.py result_server/tests/test_trigger_display.py`
- `.venv/bin/python result_server/tests/check_site_config.py`
- `git diff --check`
