### PR TITLE
Add public portal access controls

### DIFF
--- a/docs/deploy/hardening-guide.md
+++ b/docs/deploy/hardening-guide.md
@@ -46,6 +46,11 @@ loopback traffic to the app. Keep `/admin/` and `/auth/` protected by portal
 authentication; `robots.txt` only reduces crawler noise and is not an access
 control mechanism.
 
+For public portal deployments, split the browser-facing surface from restricted
+viewer, operator, and runner/API surfaces. The public route allowlist and the
+nginx/Flask responsibility split are described in
+[`public-portal-access-control.md`](public-portal-access-control.md).
+
 `app.py` trusts one reverse proxy hop with Werkzeug `ProxyFix`, so the frontend
 proxy must set `X-Forwarded-For` and `X-Forwarded-Proto`. The configured hop
 count assumes nginx is the only trusted proxy directly in front of Gunicorn. If

--- a/docs/deploy/public-portal-access-control.md
+++ b/docs/deploy/public-portal-access-control.md
@@ -1,0 +1,213 @@
+# Public Portal Access Control Design
+
+This document defines the intended access-control boundary for publishing the
+CX Portal. It is deployment design guidance, not a site-local configuration
+file. Do not record real IP ranges, hostnames, tokens, certificate paths, or
+private service paths here.
+
+## Goals
+
+The public portal should expose scientifically useful benchmark information
+while keeping operational and governance surfaces out of the public web
+interface.
+
+Public data should be useful on its own or interpretable within the CX Portal:
+
+- application, case, and experiment identifiers
+- public system metadata
+- node/process/thread/GPU shape
+- figure of merit, unit, and public breakdown values
+- public source provenance that resolves to public repositories
+- profiler artifacts such as NCU or fapp data only when the collection
+  parameters and disclosure decision make them reproducible and meaningful
+
+Public views should not expose information that mainly helps operate or attack
+the service:
+
+- pipeline IDs, job IDs, runner names, runner paths, and internal project names
+- private mirror URLs, internal URLs, database paths, environment paths, or
+  service names
+- allocation project IDs, account/budget values, reviewer/approver data, and
+  profile attribution internals
+- login, admin, profile-request, confidential-result, estimated-result, and
+  operations links
+- raw artifacts or JSON records that have not passed a public-safe projection
+  or explicit disclosure review
+
+Route names are not secrets because the source repository is public. The
+security boundary must not depend on obscurity. The deployed service should
+still make restricted routes unreachable from the public internet.
+
+## Access Classes
+
+Use separate access classes instead of a single "admin IP" bucket.
+
+| Class | Purpose | Primary gate |
+| --- | --- | --- |
+| Public browser | Anonymous public portal visitors | Route allowlist and public-safe rendering |
+| Restricted viewer | Users allowed to see confidential or estimated results | Restricted network range, TOTP login, affiliation/role checks |
+| Authenticated console user | Users allowed to create or inspect their own console-side requests | Restricted or collaboration network range, TOTP login, per-route checks |
+| Operator | Portal operators and administrators | Narrow operator network range, TOTP login, admin role checks |
+| Runner/API client | CI runners and trusted ingest/query clients | mTLS or runner-scoped API authentication, rate limits |
+
+Restricted viewer and operator networks may differ. For example, confidential
+or estimated results may need to be reachable from a wider collaboration or VPN
+range than admin pages, but they still require login and per-user authorization.
+
+## Route Allowlist
+
+The initial public allowlist should be deliberately small.
+
+| Route | Public | Restricted viewer | Authenticated console | Operator | Runner/API | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| `GET /` | yes | yes | yes | yes | no | Public home page. |
+| `GET /systemlist` | yes | yes | yes | yes | no | Public system catalog. |
+| `GET /results/` | yes | yes | yes | yes | no | Public results list, rendered with public-safe columns only. |
+| `GET /results/detail/<filename>` | conditional | yes | yes | yes | no | Public only for public results and public-safe detail fields. |
+| `GET /results/compare` | conditional | yes | yes | yes | no | Public only when every selected result is public and the rendered fields are public-safe. |
+| `GET /static/*` | yes | yes | yes | yes | no | Static assets only. Keep secrets and generated private files out of static paths. |
+| `GET /results/<filename>` | no by default | conditional | conditional | yes | no | Raw JSON and archive downloads require a separate public-safe artifact policy before public exposure. |
+| `GET /results/environment-snapshots/*` | no by default | conditional | conditional | yes | no | Environment snapshots can contain operational context; expose only after redaction/public projection review. |
+| `GET /results/confidential` | no | yes | conditional | yes | no | Must be hidden from public navigation and blocked by reverse proxy for public clients. |
+| `GET /estimated/*` | no | yes | conditional | yes | no | Requires restricted network, TOTP, and affiliation/role checks. |
+| `GET/POST /execution-profile-requests/*` | no | no by default | yes | yes | no | Authenticated console surface. Applicant access may be enabled for non-admin users behind an operator or collaboration network. |
+| `GET/POST /admin/*` | no | no | no | yes | no | Operator-only; Flask admin role checks still apply. |
+| `GET/POST /auth/*` | no | yes | yes | yes | no | Login/setup/logout should not exist on the public surface. |
+| `GET /results/usage` | no | no | no | yes | no | Operations/admin report. |
+| `GET/POST /api/ingest/*` | no | no | no | no | yes | CI ingest only. Prefer nginx-verified mTLS. |
+| `GET /api/query/*` | no | no | no | no | yes | CI/query clients only unless a separate public read API is intentionally designed. |
+| `/dev/*`, `/dev2/*` | no | no by default | no by default | yes | no | Development portals should not be public. |
+
+The public allowlist should prefer rendered pages over raw files. If public
+artifact downloads are added, they should use explicit public artifact metadata
+and public-safe filenames rather than inheriting access from the raw result
+file route.
+
+## Reverse Proxy Responsibilities
+
+The reverse proxy should provide reachability control before requests arrive at
+Flask:
+
+- terminate TLS
+- keep Gunicorn bound to loopback or a Unix socket
+- allow only public routes from the public internet
+- return `404` for restricted routes when the client is outside the allowed
+  restricted or operator network
+- keep restricted viewer and operator network lists separate
+- protect runner API routes with mTLS or an equivalent trusted-client gate
+- set security headers for restricted responses, including `Cache-Control:
+  no-store` and `X-Robots-Tag: noindex, noarchive`
+
+Do not base reverse-proxy IP allowlists on client-supplied headers such as
+`X-Forwarded-For`. If another load balancer or CDN is inserted before nginx,
+review the trusted proxy chain and forwarded-header handling before deployment.
+
+Conceptual nginx layout:
+
+```nginx
+# Public routes: allow all.
+location = / { proxy_pass http://portal_backend; }
+location = /systemlist { proxy_pass http://portal_backend; }
+location = /results/ { proxy_pass http://portal_backend; }
+location /static/ { proxy_pass http://portal_backend; }
+
+# Public only after Flask renders a public-safe projection.
+location /results/detail/ { proxy_pass http://portal_backend; }
+location = /results/compare { proxy_pass http://portal_backend; }
+
+# Restricted viewer routes: restricted network first, then Flask auth/role.
+location /estimated/ { return 404; }              # replace with restricted gate
+location = /results/confidential { return 404; }  # replace with restricted gate
+
+# Operator routes: narrow operator network first, then Flask auth/admin role.
+location /admin/ { return 404; }                  # replace with operator gate
+location /execution-profile-requests/ { return 404; }
+location /auth/ { return 404; }
+
+# Runner API: do not expose as a browser-public route.
+location /api/ { return 404; }                    # replace with mTLS gate
+```
+
+The example intentionally omits real IPs and certificate settings. Site-local
+nginx configuration should implement the restricted and operator gates using
+deployment-managed allowlists.
+
+## Flask Responsibilities
+
+Flask should not rely on the reverse proxy alone. It should keep separate
+rendering and authorization paths:
+
+- public views receive only public-safe data
+- public portal mode blocks restricted viewer, authenticated-console, auth,
+  and operator browser endpoints at the Flask layer with `404`
+- operator views may include pipeline, runner, trigger, profile, and allocation
+  context where the user's role permits it
+- confidential and estimated result routes require an authenticated session
+  and per-user affiliation/role filtering
+- raw JSON and artifact downloads check the same permission model as their
+  corresponding rendered views
+- navigation is split into public and operator surfaces
+- public templates do not show login/admin/estimated/confidential/profile
+  request links
+- restricted responses use no-store caching headers
+- access attempts to restricted routes are auditable at nginx and Flask layers
+
+In the current codebase, public and confidential result lists are separate
+(`/results/` and `/results/confidential`). When
+`RESULT_SERVER_PUBLIC_PORTAL_MODE=true` is enabled for the public portal
+deployment, public results list/detail/compare pages use a reduced public
+surface:
+raw JSON links, PA archive links, CI/pipeline columns, trigger internals, PA
+archive tables, quality/validator rows, and environment snapshot rows are
+hidden. Raw result file and environment snapshot routes return `404` in this
+mode. The same public-safe projection is used even if an old authenticated
+session cookie is present on the public host.
+
+The public portal Flask guard allows runner/API endpoints to reach their own
+API authentication layer so that mTLS or runner-scoped API authentication can
+continue to protect CI upload/query clients. Browser routes for auth, estimated
+results, confidential results, profile requests, usage reports, and admin pages
+are blocked by the Flask guard in addition to the reverse proxy policy.
+
+Before publication, review the rendered public detail fields and any future
+public artifact policy against this document.
+
+The route access allowlist is also represented in
+`result_server/utils/portal_access.py`. Tests should fail when a new Flask
+endpoint is added without a conscious public, restricted-viewer,
+authenticated-console, operator, or runner/API classification.
+
+Set `RESULT_SERVER_PUBLIC_PORTAL_MODE=true` to make the deployment expose the
+public browser surface: restricted links are hidden, rendered result pages use
+the public-safe projection, and the Flask public-route allowlist blocks
+restricted browser endpoints. Nginx reachability controls and Flask
+authentication/authorization checks remain required.
+
+Prefer setting this flag in the systemd `EnvironmentFile` used by the public
+main portal deployment, alongside other result-server deployment mode flags
+such as `RESULT_SERVER_TRUSTED_PROXY_AUTH`. Keeping deployment mode variables
+in the `EnvironmentFile` leaves the service unit generic. For example, the
+environment file should contain:
+
+```sh
+RESULT_SERVER_PUBLIC_PORTAL_MODE=true
+```
+
+Development or internal-only portal services may leave the flag unset unless
+they intentionally need to preview the public browser surface.
+
+## Testing Plan
+
+Add lightweight tests as the design is implemented:
+
+- public navigation does not contain `Login`, `Admin`, `Estimated`,
+  `Confidential`, `Profile`, `Allocation`, `Runner`, or `Pipeline`
+- public results list and detail omit pipeline IDs, runner information,
+  allocation values, internal URLs, and profile attribution internals
+- unauthenticated access to confidential and estimated pages does not render
+  protected data
+- restricted raw JSON and archive routes apply the same permission checks as
+  rendered pages
+- route classification tests cover every registered Flask route so new routes
+  must be consciously classified as public, restricted viewer, operator, or
+  runner/API

--- a/result_server/app.py
+++ b/result_server/app.py
@@ -15,6 +15,7 @@ from utils.admin_policy import parse_allowed_affiliations
 from utils.audit_logging import configure_audit_logging
 from utils.auth import parse_ingest_keys
 from utils.csrf import init_csrf
+from utils.portal_access import is_public_portal_mode, register_public_portal_guard
 from utils.preflight import validate_production_config
 
 
@@ -135,6 +136,13 @@ def _configure_api_auth(app):
     ).strip()
 
 
+def _configure_public_portal_mode(app):
+    """Configure whether browser routes expose only the public surface."""
+    app.config["PUBLIC_PORTAL_MODE"] = is_public_portal_mode(
+        os.environ.get("RESULT_SERVER_PUBLIC_PORTAL_MODE")
+    )
+
+
 def _configure_execution_profiles(app, base_dir):
     """Configure the site-local execution profile database path."""
     app.config["EXECUTION_PROFILE_DB_PATH"] = os.environ.get(
@@ -184,7 +192,9 @@ def create_app(prefix="", base_dir=None):
     _configure_upload_limits(app)
     _configure_admin_policy(app)
     _configure_api_auth(app)
+    _configure_public_portal_mode(app)
     _configure_execution_profiles(app, base_dir)
+    register_public_portal_guard(app)
     init_csrf(app, exempt_blueprints=(api_bp,))
 
     register_home_routes(app, prefix=prefix)

--- a/result_server/routes/results_detail_routes.py
+++ b/result_server/routes/results_detail_routes.py
@@ -23,6 +23,9 @@ from utils.trigger_display import load_trigger_run_lookup, summarize_execution_t
 
 
 def register_results_detail_routes(results_bp):
+    def public_surface():
+        return current_app.config.get("PUBLIC_PORTAL_MODE", False)
+
     @results_bp.route("/compare", methods=["GET"])
     def result_compare():
         files_param = request.args.get("files", "")
@@ -31,11 +34,16 @@ def register_results_detail_routes(results_bp):
         if len(filenames) < 2:
             abort(400, "Select 2 or more results to compare")
 
-        compare_context = load_result_compare_context(filenames, current_app.config["RECEIVED_DIR"])
+        compare_context = load_result_compare_context(
+            filenames,
+            current_app.config["RECEIVED_DIR"],
+            public_surface=public_surface(),
+        )
         return render_template("result_compare.html", **compare_context)
 
     @results_bp.route("/detail/<filename>")
     def result_detail(filename):
+        is_public_surface = public_surface()
         result = load_permitted_result_json(
             filename,
             current_app.config["RECEIVED_DIR"],
@@ -49,8 +57,9 @@ def register_results_detail_routes(results_bp):
             quality,
             load_trigger_run_lookup(current_app.config.get("EXECUTION_PROFILE_DB_PATH")),
             padata_filenames,
+            public_surface=is_public_surface,
         )
-        if detail_context.get("environment_snapshot_hash"):
+        if detail_context.get("environment_snapshot_hash") and not is_public_surface:
             detail_context["environment_snapshot_results_url"] = url_for(
                 "results.environment_snapshot_results",
                 snapshot_hash=detail_context["environment_snapshot_hash"],
@@ -59,6 +68,9 @@ def register_results_detail_routes(results_bp):
 
     @results_bp.route("/environment-snapshots/<path:snapshot_hash>")
     def environment_snapshot_results(snapshot_hash):
+        if public_surface():
+            abort(404)
+
         db_path = current_app.config.get("EXECUTION_PROFILE_DB_PATH")
         snapshot = get_environment_snapshot(db_path, snapshot_hash)
         if snapshot is None:
@@ -108,6 +120,9 @@ def register_results_detail_routes(results_bp):
 
     @results_bp.route("/<filename>")
     def show_result(filename):
+        if public_surface():
+            abort(404)
+
         if filename.endswith(".tgz"):
             return serve_permitted_result_file(
                 filename,

--- a/result_server/routes/results_list_routes.py
+++ b/result_server/routes/results_list_routes.py
@@ -15,6 +15,7 @@ from utils.table_query_params import parse_table_query_params
 
 def _render_results_list(public_only, template_name, redirect_endpoint):
     params = parse_table_query_params(request.args)
+    public_surface = public_only and current_app.config.get("PUBLIC_PORTAL_MODE", False)
 
     received_dir = current_app.config["RECEIVED_DIR"]
     received_padata_dir = current_app.config.get("RECEIVED_PADATA_DIR", received_dir)
@@ -29,6 +30,7 @@ def _render_results_list(public_only, template_name, redirect_endpoint):
         filter_exp=params["filter_exp"],
         padata_directory=received_padata_dir,
         execution_profile_db_path=current_app.config.get("EXECUTION_PROFILE_DB_PATH"),
+        public_surface=public_surface,
     )
     filter_kwargs = dict(public_only=public_only)
     template_extra = {}

--- a/result_server/templates/_navigation.html
+++ b/result_server/templates/_navigation.html
@@ -97,13 +97,15 @@
 .nav-dropdown:hover .nav-dropdown-menu { display: block; }
 </style>
 
+{% set public_portal_mode = config.get('PUBLIC_PORTAL_MODE', False) %}
+
 <nav class="nav-bar">
     <div class="nav-left">
         <a href="{{ url_for('home') }}" class="nav-brand">CX Portal</a>
         <a href="{{ url_for('home') }}" class="nav-link {% if request.endpoint == 'home' %}active{% endif %}">Home</a>
         <a href="{{ url_for('systemlist') }}" class="nav-link {% if request.endpoint == 'systemlist' %}active{% endif %}">Systems</a>
 
-        {% if session.get('authenticated') %}
+        {% if session.get('authenticated') and not public_portal_mode %}
         <a href="{{ url_for('results.results') }}" class="nav-link {% if request.endpoint == 'results.results' %}active{% endif %}">Public</a>
         <a href="{{ url_for('results.results_confidential') }}" class="nav-link {% if request.endpoint == 'results.results_confidential' %}active{% endif %}">All Results</a>
         <a href="{{ url_for('estimated.estimated_results') }}" class="nav-link {% if request.endpoint == 'estimated.estimated_results' %}active{% endif %}">Estimated</a>
@@ -116,7 +118,7 @@
     </div>
 
     <div class="nav-right">
-        {% if session.get('authenticated') %}
+        {% if session.get('authenticated') and not public_portal_mode %}
         <div class="nav-dropdown">
             <button class="nav-dropdown-btn">{{ session.get('user_email') }} ▾</button>
             <div class="nav-dropdown-menu right">
@@ -134,7 +136,7 @@
                 <a href="{{ url_for('auth.logout') }}">Logout</a>
             </div>
         </div>
-        {% else %}
+        {% elif not public_portal_mode %}
         <a href="{{ url_for('auth.login') }}" class="nav-link">Login</a>
         {% endif %}
     </div>

--- a/result_server/templates/home.html
+++ b/result_server/templates/home.html
@@ -2,9 +2,21 @@
 
 {% block title %}CX Portal{% endblock %}
 {% block page_title %}CX Data Flow, Connected Systems, and Portal Access{% endblock %}
-{% block page_subtitle %}This portal is part of the CX Framework, supporting continuous benchmarking, estimation, and feedback for integrated HPC applications.{% endblock %}
+{% block page_subtitle %}
+{% if config.get('PUBLIC_PORTAL_MODE', False) %}
+This portal publishes public CX benchmark results and connected system information for integrated HPC applications.
+{% else %}
+This portal is part of the CX Framework, supporting continuous benchmarking, estimation, and feedback for integrated HPC applications.
+{% endif %}
+{% endblock %}
 
 {% block content %}
+{% set public_portal_mode = config.get('PUBLIC_PORTAL_MODE', False) %}
+{% set is_authenticated = session.get('authenticated') %}
+{% set show_restricted_entries = is_authenticated and not public_portal_mode %}
+{% set is_operator = show_restricted_entries and 'admin' in session.get('user_affiliations', []) %}
+{% set public_surface = public_portal_mode %}
+{% set entry_point_count = 4 if is_operator else (2 if public_surface else 3) %}
 <style>
     .home-overview-grid {
         display: grid;
@@ -198,14 +210,18 @@
     <section class="page-card">
         <h2 class="section-title">Start Here</h2>
         <p class="section-intro">
+            {% if public_surface %}
+            Browse public measured results, inspect connected systems, and open onboarding guides for applications and sites.
+            {% else %}
             Browse measured and estimated results, inspect connected systems, and jump directly into onboarding guides for applications and sites.
+            {% endif %}
         </p>
         <div class="home-actions">
             <a class="home-action-link home-action-link-primary" href="{{ url_for('results.results') }}">Browse Results</a>
             <a class="home-action-link home-action-link-secondary" href="{{ url_for('systemlist') }}">View All Systems</a>
-            {% if session.get('authenticated') %}
+            {% if show_restricted_entries %}
             <a class="home-action-link home-action-link-secondary" href="{{ url_for('estimated.estimated_results') }}">Open Estimated Results</a>
-            {% else %}
+            {% elif not public_portal_mode %}
             <a class="home-action-link home-action-link-locked" href="{{ url_for('auth.login') }}">Estimated Results (login required)</a>
             {% endif %}
         </div>
@@ -222,12 +238,12 @@
                 <span class="home-summary-label">Connected systems</span>
             </div>
             <div class="home-summary-card">
-                <span class="home-summary-value">{% if session.get('authenticated') and 'admin' in session.get('user_affiliations', []) %}4{% else %}3{% endif %}</span>
+                <span class="home-summary-value">{{ entry_point_count }}</span>
                 <span class="home-summary-label">Primary entry points</span>
             </div>
             <div class="home-summary-card">
                 <span class="home-summary-value">Results</span>
-                <span class="home-summary-label">Measured and projected views</span>
+                <span class="home-summary-label">{% if public_surface %}Public measured views{% else %}Measured and projected views{% endif %}</span>
             </div>
             <div class="home-summary-card">
                 <span class="home-summary-value">Guides</span>
@@ -237,19 +253,24 @@
     </aside>
 </section>
 
-<section class="home-content-grid {% if session.get('authenticated') and 'admin' in session.get('user_affiliations', []) %}home-content-grid-three{% endif %}">
+<section class="home-content-grid {% if is_operator %}home-content-grid-three{% endif %}">
     <section class="page-card">
         <h2 class="section-title">Main Entry Points</h2>
         <p class="section-intro">
+            {% if public_surface %}
+            Start here for the public portal pages used to browse measured results and connected systems.
+            {% else %}
             Start here for the main portal pages used to browse measured results, projected outputs, and connected systems.
+            {% endif %}
         </p>
         <div class="home-link-list">
             <a class="home-link-card" href="{{ url_for('results.results') }}">
                 <strong>Results</strong>
                 <span>Browse measured benchmark results, compare runs, and inspect result-quality detail pages.</span>
             </a>
-            <a class="home-link-card" href="{% if session.get('authenticated') %}{{ url_for('estimated.estimated_results') }}{% else %}{{ url_for('auth.login') }}{% endif %}">
-                {% if session.get('authenticated') %}
+            {% if show_restricted_entries or not public_portal_mode %}
+            <a class="home-link-card" href="{% if show_restricted_entries %}{{ url_for('estimated.estimated_results') }}{% else %}{{ url_for('auth.login') }}{% endif %}">
+                {% if show_restricted_entries %}
                 <strong>Estimated Results</strong>
                 <span>Review system projections, current/future breakdowns, and estimation detail derived from benchmark inputs.</span>
                 {% else %}
@@ -258,6 +279,7 @@
                 <span class="home-access-note">Login required</span>
                 {% endif %}
             </a>
+            {% endif %}
             <a class="home-link-card" href="{{ url_for('systemlist') }}">
                 <strong>Systems</strong>
                 <span>See connected systems, quick hardware summaries, and onboarding-facing system metadata.</span>
@@ -292,7 +314,7 @@
         </div>
     </section>
 
-    {% if session.get('authenticated') and 'admin' in session.get('user_affiliations', []) %}
+    {% if is_operator %}
     <section class="page-card">
         <h2 class="section-title">Operations Views</h2>
         <p class="section-intro">

--- a/result_server/tests/test_environment_snapshot_results_route.py
+++ b/result_server/tests/test_environment_snapshot_results_route.py
@@ -97,6 +97,29 @@ def test_environment_snapshot_results_route_lists_linked_results(tmp_path):
     assert "0.03" in html
 
 
+def test_public_portal_mode_blocks_anonymous_environment_snapshot_results(tmp_path):
+    received_dir = tmp_path / "received"
+    received_dir.mkdir()
+    db_path = tmp_path / "cx_portal.sqlite3"
+    filename = "result_20260810_160604_11111111-2222-3333-4444-555555555555.json"
+    payload = _payload("11111111-2222-3333-4444-555555555555")
+    _write_json(received_dir / filename, payload)
+    assert index_environment_snapshot(
+        db_path=str(db_path),
+        payload=payload,
+        json_file=filename,
+    )
+
+    app = build_results_route_app(received_dir=str(received_dir))
+    _add_navigation_routes(app)
+    app.config["EXECUTION_PROFILE_DB_PATH"] = str(db_path)
+    app.config["PUBLIC_PORTAL_MODE"] = True
+
+    response = app.test_client().get("/results/environment-snapshots/sha256:routeabc")
+
+    assert response.status_code == 404
+
+
 def test_result_detail_links_to_environment_snapshot_results(tmp_path):
     received_dir = tmp_path / "received"
     received_dir.mkdir()
@@ -112,3 +135,24 @@ def test_result_detail_links_to_environment_snapshot_results(tmp_path):
     html = response.get_data(as_text=True)
     assert "View results with this snapshot" in html
     assert "/results/environment-snapshots/sha256:routeabc" in html
+
+
+def test_public_portal_mode_result_detail_omits_environment_snapshot_link(tmp_path):
+    received_dir = tmp_path / "received"
+    received_dir.mkdir()
+    filename = "result_20260810_160604_11111111-2222-3333-4444-555555555555.json"
+    _write_json(received_dir / filename, _payload("11111111-2222-3333-4444-555555555555"))
+
+    app = build_results_route_app(received_dir=str(received_dir))
+    _add_navigation_routes(app)
+    app.config["EXECUTION_PROFILE_DB_PATH"] = str(tmp_path / "cx_portal.sqlite3")
+    app.config["PUBLIC_PORTAL_MODE"] = True
+    response = app.test_client().get(f"/results/detail/{filename}")
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert "View results with this snapshot" not in html
+    assert "/results/environment-snapshots/sha256:routeabc" not in html
+    assert "Pipeline ID" not in html
+    assert "Allocation Project ID" not in html
+    assert "Runner" not in html

--- a/result_server/tests/test_portal_access_policy.py
+++ b/result_server/tests/test_portal_access_policy.py
@@ -1,0 +1,183 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from test_support import build_portal_route_app, build_portal_shell_app, install_portal_test_stubs
+
+install_portal_test_stubs(include_otp=False)
+
+from utils.portal_access import (
+    ACCESS_AUTHENTICATED_CONSOLE,
+    ACCESS_OPERATOR,
+    ACCESS_PUBLIC,
+    ACCESS_PUBLIC_CONDITIONAL,
+    ACCESS_RESTRICTED_VIEWER,
+    ACCESS_RUNNER_API,
+    classify_endpoint,
+    register_public_portal_guard,
+)
+
+
+def _portal_app(tmp_path):
+    received_dir = tmp_path / "received"
+    estimated_dir = tmp_path / "estimated"
+    padata_dir = tmp_path / "received_padata"
+    for path in (received_dir, estimated_dir, padata_dir):
+        path.mkdir()
+
+    app = build_portal_route_app(
+        templates_dir=os.path.join(os.path.dirname(__file__), "..", "templates"),
+        received_dir=str(received_dir),
+        estimated_dir=str(estimated_dir),
+    )
+    app.config["RECEIVED_PADATA_DIR"] = str(padata_dir)
+
+    from routes.api import api_bp
+    from routes.security_metadata import register_security_metadata_routes
+
+    register_security_metadata_routes(app)
+    app.register_blueprint(api_bp)
+    return app
+
+
+def test_every_registered_route_has_access_class(tmp_path):
+    app = _portal_app(tmp_path)
+
+    unclassified = sorted(
+        rule.endpoint
+        for rule in app.url_map.iter_rules()
+        if classify_endpoint(rule.endpoint) is None
+    )
+
+    assert unclassified == []
+
+
+def test_representative_route_access_classes():
+    assert classify_endpoint("home") == ACCESS_PUBLIC
+    assert classify_endpoint("systemlist") == ACCESS_PUBLIC
+    assert classify_endpoint("results.results") == ACCESS_PUBLIC
+    assert classify_endpoint("results.result_detail") == ACCESS_PUBLIC_CONDITIONAL
+    assert classify_endpoint("results.show_result") == ACCESS_RESTRICTED_VIEWER
+    assert classify_endpoint("results.results_confidential") == ACCESS_RESTRICTED_VIEWER
+    assert classify_endpoint("estimated.estimated_results") == ACCESS_RESTRICTED_VIEWER
+    assert classify_endpoint("auth.login") == ACCESS_RESTRICTED_VIEWER
+    assert classify_endpoint("profile_requests.my_profile_requests") == ACCESS_AUTHENTICATED_CONSOLE
+    assert classify_endpoint("results.usage_report") == ACCESS_OPERATOR
+    assert classify_endpoint("admin.users") == ACCESS_OPERATOR
+    assert classify_endpoint("api.ingest_result") == ACCESS_RUNNER_API
+
+
+def test_public_portal_mode_blocks_restricted_browser_routes_but_allows_api_auth(tmp_path):
+    app = _portal_app(tmp_path)
+    app.config["PUBLIC_PORTAL_MODE"] = True
+    register_public_portal_guard(app)
+
+    with app.test_client() as client:
+        assert client.get("/").status_code == 200
+        assert client.get("/auth/login").status_code == 404
+        assert client.get("/estimated/").status_code == 404
+        assert client.get("/results/confidential").status_code == 404
+        assert client.get("/admin/users").status_code == 404
+        assert client.get("/execution-profile-requests/").status_code == 404
+
+        response = client.get("/api/query/result")
+
+    assert response.status_code == 401
+
+
+def test_public_portal_mode_hides_anonymous_restricted_navigation():
+    app = build_portal_shell_app(
+        templates_dir=os.path.join(os.path.dirname(__file__), "..", "templates"),
+    )
+    app.config["PUBLIC_PORTAL_MODE"] = True
+
+    with app.test_request_context("/"):
+        from flask import render_template
+
+        html = render_template("_navigation.html")
+
+    assert "Home" in html
+    assert "Systems" in html
+    assert "Results" in html
+    assert "Login" not in html
+    assert "Admin" not in html
+    assert "Estimated" not in html
+    assert "Confidential" not in html
+    assert "Profile" not in html
+
+
+def test_public_portal_mode_hides_authenticated_restricted_navigation():
+    app = build_portal_shell_app(
+        templates_dir=os.path.join(os.path.dirname(__file__), "..", "templates"),
+    )
+    app.config["PUBLIC_PORTAL_MODE"] = True
+
+    with app.test_request_context("/"):
+        from flask import render_template, session
+
+        session["authenticated"] = True
+        session["user_email"] = "admin@example.test"
+        session["user_affiliations"] = ["admin"]
+        html = render_template("_navigation.html")
+
+    assert "Home" in html
+    assert "Systems" in html
+    assert "Results" in html
+    assert "admin@example.test" not in html
+    assert "Login" not in html
+    assert "Admin" not in html
+    assert "Estimated" not in html
+    assert "Confidential" not in html
+    assert "Profile" not in html
+
+
+def test_public_portal_mode_hides_home_restricted_entry_points(monkeypatch):
+    monkeypatch.delenv("CX_DISCORD_INVITE_URL", raising=False)
+    app = build_portal_shell_app(
+        templates_dir=os.path.join(os.path.dirname(__file__), "..", "templates"),
+        include_home_route=False,
+    )
+    app.config["PUBLIC_PORTAL_MODE"] = True
+
+    from routes.home import register_home_routes
+
+    register_home_routes(app)
+
+    with app.test_client() as client:
+        response = client.get("/")
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert "Browse Results" in html
+    assert "View All Systems" in html
+    assert "Estimated Results (login required)" not in html
+    assert "Open Estimated Results" not in html
+    assert "Login required" not in html
+
+
+def test_public_portal_mode_hides_home_restricted_entry_points_when_authenticated(monkeypatch):
+    monkeypatch.delenv("CX_DISCORD_INVITE_URL", raising=False)
+    app = build_portal_shell_app(
+        templates_dir=os.path.join(os.path.dirname(__file__), "..", "templates"),
+        include_home_route=False,
+    )
+    app.config["PUBLIC_PORTAL_MODE"] = True
+
+    from routes.home import register_home_routes
+
+    register_home_routes(app)
+
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["authenticated"] = True
+            sess["user_email"] = "admin@example.test"
+            sess["user_affiliations"] = ["admin"]
+        response = client.get("/")
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert "Browse Results" in html
+    assert "View All Systems" in html
+    assert "Open Estimated Results" not in html
+    assert "Operations Views" not in html
+    assert "Profile Request Review" not in html

--- a/result_server/tests/test_result_compare_view.py
+++ b/result_server/tests/test_result_compare_view.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 
@@ -6,7 +7,7 @@ from test_support import install_portal_test_stubs
 
 install_portal_test_stubs()
 
-from utils.result_compare_view import build_result_compare_context
+from utils.result_compare_view import build_result_compare_context, load_result_compare_context
 
 
 def test_build_result_compare_context_marks_same_system_code_as_not_mixed():
@@ -55,3 +56,46 @@ def test_build_result_compare_context_uses_vector_axis_metadata():
     assert context["has_vector_metrics"] is True
     assert context["compare_chart"]["vector_axis_label"] == "message_size (bytes)"
     assert context["compare_chart"]["fom_unit"] == "s"
+
+
+def test_public_surface_compare_context_projects_raw_result_data(tmp_path):
+    filename = "result_20250101_120000_11111111-2222-3333-4444-555555555555.json"
+    payload = {
+        "code": "qws",
+        "system": "Fugaku",
+        "Exp": "CASE0",
+        "FOM": 1.0,
+        "FOM_unit": "s",
+        "pipeline_id": 1234,
+        "runner": "internal-runner",
+        "environment_snapshot": {
+            "summary": {
+                "allocation_project_id": "allocation-id",
+                "runner": "internal-runner",
+            },
+        },
+        "metrics": {
+            "scalar": {"internal_metric": 2.0},
+            "vector": {
+                "x_axis": {"name": "message_size", "unit": "bytes"},
+                "table": {"columns": ["message_size", "Bandwidth"], "rows": [[1, 2.0]]},
+            },
+        },
+    }
+    with open(tmp_path / filename, "w", encoding="utf-8") as f:
+        json.dump(payload, f)
+
+    context = load_result_compare_context(
+        [filename],
+        str(tmp_path),
+        public_surface=True,
+    )
+
+    projected = context["results"][0]["data"]
+    assert projected["code"] == "qws"
+    assert projected["FOM"] == 1.0
+    assert "pipeline_id" not in projected
+    assert "runner" not in projected
+    assert "environment_snapshot" not in projected
+    assert "scalar" not in projected["metrics"]
+    assert projected["metrics"]["vector"]["x_axis"]["name"] == "message_size"

--- a/result_server/tests/test_result_detail_template.py
+++ b/result_server/tests/test_result_detail_template.py
@@ -100,10 +100,15 @@ FULL_QUALITY = {
 }
 
 
-def _render_result_detail(result, quality, padata_filenames=None):
+def _render_result_detail(result, quality, padata_filenames=None, *, public_surface=False):
     from flask import render_template
 
-    detail_context = build_result_detail_context(result, quality, padata_filenames=padata_filenames)
+    detail_context = build_result_detail_context(
+        result,
+        quality,
+        padata_filenames=padata_filenames,
+        public_surface=public_surface,
+    )
     return render_template("result_detail.html", result=result, quality=quality, **detail_context)
 
 
@@ -128,6 +133,25 @@ class TestResultDetailTemplate:
         assert "slurm" in html
         assert "Back to Results" in html
         assert "Results" in html
+
+    def test_public_surface_meta_omits_operator_fields(self, app):
+        with app.test_request_context():
+            html = _render_result_detail(FULL_RESULT, FULL_QUALITY, public_surface=True)
+
+        assert "benchpark-osu-micro-benchmarks" in html
+        assert "RC_GH200" in html
+        assert "6.470" in html
+        assert "Pipeline ID" not in html
+        assert "Parent Pipeline ID" not in html
+        assert "Run Cause" not in html
+        assert "<h2>Quality</h2>" not in html
+        assert "Suggested Actions" not in html
+        assert "Improvement Candidates" not in html
+        assert "Environment Snapshot" not in html
+        assert "Allocation Project ID" not in html
+        assert "Runner" not in html
+        assert "rccs-cloud" not in html
+        assert "gh200-runner" not in html
 
     def test_vector_chart_section(self, app):
         with app.test_request_context():
@@ -207,6 +231,43 @@ class TestResultDetailTemplate:
         assert "pairlist" in html
         assert "results/padata_k003_void_kern_build_pairlist.tgz" in html
         assert f'href="/results/{filename}"' in html
+
+    def test_public_surface_omits_padata_archive_links(self, app):
+        result = {
+            **FULL_RESULT,
+            "_server_uuid": "12345678-1234-1234-1234-123456789abc",
+            "_server_timestamp": "20260819_161329",
+            "fom_breakdown": {
+                "sections": [
+                    {
+                        "name": "pairlist",
+                        "time": 1.0,
+                        "artifacts": [
+                            {
+                                "type": "file_reference",
+                                "path": "results/padata_k003_void_kern_build_pairlist.tgz",
+                            }
+                        ],
+                    }
+                ],
+                "overlaps": [],
+            },
+        }
+        filename = (
+            "padata_20260819_161329_12345678-1234-1234-1234-123456789abc_"
+            "padata_k003_void_kern_build_pairlist.tgz"
+        )
+
+        with app.test_request_context():
+            html = _render_result_detail(
+                result,
+                FULL_QUALITY,
+                [filename],
+                public_surface=True,
+            )
+
+        assert "PA Data Archives" not in html
+        assert f'href="/results/{filename}"' not in html
 
     def test_vector_data_table(self, app):
         with app.test_request_context():

--- a/result_server/tests/test_result_padata_route.py
+++ b/result_server/tests/test_result_padata_route.py
@@ -52,6 +52,41 @@ def test_results_route_serves_padata_from_received_padata_dir(client, tmp_dirs):
     assert resp.data == b"fake tgz content"
 
 
+def test_public_portal_mode_blocks_anonymous_raw_result_files(client, app, tmp_dirs):
+    received, received_padata = tmp_dirs
+    app.config["PUBLIC_PORTAL_MODE"] = True
+    uid = "12345678-1234-1234-1234-123456789abc"
+    json_name = f"result_20250101_120000_{uid}.json"
+    tgz_name = f"padata_20250101_120000_{uid}.tgz"
+
+    with open(os.path.join(received, json_name), "w", encoding="utf-8") as f:
+        json.dump({"code": "qws", "system": "Fugaku", "FOM": 1.0}, f)
+    with open(os.path.join(received_padata, tgz_name), "wb") as f:
+        f.write(b"fake tgz content")
+
+    assert client.get(f"/results/{json_name}").status_code == 404
+    assert client.get(f"/results/{tgz_name}").status_code == 404
+
+
+def test_public_portal_mode_blocks_authenticated_raw_result_files(client, app, tmp_dirs):
+    received, received_padata = tmp_dirs
+    app.config["PUBLIC_PORTAL_MODE"] = True
+    uid = "12345678-1234-1234-1234-123456789abc"
+    json_name = f"result_20250101_120000_{uid}.json"
+    tgz_name = f"padata_20250101_120000_{uid}.tgz"
+
+    with open(os.path.join(received, json_name), "w", encoding="utf-8") as f:
+        json.dump({"code": "qws", "system": "Fugaku", "FOM": 1.0}, f)
+    with open(os.path.join(received_padata, tgz_name), "wb") as f:
+        f.write(b"fake tgz content")
+
+    with client.session_transaction() as sess:
+        sess["authenticated"] = True
+
+    assert client.get(f"/results/{json_name}").status_code == 404
+    assert client.get(f"/results/{tgz_name}").status_code == 404
+
+
 def test_results_route_blocks_confidential_padata_matched_by_server_uuid(client, tmp_dirs):
     received, received_padata = tmp_dirs
     uid = "12345678-1234-1234-1234-123456789abc"

--- a/result_server/tests/test_results_loader.py
+++ b/result_server/tests/test_results_loader.py
@@ -285,6 +285,48 @@ class TestLoadResultsTableExtension:
         ]
         assert columns == expected_columns
 
+    def test_public_surface_columns_and_links_are_reduced(self, flask_app, tmp_dir):
+        uid = str(uuid.uuid4())
+        filename = f"result_20250101_120000_{uid}.json"
+        padata_dir = os.path.join(tmp_dir, "padata")
+        os.mkdir(padata_dir)
+        _write_json(tmp_dir, filename, {
+            "code": "genesis",
+            "system": "RIKYU",
+            "Exp": "CASE0",
+            "FOM": 1.0,
+            "pipeline_id": 17026,
+            "ci_trigger": "schedule",
+            "profile_data": {
+                "tool": "ncu",
+                "level": "single",
+                "report_format": "text",
+                "run_count": 1,
+                "ncu_options": ["--set", "basic"],
+            },
+        })
+        with open(os.path.join(padata_dir, f"padata_20250101_120000_{uid}.tgz"), "wb") as f:
+            f.write(b"padata")
+
+        with flask_app.test_request_context():
+            rows, columns, _ = load_results_table(
+                tmp_dir,
+                public_only=True,
+                padata_directory=padata_dir,
+                public_surface=True,
+            )
+
+        column_keys = [column["key"] for column in columns]
+        assert "json_link" not in column_keys
+        assert "ci_summary" not in column_keys
+        assert "execution_trigger_summary" not in column_keys
+        assert "profile_summary" in column_keys
+        assert rows[0]["json_link"] is None
+        assert rows[0]["data_link"] is None
+        assert rows[0]["source_link"] is None
+        assert rows[0]["profile_summary"] == "ncu / single"
+        assert rows[0]["profile_summary_meta"]["ncu_options"] == ["--set", "basic"]
+
     def test_existing_row_fields_preserved(self, flask_app, tmp_dir):
         """Test case."""
         uid = str(uuid.uuid4())

--- a/result_server/utils/portal_access.py
+++ b/result_server/utils/portal_access.py
@@ -1,0 +1,111 @@
+"""Route access classification for CX Portal deployment policy."""
+
+from __future__ import annotations
+
+from flask import abort, request
+
+
+ACCESS_PUBLIC = "public"
+ACCESS_PUBLIC_CONDITIONAL = "public_conditional"
+ACCESS_RESTRICTED_VIEWER = "restricted_viewer"
+ACCESS_AUTHENTICATED_CONSOLE = "authenticated_console"
+ACCESS_OPERATOR = "operator"
+ACCESS_RUNNER_API = "runner_api"
+
+ACCESS_CLASSES = {
+    ACCESS_PUBLIC,
+    ACCESS_PUBLIC_CONDITIONAL,
+    ACCESS_RESTRICTED_VIEWER,
+    ACCESS_AUTHENTICATED_CONSOLE,
+    ACCESS_OPERATOR,
+    ACCESS_RUNNER_API,
+}
+
+PUBLIC_ENDPOINTS = frozenset(
+    {
+        "home",
+        "systemlist",
+        "static",
+        "results.results",
+    }
+)
+
+PUBLIC_CONDITIONAL_ENDPOINTS = frozenset(
+    {
+        "results.result_compare",
+        "results.result_detail",
+    }
+)
+
+RESTRICTED_VIEWER_ENDPOINTS = frozenset(
+    {
+        "auth.login",
+        "auth.logout",
+        "auth.setup",
+        "estimated.estimated_detail",
+        "estimated.estimated_results",
+        "estimated.show_estimated_result",
+        "results.environment_snapshot_results",
+        "results.results_confidential",
+        "results.show_result",
+    }
+)
+
+AUTHENTICATED_CONSOLE_ENDPOINT_PREFIXES = ("profile_requests.",)
+OPERATOR_ENDPOINT_PREFIXES = ("admin.",)
+OPERATOR_ENDPOINTS = frozenset({"results.usage_report"})
+RUNNER_API_ENDPOINT_PREFIXES = ("api.",)
+PUBLIC_ENDPOINT_PREFIXES = ("security_metadata",)
+PUBLIC_PORTAL_ALLOWED_ACCESS_CLASSES = frozenset(
+    {
+        ACCESS_PUBLIC,
+        ACCESS_PUBLIC_CONDITIONAL,
+        ACCESS_RUNNER_API,
+    }
+)
+
+
+def is_public_portal_mode(value) -> bool:
+    """Return whether a config/env value enables the public portal surface."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def classify_endpoint(endpoint: str) -> str | None:
+    """Return the deployment access class for a Flask endpoint."""
+    if endpoint in PUBLIC_ENDPOINTS or endpoint.startswith(PUBLIC_ENDPOINT_PREFIXES):
+        return ACCESS_PUBLIC
+    if endpoint in PUBLIC_CONDITIONAL_ENDPOINTS:
+        return ACCESS_PUBLIC_CONDITIONAL
+    if endpoint in RESTRICTED_VIEWER_ENDPOINTS:
+        return ACCESS_RESTRICTED_VIEWER
+    if endpoint in OPERATOR_ENDPOINTS or endpoint.startswith(OPERATOR_ENDPOINT_PREFIXES):
+        return ACCESS_OPERATOR
+    if endpoint.startswith(AUTHENTICATED_CONSOLE_ENDPOINT_PREFIXES):
+        return ACCESS_AUTHENTICATED_CONSOLE
+    if endpoint.startswith(RUNNER_API_ENDPOINT_PREFIXES):
+        return ACCESS_RUNNER_API
+    return None
+
+
+def is_endpoint_allowed_in_public_portal(endpoint: str | None) -> bool:
+    """Return whether an endpoint may be reached when public portal mode is on."""
+    if not endpoint:
+        return False
+    access_class = classify_endpoint(endpoint)
+    return access_class in PUBLIC_PORTAL_ALLOWED_ACCESS_CLASSES
+
+
+def register_public_portal_guard(app):
+    """Install a Flask allowlist guard for public portal deployments."""
+
+    @app.before_request
+    def enforce_public_portal_allowlist():
+        if not app.config.get("PUBLIC_PORTAL_MODE", False):
+            return None
+        if is_endpoint_allowed_in_public_portal(request.endpoint):
+            return None
+        abort(404)

--- a/result_server/utils/result_compare_view.py
+++ b/result_server/utils/result_compare_view.py
@@ -41,10 +41,35 @@ def build_result_compare_context(results):
     }
 
 
-def load_result_compare_context(filenames, directory):
+def load_result_compare_context(filenames, directory, *, public_surface=False):
     for filename in filenames:
         check_file_permission(filename, directory)
     results = load_result_json_batch(filenames, directory)
     if len(results) != len(filenames):
         abort(404, "Result file not found")
+    if public_surface:
+        results = [_project_public_compare_result(row) for row in results]
     return build_result_compare_context(results)
+
+
+def _project_public_compare_result(row):
+    data = row.get("data") or {}
+    metrics = data.get("metrics") if isinstance(data.get("metrics"), dict) else {}
+    public_metrics = {}
+    if isinstance(metrics.get("vector"), dict):
+        public_metrics["vector"] = metrics["vector"]
+
+    public_data = {
+        "code": data.get("code"),
+        "system": data.get("system"),
+        "Exp": data.get("Exp"),
+        "FOM": data.get("FOM"),
+        "FOM_unit": data.get("FOM_unit") or "",
+    }
+    if public_metrics:
+        public_data["metrics"] = public_metrics
+
+    return {
+        "timestamp": row.get("timestamp"),
+        "data": public_data,
+    }

--- a/result_server/utils/result_detail_view.py
+++ b/result_server/utils/result_detail_view.py
@@ -7,51 +7,69 @@ from utils.result_records import build_labeled_value_rows, format_numeric_value
 from utils.trigger_display import summarize_execution_trigger
 
 
-def build_result_detail_context(result, quality, trigger_runs_by_pipeline=None, padata_filenames=None):
+def build_result_detail_context(
+    result,
+    quality,
+    trigger_runs_by_pipeline=None,
+    padata_filenames=None,
+    *,
+    public_surface=False,
+):
     profile_data = result.get("profile_data") or {}
     build_data = result.get("build") or {}
     vector_metrics = (result.get("metrics") or {}).get("vector")
     scalar_metrics = (result.get("metrics") or {}).get("scalar") or {}
 
     return {
-        "meta_rows": _build_meta_rows(result, trigger_runs_by_pipeline),
+        "meta_rows": _build_meta_rows(result, trigger_runs_by_pipeline, public_surface=public_surface),
         "profile_rows": _build_profile_rows(profile_data),
-        "quality_rows": _build_quality_rows(quality),
-        "profile_artifact_rows": _build_profile_artifact_rows(result, padata_filenames or []),
-        "environment_rows": _build_environment_rows(result.get("environment_snapshot")),
-        "environment_snapshot_hash": _environment_snapshot_hash(result.get("environment_snapshot")),
+        "quality_rows": [] if public_surface else _build_quality_rows(quality),
+        "profile_artifact_rows": (
+            [] if public_surface else _build_profile_artifact_rows(result, padata_filenames or [])
+        ),
+        "environment_rows": (
+            [] if public_surface else _build_environment_rows(result.get("environment_snapshot"))
+        ),
+        "environment_snapshot_hash": (
+            "" if public_surface else _environment_snapshot_hash(result.get("environment_snapshot"))
+        ),
         "vector_metrics": vector_metrics,
         "scalar_rows": _build_scalar_rows(scalar_metrics),
         "build_rows": _build_build_rows(build_data),
     }
 
 
-def _build_meta_rows(result, trigger_runs_by_pipeline=None):
+def _build_meta_rows(result, trigger_runs_by_pipeline=None, *, public_surface=False):
     trigger_summary = summarize_execution_trigger(result, trigger_runs_by_pipeline)
-    rows = build_labeled_value_rows([
+    base_items = [
         ("Code", result.get("code", "N/A")),
         ("System", result.get("system", "N/A")),
         ("Exp", result.get("Exp", "N/A")),
         ("FOM", format_numeric_value(result.get("FOM", "N/A"))),
         ("FOM Unit", result.get("FOM_unit") or "not specified"),
         ("Node Count", result.get("node_count", "N/A")),
-        ("Pipeline ID", result.get("pipeline_id", "N/A")),
-        (
-            "Run Cause",
+    ]
+    if not public_surface:
+        base_items.extend([
+            ("Pipeline ID", result.get("pipeline_id", "N/A")),
             (
-                f"{trigger_summary['headline']} ({trigger_summary['subline']})"
-                if trigger_summary.get("subline")
-                else trigger_summary["headline"]
+                "Run Cause",
+                (
+                    f"{trigger_summary['headline']} ({trigger_summary['subline']})"
+                    if trigger_summary.get("subline")
+                    else trigger_summary["headline"]
+                ),
             ),
-        ),
-    ])
+        ])
+    rows = build_labeled_value_rows(base_items)
 
     optional_rows = [
         ("Processes per Node", result.get("numproc_node")),
         ("Threads per Process", result.get("nthreads")),
         ("CPUs per Node", result.get("cpus_per_node")),
-        ("Parent Pipeline ID", result.get("parent_pipeline_id")),
     ]
+    if not public_surface:
+        optional_rows.append(("Parent Pipeline ID", result.get("parent_pipeline_id")))
     for label, value in optional_rows:
         if value not in (None, "", "N/A", "null"):
             rows.append({"label": label, "value": value})

--- a/result_server/utils/result_table_rows.py
+++ b/result_server/utils/result_table_rows.py
@@ -16,13 +16,19 @@ def build_result_table_row(
     result_data,
     padata_filenames,
     trigger_runs_by_pipeline=None,
+    *,
+    public_surface=False,
 ):
     """Build a single row for the public/confidential results index table."""
     timestamp = format_result_timestamp(json_filename)
-    matched_padata = _find_matching_padata_archive(json_filename, result_data, padata_filenames)
+    matched_padata = (
+        None
+        if public_surface
+        else _find_matching_padata_archive(json_filename, result_data, padata_filenames)
+    )
     pipeline_timing = result_data.get("pipeline_timing", {})
     source_info = result_data.get("source_info")
-    source_link = _build_source_link(source_info)
+    source_link = None if public_surface else _build_source_link(source_info)
     profile_data = result_data.get("profile_data")
 
     ci_trigger = result_data.get("ci_trigger", "-") or "-"
@@ -51,7 +57,7 @@ def build_result_table_row(
         "nodes": result_data.get("node_count", "N/A"),
         "numproc_node": _normalize_optional_field(result_data.get("numproc_node")),
         "nthreads": _normalize_optional_field(result_data.get("nthreads")),
-        "json_link": url_for("results.show_result", filename=json_filename),
+        "json_link": None if public_surface else url_for("results.show_result", filename=json_filename),
         "data_link": url_for("results.show_result", filename=matched_padata) if matched_padata else None,
         "has_vector": _has_vector_metrics(result_data),
         "detail_link": url_for("results.result_detail", filename=json_filename),

--- a/result_server/utils/results_loader.py
+++ b/result_server/utils/results_loader.py
@@ -33,6 +33,12 @@ RESULT_TABLE_COLUMNS = [
     {"label": "CI", "key": "ci_summary", "tooltip": "CI trigger source and pipeline ID"},
 ]
 
+PUBLIC_RESULT_TABLE_COLUMNS = [
+    column
+    for column in RESULT_TABLE_COLUMNS
+    if column["key"] not in {"execution_trigger_summary", "json_link", "ci_summary"}
+]
+
 
 def load_results_table(
     directory,
@@ -46,6 +52,7 @@ def load_results_table(
     filter_exp=None,
     padata_directory=None,
     execution_profile_db_path=None,
+    public_surface=False,
 ):
     per_page = normalize_per_page(per_page)
 
@@ -55,7 +62,7 @@ def load_results_table(
     padata_dir = padata_directory or directory
     padata_filenames = [filename for filename in os.listdir(padata_dir) if filename.endswith(".tgz")]
 
-    columns = RESULT_TABLE_COLUMNS
+    columns = PUBLIC_RESULT_TABLE_COLUMNS if public_surface else RESULT_TABLE_COLUMNS
     trigger_runs_by_pipeline = load_trigger_run_lookup(execution_profile_db_path)
 
     has_filters = filters_are_active(filter_system, filter_code, filter_exp)
@@ -88,6 +95,7 @@ def load_results_table(
                     result_data,
                     padata_filenames,
                     trigger_runs_by_pipeline,
+                    public_surface=public_surface,
                 )
             )
 
@@ -118,6 +126,7 @@ def load_results_table(
                 result_data,
                 padata_filenames,
                 trigger_runs_by_pipeline,
+                public_surface=public_surface,
             )
         )
 


### PR DESCRIPTION
## Summary
- add a public portal mode route allowlist and access classification
- reduce public result list/detail/compare views to public-safe fields
- document the reverse-proxy and Flask responsibility split for public deployments

## Tests
- .venv/bin/python -m pytest result_server/tests
- git diff --cached --check
- python3 scripts/tests/check_text_integrity.py