### PR TITLE
Preserve section padata artifacts

### DIFF
--- a/result_server/routes/api.py
+++ b/result_server/routes/api.py
@@ -211,6 +211,33 @@ def _safe_basename(name):
     return name
 
 
+def _normalize_padata_artifact_slug(value):
+    """Return a filename-safe padata artifact slug, or None for legacy uploads."""
+    if value is None:
+        return None
+
+    artifact_path = str(value).strip()
+    if artifact_path == "":
+        return None
+    if (
+        os.path.isabs(artifact_path)
+        or "\\" in artifact_path
+        or artifact_path.startswith("../")
+        or "/../" in artifact_path
+        or artifact_path.endswith("/..")
+    ):
+        abort(400, description="Invalid padata artifact path")
+    if not artifact_path.startswith("results/"):
+        abort(400, description="Invalid padata artifact path")
+
+    basename = os.path.basename(artifact_path)
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}\.(?:tgz|tar\.gz)", basename):
+        abort(400, description="Invalid padata artifact path")
+    if basename.endswith(".tar.gz"):
+        return basename[:-7]
+    return basename[:-4]
+
+
 def _load_json_by_uuid(directory, field_path, uuid_value):
     """Return the first JSON payload whose target field matches the UUID."""
     json_files = sorted(
@@ -426,11 +453,17 @@ def ingest_padata():
         abort(400, description="No file uploaded")
 
     received_dir = current_app.config["RECEIVED_PADATA_DIR"]
+    artifact_slug = _normalize_padata_artifact_slug(request.form.get("artifact_path"))
 
-    matched_files = [
-        f for f in os.listdir(received_dir)
-        if f.endswith(".tgz") and uuid_str in f
-    ]
+    if artifact_slug:
+        filename = _safe_basename(f"padata_{timestamp}_{uuid_str}_{artifact_slug}.tgz")
+        matched_files = [filename] if os.path.exists(os.path.join(received_dir, filename)) else []
+    else:
+        legacy_pattern = re.compile(rf"^padata_\d{{8}}_\d{{6}}_{re.escape(uuid_str)}\.tgz$")
+        matched_files = [
+            f for f in os.listdir(received_dir)
+            if legacy_pattern.fullmatch(f)
+        ]
 
     if matched_files:
         old_file_path = os.path.join(received_dir, _safe_basename(matched_files[0]))
@@ -438,7 +471,8 @@ def ingest_padata():
         shutil.move(old_file_path, backup_path)
         save_path = old_file_path
     else:
-        filename = _safe_basename(f"padata_{timestamp}_{uuid_str}.tgz")
+        if not artifact_slug:
+            filename = _safe_basename(f"padata_{timestamp}_{uuid_str}.tgz")
         save_path = os.path.join(received_dir, filename)
 
     tmp_path = save_path + ".tmp"
@@ -454,6 +488,7 @@ def ingest_padata():
         "id": uuid_str,
         "timestamp": timestamp,
         "file": os.path.basename(save_path),
+        "artifact_path": request.form.get("artifact_path") or "",
         "replaced": bool(matched_files),
     }
     audit_event(

--- a/result_server/routes/results_detail_routes.py
+++ b/result_server/routes/results_detail_routes.py
@@ -1,3 +1,5 @@
+import os
+
 from flask import abort, current_app, render_template, request, url_for
 from werkzeug.exceptions import Forbidden, NotFound
 
@@ -40,10 +42,13 @@ def register_results_detail_routes(results_bp):
             not_found_message="Result file not found",
         )
         quality = summarize_result_quality(result)
+        padata_dir = current_app.config.get("RECEIVED_PADATA_DIR", current_app.config["RECEIVED_DIR"])
+        padata_filenames = [name for name in os.listdir(padata_dir) if name.endswith(".tgz")]
         detail_context = build_result_detail_context(
             result,
             quality,
             load_trigger_run_lookup(current_app.config.get("EXECUTION_PROFILE_DB_PATH")),
+            padata_filenames,
         )
         if detail_context.get("environment_snapshot_hash"):
             detail_context["environment_snapshot_results_url"] = url_for(

--- a/result_server/templates/_results_table_cell_profile.html
+++ b/result_server/templates/_results_table_cell_profile.html
@@ -3,12 +3,12 @@
         <span class="tooltip">
             <span class="profile-headline">{{ row.profile_summary_meta.headline }}</span>
             {% if row.data_link %}
-            <a class="profile-data-link" href="{{ row.data_link }}">padata</a>
+            <a class="profile-data-link" href="{{ row.data_link }}">padata{% if row.profile_summary_meta.archive_count %} x{{ row.profile_summary_meta.archive_count }}{% endif %}</a>
             {% endif %}
             <span class="tooltiptext">
                 {{ row.profile_summary_meta.headline }}
                 {% if row.profile_summary_meta.subline %}<br>{{ row.profile_summary_meta.subline }}{% endif %}
-                {% if row.data_link %}<br>archive: available{% endif %}
+                {% if row.data_link %}<br>archive: available{% if row.profile_summary_meta.archive_count %} ({{ row.profile_summary_meta.archive_count }}){% endif %}{% endif %}
                 {% if row.profile_summary_meta.events %}<br>events: {{ row.profile_summary_meta.events | join(', ') }}{% endif %}
                 {% if row.profile_summary_meta.ncu_options %}<br>ncu options: {{ row.profile_summary_meta.ncu_options | join(' ') }}{% endif %}
                 {% if row.profile_summary_meta.report_kinds %}<br>reports: {{ row.profile_summary_meta.report_kinds | join(', ') }}{% endif %}

--- a/result_server/templates/result_detail.html
+++ b/result_server/templates/result_detail.html
@@ -31,7 +31,10 @@
     .quality-list { margin: 0; padding-left: 20px; }
     .quality-level-cell { min-width: 840px; }
     .quality-summary { display: block; margin-top: 0.35rem; line-height: 1.45; }
-</style>
+    .artifact-table th { text-align: left; background-color: #f2f2f2; }
+    .artifact-table td { white-space: normal; vertical-align: top; }
+    .artifact-missing { color: #6b7280; }
+	</style>
 
 <a href="{{ url_for('results.results') }}" class="back-link">&larr; Back to Results</a>
 
@@ -39,6 +42,34 @@
 
 {% if profile_rows %}
 {{ render_titled_key_value_table("PA Data Summary", profile_rows, "meta-table") }}
+{% endif %}
+
+{% if profile_artifact_rows %}
+<div class="section">
+    <h2>PA Data Archives</h2>
+    <div class="detail-table-wrap">
+    <table class="artifact-table">
+        <thead>
+            <tr><th>Section</th><th>Artifact</th><th>Archive</th></tr>
+        </thead>
+        <tbody>
+            {% for row in profile_artifact_rows %}
+            <tr>
+                <td>{{ row.section }}</td>
+                <td>{{ row.artifact_path }}</td>
+                <td>
+                    {% if row.link %}
+                    <a href="{{ row.link }}">{{ row.filename }}</a>
+                    {% else %}
+                    <span class="artifact-missing">{{ row.filename }} not uploaded</span>
+                    {% endif %}
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    </div>
+</div>
 {% endif %}
 
 {% if quality_rows %}

--- a/result_server/test_support.py
+++ b/result_server/test_support.py
@@ -49,6 +49,10 @@ def build_portal_shell_app(*, templates_dir, include_home_route=True, include_sy
     def result_detail(filename):
         return filename
 
+    @results_bp.route("/<filename>")
+    def show_result(filename):
+        return filename
+
     @results_bp.route("/environment-snapshots/<path:snapshot_hash>")
     def environment_snapshot_results(snapshot_hash):
         return snapshot_hash

--- a/result_server/tests/test_api_routes.py
+++ b/result_server/tests/test_api_routes.py
@@ -452,6 +452,59 @@ class TestIngestPadata:
         saved_files = os.listdir(tmp_dirs[1])
         assert saved_files == ["padata_20250101_120000_12345678-1234-1234-1234-123456789abc.tgz"]
 
+    def test_upload_section_artifacts_do_not_replace_each_other(self, client, tmp_dirs):
+        """Section padata archives for one result UUID are stored separately."""
+        uuid_value = "12345678-1234-1234-1234-123456789abc"
+        base_data = {
+            "id": uuid_value,
+            "timestamp": "20250101_120000",
+            "file": (io.BytesIO(b"legacy"), "legacy.tgz"),
+        }
+        resp = client.post("/api/ingest/padata",
+                           data=base_data,
+                           headers={"X-API-Key": API_KEY},
+                           content_type="multipart/form-data")
+        assert resp.status_code == 200
+
+        for artifact_name in ("padata_pairlist.tgz", "padata_pme_real_inter.tgz"):
+            resp = client.post("/api/ingest/padata",
+                               data={
+                                   "id": uuid_value,
+                                   "timestamp": "20250101_120000",
+                                   "artifact_path": f"results/{artifact_name}",
+                                   "file": (io.BytesIO(artifact_name.encode("utf-8")), artifact_name),
+                               },
+                               headers={"X-API-Key": API_KEY},
+                               content_type="multipart/form-data")
+            assert resp.status_code == 200
+            assert resp.get_json()["replaced"] is False
+
+        assert sorted(os.listdir(tmp_dirs[1])) == [
+            "padata_20250101_120000_12345678-1234-1234-1234-123456789abc.tgz",
+            "padata_20250101_120000_12345678-1234-1234-1234-123456789abc_padata_pairlist.tgz",
+            "padata_20250101_120000_12345678-1234-1234-1234-123456789abc_padata_pme_real_inter.tgz",
+        ]
+
+    @pytest.mark.parametrize("artifact_path", [
+        "../padata.tgz",
+        "results/../padata.tgz",
+        "/tmp/padata.tgz",
+        "results/bad name.tgz",
+        "artifacts/padata.tgz",
+    ])
+    def test_rejects_invalid_padata_artifact_path(self, client, artifact_path):
+        data = {
+            "id": "12345678-1234-1234-1234-123456789abc",
+            "timestamp": "20250101_120000",
+            "artifact_path": artifact_path,
+            "file": (io.BytesIO(b"data"), "test.tgz"),
+        }
+        resp = client.post("/api/ingest/padata",
+                           data=data,
+                           headers={"X-API-Key": API_KEY},
+                           content_type="multipart/form-data")
+        assert resp.status_code == 400
+
     def test_missing_uuid_returns_400(self, client):
         """Test case."""
         import io

--- a/result_server/tests/test_portal_list_templates.py
+++ b/result_server/tests/test_portal_list_templates.py
@@ -113,6 +113,7 @@ def test_results_template_renders_ncu_options_tooltip():
                         "has_profile_data": True,
                         "headline": "ncu / single",
                         "subline": "text, 1 run",
+                        "archive_count": 3,
                         "events": [],
                         "ncu_options": ["--target-processes", "all", "--set", "basic", "--launch-count", "1"],
                         "report_kinds": ["ncu_report", "summary_text"],
@@ -146,6 +147,8 @@ def test_results_template_renders_ncu_options_tooltip():
         )
 
     assert "ncu / single" in html
+    assert "padata x3" in html
+    assert "archive: available (3)" in html
     assert "ncu options: --target-processes all --set basic --launch-count 1" in html
     assert "ncu_report" in html
 

--- a/result_server/tests/test_result_detail_template.py
+++ b/result_server/tests/test_result_detail_template.py
@@ -100,10 +100,10 @@ FULL_QUALITY = {
 }
 
 
-def _render_result_detail(result, quality):
+def _render_result_detail(result, quality, padata_filenames=None):
     from flask import render_template
 
-    detail_context = build_result_detail_context(result, quality)
+    detail_context = build_result_detail_context(result, quality, padata_filenames=padata_filenames)
     return render_template("result_detail.html", result=result, quality=quality, **detail_context)
 
 
@@ -173,6 +173,40 @@ class TestResultDetailTemplate:
         assert "NCU Options" in html
         assert "ncu_report" in html
         assert ">Events<" not in html
+
+    def test_section_padata_archives_are_linked(self, app):
+        result = {
+            **FULL_RESULT,
+            "_server_uuid": "12345678-1234-1234-1234-123456789abc",
+            "_server_timestamp": "20260819_161329",
+            "fom_breakdown": {
+                "sections": [
+                    {
+                        "name": "pairlist",
+                        "time": 1.0,
+                        "artifacts": [
+                            {
+                                "type": "file_reference",
+                                "path": "results/padata_k003_void_kern_build_pairlist.tgz",
+                            }
+                        ],
+                    }
+                ],
+                "overlaps": [],
+            },
+        }
+        filename = (
+            "padata_20260819_161329_12345678-1234-1234-1234-123456789abc_"
+            "padata_k003_void_kern_build_pairlist.tgz"
+        )
+
+        with app.test_request_context():
+            html = _render_result_detail(result, FULL_QUALITY, [filename])
+
+        assert "PA Data Archives" in html
+        assert "pairlist" in html
+        assert "results/padata_k003_void_kern_build_pairlist.tgz" in html
+        assert f'href="/results/{filename}"' in html
 
     def test_vector_data_table(self, app):
         with app.test_request_context():

--- a/result_server/tests/test_results_loader.py
+++ b/result_server/tests/test_results_loader.py
@@ -614,3 +614,23 @@ class TestPadataLinkResolution:
 
         assert len(rows) == 1
         assert rows[0]["data_link"] == f"/results/{tgz_name}"
+
+    def test_data_link_prefers_legacy_padata_when_section_archives_exist(self, flask_app, tmp_dir):
+        uid = str(uuid.uuid4())
+        filename = f"result_20250101_120000_{uid}.json"
+        legacy_name = f"padata_20250101_120000_{uid}.tgz"
+        section_name = f"padata_20250101_120000_{uid}_padata_pairlist.tgz"
+
+        _write_json(tmp_dir, filename, {
+            "code": "genesis",
+            "system": "RIKYU",
+            "FOM": 1.0,
+        })
+        open(os.path.join(tmp_dir, section_name), "wb").close()
+        open(os.path.join(tmp_dir, legacy_name), "wb").close()
+
+        with flask_app.test_request_context():
+            rows, _, _ = load_results_table(tmp_dir, public_only=True)
+
+        assert len(rows) == 1
+        assert rows[0]["data_link"] == f"/results/{legacy_name}"

--- a/result_server/utils/result_detail_view.py
+++ b/result_server/utils/result_detail_view.py
@@ -1,8 +1,13 @@
+import os
+import re
+
+from flask import url_for
+
 from utils.result_records import build_labeled_value_rows, format_numeric_value
 from utils.trigger_display import summarize_execution_trigger
 
 
-def build_result_detail_context(result, quality, trigger_runs_by_pipeline=None):
+def build_result_detail_context(result, quality, trigger_runs_by_pipeline=None, padata_filenames=None):
     profile_data = result.get("profile_data") or {}
     build_data = result.get("build") or {}
     vector_metrics = (result.get("metrics") or {}).get("vector")
@@ -12,6 +17,7 @@ def build_result_detail_context(result, quality, trigger_runs_by_pipeline=None):
         "meta_rows": _build_meta_rows(result, trigger_runs_by_pipeline),
         "profile_rows": _build_profile_rows(profile_data),
         "quality_rows": _build_quality_rows(quality),
+        "profile_artifact_rows": _build_profile_artifact_rows(result, padata_filenames or []),
         "environment_rows": _build_environment_rows(result.get("environment_snapshot")),
         "environment_snapshot_hash": _environment_snapshot_hash(result.get("environment_snapshot")),
         "vector_metrics": vector_metrics,
@@ -95,6 +101,47 @@ def _build_tool_specific_detail(profile_data):
         "detailed": "fapp event set: pa1..pa17",
     }
     return mapping.get(level, "fapp tool-specific event set")
+
+
+def _build_profile_artifact_rows(result, padata_filenames):
+    result_uuid = result.get("_server_uuid")
+    timestamp = result.get("_server_timestamp")
+    if not result_uuid or not timestamp:
+        return []
+
+    rows = []
+    for section in (result.get("fom_breakdown") or {}).get("sections") or []:
+        if not isinstance(section, dict):
+            continue
+        section_name = section.get("name") or "-"
+        for artifact in section.get("artifacts") or []:
+            if not isinstance(artifact, dict) or artifact.get("type") != "file_reference":
+                continue
+            artifact_path = artifact.get("path") or ""
+            artifact_slug = _padata_artifact_slug(artifact_path)
+            if not artifact_slug:
+                continue
+            filename = f"padata_{timestamp}_{result_uuid}_{artifact_slug}.tgz"
+            rows.append({
+                "section": section_name,
+                "artifact_path": artifact_path,
+                "filename": filename,
+                "link": url_for("results.show_result", filename=filename) if filename in padata_filenames else None,
+            })
+    return rows
+
+
+def _padata_artifact_slug(artifact_path):
+    if not isinstance(artifact_path, str):
+        return ""
+    if not artifact_path.startswith("results/"):
+        return ""
+    basename = os.path.basename(artifact_path)
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}\.(?:tgz|tar\.gz)", basename):
+        return ""
+    if basename.endswith(".tar.gz"):
+        return basename[:-7]
+    return basename[:-4]
 
 
 def _build_quality_rows(quality):

--- a/result_server/utils/result_table_rows.py
+++ b/result_server/utils/result_table_rows.py
@@ -104,7 +104,15 @@ def _find_matching_padata_archive(json_filename, result_data, padata_filenames):
     result_uuid = extract_result_uuid(json_filename) or result_data.get("_server_uuid")
     if not result_uuid:
         return None
-    return next((filename for filename in padata_filenames if result_uuid in filename), None)
+    matches = sorted(filename for filename in padata_filenames if result_uuid in filename)
+    legacy_name = next(
+        (
+            filename for filename in matches
+            if filename.endswith(f"_{result_uuid}.tgz")
+        ),
+        None,
+    )
+    return legacy_name or (matches[0] if matches else None)
 
 
 def _format_source_hash(source_info):
@@ -188,6 +196,7 @@ def _build_profile_summary_meta(profile_data):
         "has_profile_data": True,
         "headline": _format_profile_summary(profile_data),
         "subline": ", ".join(subline_parts),
+        "archive_count": profile_data.get("archive_count") if isinstance(profile_data.get("archive_count"), int) else None,
         "events": profile_data.get("events") if isinstance(profile_data.get("events"), list) else [],
         "ncu_options": profile_data.get("ncu_options") if isinstance(profile_data.get("ncu_options"), list) else [],
         "report_kinds": profile_data.get("report_kinds") if isinstance(profile_data.get("report_kinds"), list) else [],

--- a/scripts/result_server/send_results.sh
+++ b/scripts/result_server/send_results.sh
@@ -62,45 +62,110 @@ build_profile_data_summary() {
   ' 2>/dev/null || true
 }
 
-list_section_padata_archives() {
-  local json_file="$1"
+build_profile_data_summary_for_archives() {
+  local summaries_file
+  summaries_file=$(mktemp)
+  local summary
+  local archive_count=0
 
-  if ! command -v jq >/dev/null 2>&1; then
+  for tgz_file in "$@"; do
+    summary=$(build_profile_data_summary "$tgz_file")
+    if [[ -n "$summary" ]]; then
+      printf '%s\n' "$summary" >> "$summaries_file"
+      archive_count=$((archive_count + 1))
+    fi
+  done
+
+  if [[ "$archive_count" -eq 0 ]]; then
+    rm -f "$summaries_file"
+    printf '%s' ""
     return 0
   fi
 
-  jq -r '
-    .fom_breakdown.sections[]?.artifacts[]?.path? // empty
-    | select(test("(^|/)padata.*[.]tgz$"))
-  ' "$json_file" 2>/dev/null || true
+  if [[ "$archive_count" -eq 1 ]]; then
+    cat "$summaries_file"
+    rm -f "$summaries_file"
+    return 0
+  fi
+
+  jq -s -c '
+    {
+      tool: ((map(.tool) | map(select(. != null and . != "")) | unique) as $tools |
+        if ($tools | length) == 1 then $tools[0] else "multiple" end),
+      level: ((map(.level) | map(select(. != null and . != "")) | unique) as $levels |
+        if ($levels | length) == 1 then $levels[0] else "multiple" end),
+      report_format: ((map(.report_format) | map(select(. != null and . != "")) | unique) as $formats |
+        if ($formats | length) == 1 then $formats[0] else "multiple" end),
+      raw_dir: "multiple",
+      run_count: (map(.run_count // 0) | add),
+      events: (map(.events // []) | add | unique),
+      ncu_options: (map(.ncu_options // []) | add | unique),
+      report_kinds: (map(.report_kinds // []) | add | unique),
+      archive_count: length
+    }
+  ' "$summaries_file" 2>/dev/null || true
+  rm -f "$summaries_file"
 }
 
-padata_archive_already_uploaded() {
-  local tgz_file="$1"
-  local uploaded_file
-  shift
+is_safe_local_padata_path() {
+  local artifact_path="$1"
 
-  for uploaded_file in "$@"; do
-    if [[ "$uploaded_file" == "$tgz_file" ]]; then
-      return 0
+  case "$artifact_path" in
+    results/*.tgz|results/*.tar.gz) ;;
+    *) return 1 ;;
+  esac
+
+  case "$artifact_path" in
+    /*|*"/../"*|../*|*"/.."|*\\*) return 1 ;;
+  esac
+
+  [[ -f "$artifact_path" ]]
+}
+
+collect_padata_archives_for_result() {
+  local json_file="$1"
+  local legacy_tgz_file="$2"
+  declare -A seen_archives=()
+
+  if [[ -f "$legacy_tgz_file" ]]; then
+    seen_archives["$legacy_tgz_file"]=1
+    printf '%s\t%s\n' "$legacy_tgz_file" ""
+  fi
+
+  while IFS= read -r artifact_path; do
+    [[ -n "$artifact_path" ]] || continue
+    if is_safe_local_padata_path "$artifact_path" && [[ -z "${seen_archives[$artifact_path]:-}" ]]; then
+      seen_archives["$artifact_path"]=1
+      printf '%s\t%s\n' "$artifact_path" "$artifact_path"
     fi
-  done
-  return 1
+  done < <(jq -r '
+    (.fom_breakdown.sections // [])[]?
+    | (.artifacts // [])[]?
+    | select(.type == "file_reference")
+    | .path // empty
+  ' "$json_file" 2>/dev/null || true)
 }
 
 upload_padata_archive() {
   local tgz_file="$1"
   local uuid="$2"
   local timestamp="$3"
+  local artifact_path="${4:-}"
   local response
 
   echo "Uploading $tgz_file with UUID $uuid"
   local curl_auth_args=()
+  local curl_form_args=(
+    -F "id=${uuid}"
+    -F "timestamp=${timestamp}"
+    -F "file=@${tgz_file}"
+  )
+  if [[ -n "$artifact_path" ]]; then
+    curl_form_args+=(-F "artifact_path=${artifact_path}")
+  fi
   bk_result_server_set_curl_args
   if response=$(curl --fail -sS "${curl_auth_args[@]}" -X POST "${RESULT_SERVER}/api/ingest/padata" \
-    -F "id=${uuid}" \
-    -F "timestamp=${timestamp}" \
-    -F "file=@${tgz_file}" 2>&1); then
+    "${curl_form_args[@]}" 2>&1); then
     if [[ -n "$response" ]]; then
       echo "$response"
     fi
@@ -134,9 +199,16 @@ for json_file in results/result*.json; do
   fi
 
   echo tgz_file $tgz_file
-  uploaded_tgz_files=()
 
-  profile_data_summary=$(build_profile_data_summary "$tgz_file")
+  padata_archive_paths=()
+  padata_archive_specs=()
+  while IFS=$'\t' read -r archive_path artifact_path; do
+    [[ -n "$archive_path" ]] || continue
+    padata_archive_paths+=("$archive_path")
+    padata_archive_specs+=("${archive_path}"$'\t'"${artifact_path}")
+  done < <(collect_padata_archives_for_result "$json_file" "$tgz_file")
+
+  profile_data_summary=$(build_profile_data_summary_for_archives "${padata_archive_paths[@]}")
   if [[ -n "$profile_data_summary" ]]; then
     tmp_file="${json_file}.tmp"
     jq --argjson profile_data "$profile_data_summary" \
@@ -197,26 +269,17 @@ for json_file in results/result*.json; do
   echo "Updated result metadata manifest: $meta_file"
 
   
-  # Upload TGZ if it exists
-  if [[ -f "$tgz_file" ]]; then
-    upload_padata_archive "$tgz_file" "$uuid" "$timestamp"
-    uploaded_tgz_files+=("$tgz_file")
+  # Upload matching profiler archives. Legacy resultN.json/padataN.tgz pairs are
+  # kept, and section artifact archives are sent with artifact_path so the server
+  # can keep multiple archives for the same result UUID.
+  if [[ "${#padata_archive_specs[@]}" -gt 0 ]]; then
+    for archive_spec in "${padata_archive_specs[@]}"; do
+      IFS=$'\t' read -r archive_path artifact_path <<< "$archive_spec"
+      upload_padata_archive "$archive_path" "$uuid" "$timestamp" "$artifact_path"
+    done
   else
-    echo "No matching TGZ found for $json_file (expected: $tgz_file). Skipping upload."
+    echo "No profiler TGZ found for $json_file (expected: $tgz_file or section artifact padata archives). Skipping upload."
   fi
-
-  while IFS= read -r section_tgz_file; do
-    [[ -n "$section_tgz_file" ]] || continue
-    if padata_archive_already_uploaded "$section_tgz_file" "${uploaded_tgz_files[@]}"; then
-      continue
-    fi
-    if [[ -f "$section_tgz_file" ]]; then
-      upload_padata_archive "$section_tgz_file" "$uuid" "$timestamp"
-      uploaded_tgz_files+=("$section_tgz_file")
-    else
-      echo "No matching section TGZ found for $json_file (expected: $section_tgz_file). Skipping upload."
-    fi
-  done < <(list_section_padata_archives "$json_file")
 
 done
 

--- a/scripts/tests/test_send_results_profile_data.sh
+++ b/scripts/tests/test_send_results_profile_data.sh
@@ -27,6 +27,7 @@ cat > "${TMP_DIR}/results/result0.json" <<'EOF'
     "sections": [
       {
         "name": "pme_real_inter",
+        "time": 1.0,
         "artifacts": [
           {
             "type": "file_reference",
@@ -36,6 +37,7 @@ cat > "${TMP_DIR}/results/result0.json" <<'EOF'
       },
       {
         "name": "pme_real_intra",
+        "time": 1.0,
         "artifacts": [
           {
             "type": "file_reference",
@@ -45,6 +47,7 @@ cat > "${TMP_DIR}/results/result0.json" <<'EOF'
       },
       {
         "name": "pairlist",
+        "time": 1.0,
         "artifacts": [
           {
             "type": "file_reference",
@@ -52,7 +55,8 @@ cat > "${TMP_DIR}/results/result0.json" <<'EOF'
           }
         ]
       }
-    ]
+    ],
+    "overlaps": []
   }
 }
 EOF
@@ -88,6 +92,7 @@ tar -czf "${TMP_DIR}/results/padata_k003.tgz" -C "${TMP_DIR}" bk_profiler_artifa
 cat > "${TMP_DIR}/bin/curl" <<'EOF'
 #!/bin/bash
 set -euo pipefail
+printf '%s\n' "$*" >> "${TMP_DIR}/curl_calls.log"
 if printf '%s\n' "$*" | grep -q '/api/ingest/result'; then
   printf '%s\n' '{"id":"11111111-2222-3333-4444-555555555555","timestamp":"20260413_230000"}'
   exit 0
@@ -163,6 +168,41 @@ raise SystemExit(1)
 PY
 fi
 
+if [ "$1" = "-s" ] && [ "$2" = "-c" ]; then
+  summaries_file="$4"
+  "$python_exe" - "$summaries_file" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    items = [json.loads(line) for line in fh if line.strip()]
+
+def uniq(values):
+    result = []
+    for value in values:
+        if value not in result:
+            result.append(value)
+    return result
+
+tools = uniq([item.get("tool") for item in items if item.get("tool")])
+levels = uniq([item.get("level") for item in items if item.get("level")])
+formats = uniq([item.get("report_format") for item in items if item.get("report_format")])
+summary = {
+    "tool": tools[0] if len(tools) == 1 else "multiple",
+    "level": levels[0] if len(levels) == 1 else "multiple",
+    "report_format": formats[0] if len(formats) == 1 else "multiple",
+    "raw_dir": "multiple",
+    "run_count": sum(item.get("run_count", 0) for item in items),
+    "events": uniq([event for item in items for event in item.get("events", [])]),
+    "ncu_options": uniq([option for item in items for option in item.get("ncu_options", [])]),
+    "report_kinds": uniq([kind for item in items for kind in item.get("report_kinds", [])]),
+    "archive_count": len(items),
+}
+print(json.dumps(summary))
+PY
+  exit 0
+fi
+
 if [ "$1" = "-r" ]; then
   shift
   expr="$1"
@@ -174,7 +214,7 @@ import sys
 path, expr = sys.argv[1:3]
 with open(path, "r", encoding="utf-8") as fh:
     data = json.load(fh)
-if "fom_breakdown.sections" in expr and "padata" in expr:
+if "fom_breakdown.sections" in expr:
     for section in data.get("fom_breakdown", {}).get("sections", []):
         for artifact in section.get("artifacts", []):
             artifact_path = artifact.get("path")
@@ -283,7 +323,8 @@ popd >/dev/null
 grep -q '"profile_data"' "${TMP_DIR}/results/result0.json"
 grep -Eq '"tool":[[:space:]]*"ncu"' "${TMP_DIR}/results/result0.json"
 grep -Eq '"level":[[:space:]]*"single"' "${TMP_DIR}/results/result0.json"
-grep -Eq '"run_count":[[:space:]]*1' "${TMP_DIR}/results/result0.json"
+grep -Eq '"run_count":[[:space:]]*4' "${TMP_DIR}/results/result0.json"
+grep -Eq '"archive_count":[[:space:]]*4' "${TMP_DIR}/results/result0.json"
 grep -Eq '"events":[[:space:]]*\[[[:space:]]*\]' "${TMP_DIR}/results/result0.json"
 grep -Eq '"ncu_options":[[:space:]]*\[' "${TMP_DIR}/results/result0.json"
 grep -Eq '"ncu_report"' "${TMP_DIR}/results/result0.json"
@@ -293,6 +334,9 @@ grep -q 'padata0.tgz' "${TMP_DIR}/padata_uploads.log"
 grep -q 'padata_k001.tgz' "${TMP_DIR}/padata_uploads.log"
 grep -q 'padata_k002.tgz' "${TMP_DIR}/padata_uploads.log"
 grep -q 'padata_k003.tgz' "${TMP_DIR}/padata_uploads.log"
+grep -q 'artifact_path=results/padata_k001.tgz' "${TMP_DIR}/padata_uploads.log"
+grep -q 'artifact_path=results/padata_k002.tgz' "${TMP_DIR}/padata_uploads.log"
+grep -q 'artifact_path=results/padata_k003.tgz' "${TMP_DIR}/padata_uploads.log"
 test "$(grep -c '/api/ingest/padata' "${TMP_DIR}/padata_uploads.log")" = "4"
 
 mkdir -p "${TMP_DIR}/case413/results"


### PR DESCRIPTION
## Summary
- Upload section-level results/padata_*.tgz archives referenced from fom_breakdown section artifacts.
- Store section padata archives with safe artifact suffixes so multiple archives for one result UUID do not overwrite each other.
- Surface profiler archive counts in the results table and link section padata archives from the result detail page.

## Root Cause
GENESIS can produce multiple profiler archives for separate kernel sections, but the upload and portal ingest path still assumed one padata archive per result UUID. Later uploads could overwrite earlier section archives, and the portal did not expose each section archive.

## Validation
- .venv/bin/python -m pytest result_server/tests
- bash scripts/tests/test_send_results_profile_data.sh
- bash scripts/tests/test_result_profile_data.sh
- git diff --check