### PR TITLE
Avoid force push to GitLab.com mirror

### DIFF
--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -43,20 +43,28 @@ jobs:
             local remote_name="$1"
             local token="$2"
             local host_path="$3"
+            local force_mode="${4:-force}"
 
             git remote remove "${remote_name}" 2>/dev/null || true
             git remote add "${remote_name}" "https://oauth2:${token}@${host_path}"
-            git push -o ci.skip "${remote_name}" \
-              refs/remotes/origin/develop:refs/heads/develop \
-              refs/remotes/origin/main:refs/heads/main \
-              --force
-            git push -o ci.skip "${remote_name}" --tags --force
+            if [ "${force_mode}" = "force" ]; then
+              git push -o ci.skip "${remote_name}" \
+                refs/remotes/origin/develop:refs/heads/develop \
+                refs/remotes/origin/main:refs/heads/main \
+                --force
+              git push -o ci.skip "${remote_name}" --tags --force
+            else
+              git push -o ci.skip "${remote_name}" \
+                refs/remotes/origin/develop:refs/heads/develop \
+                refs/remotes/origin/main:refs/heads/main
+              git push -o ci.skip "${remote_name}" --tags
+            fi
           }
 
           sync_gitlab_remote gitlab "${GITLAB_TOKEN}" "${GITLAB_REPO_HOST_PATH}"
 
           if [ -n "${GITLAB_COM_TOKEN}" ]; then
-            sync_gitlab_remote gitlab-com "${GITLAB_COM_TOKEN}" "${GITLAB_COM_REPO_HOST_PATH}"
+            sync_gitlab_remote gitlab-com "${GITLAB_COM_TOKEN}" "${GITLAB_COM_REPO_HOST_PATH}" no-force
           else
             echo "GITLAB_COM_TOKEN is not set; skipping GitLab.com mirror ${GITLAB_COM_REPO_HOST_PATH}."
           fi


### PR DESCRIPTION
## Summary

- keep the primary SWC GitLab mirror sync behavior unchanged
- push the GitLab.com mirror without `--force` so protected `develop` / `main` branches can accept fast-forward updates
- leave GitLab.com divergence visible as a sync failure instead of rewriting protected branch history

## Validation

- `python - <<'PY' ... yaml.safe_load(...)`
- `git diff --check`

## Notes

GitLab.com `develop` was manually aligned to GitHub `develop` at `6d5a38c`.
After this change, the next protected-branch sync should fast-forward GitLab.com
instead of trying a protected force push.
