### PR TITLE
Show latest snapshot in profile usage overview

### DIFF
--- a/result_server/templates/_usage_report_profile_overview_section.html
+++ b/result_server/templates/_usage_report_profile_overview_section.html
@@ -69,6 +69,13 @@
             <a href="{{ url_for('results.result_detail', filename=row.latest_result.filename) }}">{{ row.latest_result.timestamp }}</a>
             <span class="profile-usage-subline">{{ row.latest_result.code }} / {{ row.latest_result.system }} / {{ row.latest_result.exp }}</span>
             <span class="profile-usage-subline">{{ row.latest_result.trigger_headline }} / pipeline {{ row.latest_result.pipeline_id }}</span>
+            {% if row.latest_result.environment_snapshot %}
+            <span class="profile-usage-subline" title="{{ row.latest_result.environment_snapshot.hash }}">
+              snapshot {{ row.latest_result.environment_snapshot.short_hash }}
+              / {{ row.latest_result.environment_snapshot.allocation_project_id }}
+              / {{ row.latest_result.environment_snapshot.scheduler }}
+            </span>
+            {% endif %}
             {% else %}
             -
             {% endif %}

--- a/result_server/tests/test_profile_usage_overview.py
+++ b/result_server/tests/test_profile_usage_overview.py
@@ -79,6 +79,15 @@ def test_profile_usage_overview_links_profile_triggers_results_and_node_hours(tm
                     "type": "scheduled",
                     "reason": "cron:0 14 * * *@2026-08-10T14:00+09:00",
                 },
+                "environment_snapshot": {
+                    "hash": "sha256:54d4b0024f2e58b62b80cc5ca2b86f522fa69fee381c5a15e4cf37168debe7fb",
+                    "summary": {
+                        "system": "Fugaku",
+                        "allocation_project_id": "rkp00010",
+                        "scheduler": "pbs",
+                        "runner": "fugaku-runner",
+                    },
+                },
             }
         ),
         encoding="utf-8",
@@ -101,6 +110,8 @@ def test_profile_usage_overview_links_profile_triggers_results_and_node_hours(tm
     assert row["latest_trigger_run"]["status"] == "submitted"
     assert row["latest_result"]["filename"] == result_file
     assert row["latest_result"]["trigger_headline"] == "Scheduled / qws-fugaku-time"
+    assert row["latest_result"]["environment_snapshot"]["short_hash"] == "sha256:54d4b0024f..."
+    assert row["latest_result"]["environment_snapshot"]["allocation_project_id"] == "rkp00010"
 
 
 def test_profile_usage_overview_handles_missing_db(tmp_path):

--- a/result_server/utils/profile_usage_overview.py
+++ b/result_server/utils/profile_usage_overview.py
@@ -184,6 +184,7 @@ def _latest_result_context(record: dict[str, Any] | None) -> dict[str, Any] | No
     if not record:
         return None
     trigger_summary = summarize_execution_trigger(record["data"])
+    snapshot = _environment_snapshot_context(record["data"].get("environment_snapshot"))
     return {
         "filename": record["filename"],
         "timestamp": record["timestamp_label"],
@@ -192,6 +193,7 @@ def _latest_result_context(record: dict[str, Any] | None) -> dict[str, Any] | No
         "exp": record["data"].get("Exp") or "-",
         "pipeline_id": record["data"].get("pipeline_id") or "-",
         "trigger_headline": trigger_summary.get("headline") or "-",
+        "environment_snapshot": snapshot,
     }
 
 
@@ -202,4 +204,25 @@ def _latest_run_context(run: dict[str, Any] | None) -> dict[str, str] | None:
         "status": str(run.get("status") or "-"),
         "created_at": str(run.get("created_at") or "-"),
         "reason": str(run.get("reason") or "-"),
+    }
+
+
+def _environment_snapshot_context(snapshot: Any) -> dict[str, str] | None:
+    if not isinstance(snapshot, dict):
+        return None
+    snapshot_hash = str(snapshot.get("hash") or "").strip()
+    if not snapshot_hash:
+        return None
+    summary = snapshot.get("summary")
+    summary = summary if isinstance(summary, dict) else {}
+    short_hash = snapshot_hash
+    if snapshot_hash.startswith("sha256:") and len(snapshot_hash) > 18:
+        short_hash = f"{snapshot_hash[:17]}..."
+    return {
+        "hash": snapshot_hash,
+        "short_hash": short_hash,
+        "system": str(summary.get("system") or "-"),
+        "allocation_project_id": str(summary.get("allocation_project_id") or "-"),
+        "scheduler": str(summary.get("scheduler") or "-"),
+        "runner": str(summary.get("runner") or "-"),
     }


### PR DESCRIPTION
## Summary

Shows the latest environment snapshot marker in the Profile Operations Overview.

## Changes

- Add snapshot context to each profile's latest result summary
- Render a compact `snapshot sha256:... / allocation / scheduler` line under Latest Result
- Keep the full snapshot details on the Result Detail page

## Validation

- `.venv/bin/python result_server/tests/run_result_server_tests.py`
- `.venv/bin/python result_server/tests/check_site_config.py`
- dev2 manual trigger confirmed snapshot-backed latest result data for `qws-fugaku`

