### PR TITLE
Detect GENESIS RIKYU apptainer path

### DIFF
--- a/programs/genesis/README.md
+++ b/programs/genesis/README.md
@@ -38,7 +38,9 @@ GENESIS_RIKYU_GPU_ARCH=sm_100
 
 The RIKYU SIF image name, path, and contents are still site-local and may
 change. Set `GENESIS_RIKYU_SIF` to override the image path. Set
-`GENESIS_RIKYU_APPTAINER` to override the Apptainer command and
+`GENESIS_RIKYU_APPTAINER` to override the Apptainer command; it defaults to the
+RIKYU site path `/shared/software/apptainer/bin/apptainer` because the custom
+executor environment may not inherit the normal login shell path. Set
 `GENESIS_RIKYU_APPTAINER_BINDS` to add comma-separated bind mounts.
 
 The RIKYU run path keeps the benchmark at the p8 default size and launches the

--- a/programs/genesis/build.sh
+++ b/programs/genesis/build.sh
@@ -9,7 +9,7 @@ BRANCH="${GENESIS_BRANCH:-main}"
 
 run_genesis_rikyu_in_container() {
     local image="${GENESIS_RIKYU_SIF:-/shared/software/hpc-dev-container/hpc_dev.sif}"
-    local apptainer_bin="${GENESIS_RIKYU_APPTAINER:-apptainer}"
+    local apptainer_bin="${GENESIS_RIKYU_APPTAINER:-/shared/software/apptainer/bin/apptainer}"
     local binds="${PWD}:${PWD}"
 
     if [ "${GENESIS_RIKYU_IN_CONTAINER:-false}" = "true" ]; then


### PR DESCRIPTION
## Summary
- Default GENESIS RIKYU builds to the site apptainer path used on RIKYU compute nodes.
- Document why the wrapper does not rely on the login shell PATH.

## Validation
- bash -n programs/genesis/build.sh
- shellcheck -S error programs/genesis/build.sh
- git diff --check