### PR TITLE
Support console-prefixed profile request links

### DIFF
--- a/result_server/templates/_navigation.html
+++ b/result_server/templates/_navigation.html
@@ -126,11 +126,11 @@
                 <a href="{{ url_for('admin.users') }}">Admin</a>
                 <a href="{{ url_for('admin.execution_profiles') }}">Execution Profiles</a>
                 <a href="{{ url_for('admin.execution_profile_requests') }}">Profile Request Review</a>
-                {% set portal_prefix = '/dev2' if request.path.startswith('/dev2/') else ('/dev' if request.path.startswith('/dev/') else '') %}
+                {% set portal_prefix = '/console' if request.path.startswith('/console/') else ('/dev2' if request.path.startswith('/dev2/') else ('/dev' if request.path.startswith('/dev/') else '')) %}
                 <a href="{{ portal_prefix }}/execution-profile-requests/">Profile Requests</a>
                 <hr>
                 {% else %}
-                {% set portal_prefix = '/dev2' if request.path.startswith('/dev2/') else ('/dev' if request.path.startswith('/dev/') else '') %}
+                {% set portal_prefix = '/console' if request.path.startswith('/console/') else ('/dev2' if request.path.startswith('/dev2/') else ('/dev' if request.path.startswith('/dev/') else '')) %}
                 <a href="{{ portal_prefix }}/execution-profile-requests/">Profile Requests</a>
                 {% endif %}
                 <a href="{{ url_for('auth.logout') }}">Logout</a>

--- a/result_server/templates/admin_execution_profile_requests.html
+++ b/result_server/templates/admin_execution_profile_requests.html
@@ -229,7 +229,7 @@
 </section>
 {% else %}
 <div class="request-review-link">
-    {% set portal_prefix = '/dev2' if request.path.startswith('/dev2/') else ('/dev' if request.path.startswith('/dev/') else '') %}
+    {% set portal_prefix = '/console' if request.path.startswith('/console/') else ('/dev2' if request.path.startswith('/dev2/') else ('/dev' if request.path.startswith('/dev/') else '')) %}
     <a class="btn btn-secondary" href="{{ portal_prefix }}/execution-profile-requests/">Open Applicant Request View</a>
 </div>
 {% endif %}

--- a/result_server/test_support.py
+++ b/result_server/test_support.py
@@ -26,7 +26,13 @@ def install_portal_test_stubs(*, include_redis=True, include_otp=True):
     sys.modules["utils.otp_redis_manager"] = otp_redis_mod
 
 
-def build_portal_shell_app(*, templates_dir, include_home_route=True, include_systemlist_route=True):
+def build_portal_shell_app(
+    *,
+    templates_dir,
+    include_home_route=True,
+    include_systemlist_route=True,
+    prefix="",
+):
     """Build a lightweight Flask app with common portal shell routes for template tests."""
     app = Flask(__name__, template_folder=templates_dir)
     app.config["TESTING"] = True
@@ -36,9 +42,14 @@ def build_portal_shell_app(*, templates_dir, include_home_route=True, include_sy
     estimated_bp = Blueprint("estimated", __name__)
     auth_bp = Blueprint("auth", __name__)
     admin_bp = Blueprint("admin", __name__)
+    profile_requests_bp = Blueprint("profile_requests", __name__)
 
     @results_bp.route("/")
     def results():
+        return ""
+
+    @results_bp.route("/confidential")
+    def results_confidential():
         return ""
 
     @results_bp.route("/compare")
@@ -81,6 +92,10 @@ def build_portal_shell_app(*, templates_dir, include_home_route=True, include_sy
     def setup(token):
         return token
 
+    @auth_bp.route("/logout")
+    def logout():
+        return ""
+
     @admin_bp.route("/users")
     def users():
         return ""
@@ -109,18 +124,23 @@ def build_portal_shell_app(*, templates_dir, include_home_route=True, include_sy
     def delete_user(email):
         return email
 
-    app.register_blueprint(results_bp, url_prefix="/results")
-    app.register_blueprint(estimated_bp, url_prefix="/estimated")
-    app.register_blueprint(auth_bp, url_prefix="/auth")
-    app.register_blueprint(admin_bp, url_prefix="/admin")
+    @profile_requests_bp.route("/")
+    def profile_requests():
+        return ""
+
+    app.register_blueprint(results_bp, url_prefix=f"{prefix}/results")
+    app.register_blueprint(estimated_bp, url_prefix=f"{prefix}/estimated")
+    app.register_blueprint(auth_bp, url_prefix=f"{prefix}/auth")
+    app.register_blueprint(admin_bp, url_prefix=f"{prefix}/admin")
+    app.register_blueprint(profile_requests_bp, url_prefix=f"{prefix}/execution-profile-requests")
 
     if include_home_route:
-        @app.route("/")
+        @app.route(f"{prefix}/")
         def home():
             return ""
 
     if include_systemlist_route:
-        @app.route("/systemlist")
+        @app.route(f"{prefix}/systemlist")
         def systemlist():
             return ""
 

--- a/result_server/tests/test_portal_access_policy.py
+++ b/result_server/tests/test_portal_access_policy.py
@@ -61,7 +61,7 @@ def test_representative_route_access_classes():
     assert classify_endpoint("results.results_confidential") == ACCESS_RESTRICTED_VIEWER
     assert classify_endpoint("estimated.estimated_results") == ACCESS_RESTRICTED_VIEWER
     assert classify_endpoint("auth.login") == ACCESS_RESTRICTED_VIEWER
-    assert classify_endpoint("profile_requests.my_profile_requests") == ACCESS_AUTHENTICATED_CONSOLE
+    assert classify_endpoint("profile_requests.profile_requests") == ACCESS_AUTHENTICATED_CONSOLE
     assert classify_endpoint("results.usage_report") == ACCESS_OPERATOR
     assert classify_endpoint("admin.users") == ACCESS_OPERATOR
     assert classify_endpoint("api.ingest_result") == ACCESS_RUNNER_API
@@ -129,6 +129,24 @@ def test_public_portal_mode_hides_authenticated_restricted_navigation():
     assert "Estimated" not in html
     assert "Confidential" not in html
     assert "Profile" not in html
+
+
+def test_console_prefixed_navigation_uses_prefixed_profile_request_url():
+    app = build_portal_shell_app(
+        templates_dir=os.path.join(os.path.dirname(__file__), "..", "templates"),
+        prefix="/console",
+    )
+
+    with app.test_request_context("/console/admin/users"):
+        from flask import render_template, session
+
+        session["authenticated"] = True
+        session["user_email"] = "admin@example.test"
+        session["user_affiliations"] = ["admin"]
+        html = render_template("_navigation.html")
+
+    assert 'href="/console/execution-profile-requests/"' in html
+    assert 'href="/execution-profile-requests/"' not in html
 
 
 def test_public_portal_mode_hides_home_restricted_entry_points(monkeypatch):


### PR DESCRIPTION
## Summary
- support /console-prefixed profile request links in portal navigation
- extend portal shell test helper to cover prefixed route rendering
- add regression coverage for console-prefixed Profile Requests URLs

## Tests
- .venv/bin/python -m pytest result_server/tests
- git diff --check
- python3 scripts/tests/check_text_integrity.py