### PR TITLE
Enable GENESIS RIKYU NCU profiling by default

### DIFF
--- a/programs/genesis/README.md
+++ b/programs/genesis/README.md
@@ -38,10 +38,9 @@ GENESIS_RIKYU_GPU_ARCH=sm_100
 
 The RIKYU SIF image name, path, and contents are still site-local and may
 change. Set `GENESIS_RIKYU_SIF` to override the image path. Set
-`GENESIS_RIKYU_APPTAINER` to override the Apptainer command; it defaults to the
-RIKYU site path `/shared/software/apptainer/bin/apptainer` because the custom
-executor environment may not inherit the normal login shell path. Set
-`GENESIS_RIKYU_APPTAINER_BINDS` to add comma-separated bind mounts.
+`GENESIS_RIKYU_APPTAINER` to override the Apptainer command and
+`GENESIS_RIKYU_APPTAINER_BINDS` to add comma-separated bind mounts. The CI
+runner environment is expected to make `apptainer` available on `PATH`.
 
 The RIKYU run path keeps the benchmark at the p8 default size and launches the
 container per rank from inside the Slurm allocation:
@@ -52,9 +51,9 @@ srun --mpi=pmix -n 8 --ntasks-per-node=4 apptainer exec --nv ... ./spdyn p8.inp.
 
 `PMIX_MCA_gds=hash` is set by default for RIKYU because the containerized
 Open MPI runtime otherwise fails to read Slurm PMIx shared-memory state on
-multi-node p8 runs. RIKYU also defaults `GENESIS_RIKYU_PROFILER_TOOL=none`;
-set it to `ncu` explicitly if profiler acquisition is needed after validating
-the profiler launcher path for the site image.
+multi-node p8 runs. RIKYU follows the same default additional NCU acquisition
+policy as the other NVIDIA GPU systems; set `BK_PROFILER=none` or
+`GENESIS_RIKYU_PROFILER_TOOL=none` to run without profiling.
 
 The current GENESIS wrapper can collect multiple NCU windows as separate
 archives:

--- a/programs/genesis/build.sh
+++ b/programs/genesis/build.sh
@@ -9,7 +9,7 @@ BRANCH="${GENESIS_BRANCH:-main}"
 
 run_genesis_rikyu_in_container() {
     local image="${GENESIS_RIKYU_SIF:-/shared/software/hpc-dev-container/hpc_dev.sif}"
-    local apptainer_bin="${GENESIS_RIKYU_APPTAINER:-/shared/software/apptainer/bin/apptainer}"
+    local apptainer_bin="${GENESIS_RIKYU_APPTAINER:-apptainer}"
     local binds="${PWD}:${PWD}"
 
     if [ "${GENESIS_RIKYU_IN_CONTAINER:-false}" = "true" ]; then

--- a/programs/genesis/run.sh
+++ b/programs/genesis/run.sh
@@ -216,7 +216,6 @@ case "$system" in
     GENESIS_RIKYU_APPTAINER_PREFIX=$(genesis_rikyu_apptainer_run_prefix)
     export GENESIS_RIKYU_MPI_CMD="${GENESIS_RIKYU_MPI_CMD:-srun --mpi=pmix -n ${numproc} --ntasks-per-node=${numproc_node} ${GENESIS_RIKYU_APPTAINER_PREFIX}}"
     export GENESIS_RIKYU_MPI_ARGS="${GENESIS_RIKYU_MPI_ARGS:-}"
-    export GENESIS_RIKYU_PROFILER_TOOL="${GENESIS_RIKYU_PROFILER_TOOL:-none}"
     run_genesis_nvidia_gpu "$system" GENESIS_RIKYU "$GENESIS_RIKYU_MODULE"
     ;;
   *)


### PR DESCRIPTION
## Summary
- Enable the shared GENESIS NVIDIA GPU NCU profiling default for RIKYU.
- Keep RIKYU opt-out behavior through BK_PROFILER=none or GENESIS_RIKYU_PROFILER_TOOL=none.
- Revert the build wrapper to expect apptainer on PATH now that the runner environment provides it.

## Validation
- bash -n programs/genesis/build.sh programs/genesis/run.sh programs/genesis/profile.sh
- shellcheck -S error programs/genesis/build.sh programs/genesis/run.sh programs/genesis/profile.sh
- git diff --check
- bash scripts/tests/test_bk_profiler.sh
- bash scripts/tests/test_genesis_gpu_mlp_estimation.sh
- bash scripts/tests/test_result_profile_data.sh
- bash scripts/tests/test_ncu_plan_generation.sh