### PR TITLE
Refine public portal surface

### DIFF
--- a/docs/deploy/public-portal-access-control.md
+++ b/docs/deploy/public-portal-access-control.md
@@ -61,12 +61,12 @@ The initial public allowlist should be deliberately small.
 | Route | Public | Restricted viewer | Authenticated console | Operator | Runner/API | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
 | `GET /` | yes | yes | yes | yes | no | Public home page. |
-| `GET /systemlist` | yes | yes | yes | yes | no | Public system catalog. |
+| `GET /systems` | yes | yes | yes | yes | no | Public system catalog. |
 | `GET /results/` | yes | yes | yes | yes | no | Public results list, rendered with public-safe columns only. |
 | `GET /results/detail/<filename>` | conditional | yes | yes | yes | no | Public only for public results and public-safe detail fields. |
 | `GET /results/compare` | conditional | yes | yes | yes | no | Public only when every selected result is public and the rendered fields are public-safe. |
 | `GET /static/*` | yes | yes | yes | yes | no | Static assets only. Keep secrets and generated private files out of static paths. |
-| `GET /results/<filename>` | no by default | conditional | conditional | yes | no | Raw JSON and archive downloads require a separate public-safe artifact policy before public exposure. |
+| `GET /results/<filename>` | conditional | conditional | conditional | yes | no | Public only for PA archive downloads that match public result metadata. Raw JSON remains restricted. |
 | `GET /results/environment-snapshots/*` | no by default | conditional | conditional | yes | no | Environment snapshots can contain operational context; expose only after redaction/public projection review. |
 | `GET /results/confidential` | no | yes | conditional | yes | no | Must be hidden from public navigation and blocked by reverse proxy for public clients. |
 | `GET /estimated/*` | no | yes | conditional | yes | no | Requires restricted network, TOTP, and affiliation/role checks. |
@@ -78,10 +78,11 @@ The initial public allowlist should be deliberately small.
 | `GET /api/query/*` | no | no | no | no | yes | CI/query clients only unless a separate public read API is intentionally designed. |
 | `/dev/*`, `/dev2/*` | no | no by default | no by default | yes | no | Development portals should not be public. |
 
-The public allowlist should prefer rendered pages over raw files. If public
-artifact downloads are added, they should use explicit public artifact metadata
-and public-safe filenames rather than inheriting access from the raw result
-file route.
+The public allowlist should prefer rendered pages over raw files. PA data
+archives may be public when they match public result metadata because they are
+reproducible current-system measurement artifacts. Confidential-result PA data,
+raw JSON, environment snapshots, and confidential/estimated artifacts remain
+outside the public browser surface.
 
 ## Reverse Proxy Responsibilities
 
@@ -107,7 +108,7 @@ Conceptual nginx layout:
 ```nginx
 # Public routes: allow all.
 location = / { proxy_pass http://portal_backend; }
-location = /systemlist { proxy_pass http://portal_backend; }
+location = /systems { proxy_pass http://portal_backend; }
 location = /results/ { proxy_pass http://portal_backend; }
 location /static/ { proxy_pass http://portal_backend; }
 
@@ -157,11 +158,11 @@ In the current codebase, public and confidential result lists are separate
 `RESULT_SERVER_PUBLIC_PORTAL_MODE=true` is enabled for the public portal
 deployment, public results list/detail/compare pages use a reduced public
 surface:
-raw JSON links, PA archive links, CI/pipeline columns, trigger internals, PA
-archive tables, quality/validator rows, and environment snapshot rows are
-hidden. Raw result file and environment snapshot routes return `404` in this
-mode. The same public-safe projection is used even if an old authenticated
-session cookie is present on the public host.
+raw JSON links, CI/pipeline columns, trigger internals, quality/validator rows,
+and environment snapshot rows are hidden. PA archive links are kept when the
+archive belongs to public result metadata. Raw result JSON and environment
+snapshot routes return `404` in this mode. The same public-safe projection is
+used even if an old authenticated session cookie is present on the public host.
 
 The public portal Flask guard allows runner/API endpoints to reach their own
 API authentication layer so that mTLS or runner-scoped API authentication can
@@ -206,8 +207,8 @@ Add lightweight tests as the design is implemented:
   allocation values, internal URLs, and profile attribution internals
 - unauthenticated access to confidential and estimated pages does not render
   protected data
-- restricted raw JSON and archive routes apply the same permission checks as
-  rendered pages
+- restricted raw JSON routes and non-public artifacts apply the same permission
+  checks as rendered pages
 - route classification tests cover every registered Flask route so new routes
   must be consciously classified as public, restricted viewer, operator, or
   runner/API

--- a/docs/guides/add-app.md
+++ b/docs/guides/add-app.md
@@ -105,7 +105,7 @@ BenchKit では、実行条件とシステム運用設定を明確に分けま�
   - `mode`、Runner tag、`queue`、`queue_group` など、そのシステムで共通な運用設定を書く
   - 全アプリで共有される条件を書く
 - `config/system_info.csv`
-  - Result Server や `/systemlist` に出すシステム表示情報を書く
+  - Result Server や `/systems` に出すシステム表示情報を書く
   - アプリ開発者が、その system が portal 上でどう見えるかを確認するときの正本になる
 
 新しい system を `list.csv` に追加する前に、`config/system.csv` と `config/system_info.csv` の両方に対象 system があるかを確認しておくと、実行条件と portal 表示のずれを減らせる。

--- a/result_server/app.py
+++ b/result_server/app.py
@@ -200,7 +200,6 @@ def create_app(prefix="", base_dir=None):
     register_home_routes(app, prefix=prefix)
     _register_portal_blueprints(app, prefix)
 
-    @app.route(f"{prefix}/systemlist")
     def systemlist():
         from utils.system_info import get_all_systems_info, summarize_systems_info
 
@@ -210,6 +209,8 @@ def create_app(prefix="", base_dir=None):
             systems_info=systems_info,
             systems_summary=summarize_systems_info(systems_info),
         )
+
+    app.add_url_rule(f"{prefix}/systems", endpoint="systemlist", view_func=systemlist)
 
     return app
 

--- a/result_server/app_dev.py
+++ b/result_server/app_dev.py
@@ -265,7 +265,6 @@ def create_dev_app(base_dir):
     app.register_blueprint(profile_requests_bp)
     app.register_blueprint(admin_bp, url_prefix="/admin")
 
-    @app.route("/systemlist")
     def systemlist():
         systems_info = get_all_systems_info()
         return render_template(
@@ -273,6 +272,8 @@ def create_dev_app(base_dir):
             systems_info=systems_info,
             systems_summary=summarize_systems_info(systems_info),
         )
+
+    app.add_url_rule("/systems", endpoint="systemlist", view_func=systemlist)
 
     return app
 
@@ -584,7 +585,7 @@ def main():
 
     print(f"\nStarting dev server on http://{args.host}:{args.port}")
     print(f"  Results: http://{args.host}:{args.port}/results")
-    print(f"  Systems: http://{args.host}:{args.port}/systemlist")
+    print(f"  Systems: http://{args.host}:{args.port}/systems")
     print(f"  Data dir: {base_dir}")
     print()
 

--- a/result_server/routes/estimated_list_routes.py
+++ b/result_server/routes/estimated_list_routes.py
@@ -15,6 +15,12 @@ from utils.table_page_utils import (
 )
 from utils.table_query_params import parse_table_query_params
 
+
+ESTIMATION_LINKS = {
+    "perftools": "https://github.com/masaaki-kondo/PerfTools",
+}
+
+
 def register_estimated_list_routes(estimated_bp):
     @estimated_bp.route("/", methods=["GET"], strict_slashes=False)
     def estimated_results():
@@ -25,6 +31,7 @@ def register_estimated_list_routes(estimated_bp):
                 per_page=DEFAULT_PER_PAGE,
                 authenticated=False,
                 systems_info=get_all_systems_info(),
+                estimation_links=ESTIMATION_LINKS,
             )
 
         params = parse_table_query_params(request.args)
@@ -55,6 +62,7 @@ def register_estimated_list_routes(estimated_bp):
             params=params,
             authenticated=True,
             systems_info=get_all_systems_info(),
+            estimation_links=ESTIMATION_LINKS,
         )
 
         return render_table_page_response(

--- a/result_server/routes/home.py
+++ b/result_server/routes/home.py
@@ -2,46 +2,27 @@ import os
 
 from flask import render_template
 
-from utils.system_info import get_all_systems_info
 
-
-GUIDE_LINKS = {
+HOME_GUIDE_LINKS = {
     "add_app": "https://github.com/RIKEN-RCCS/benchkit/blob/main/docs/guides/add-app.md",
     "add_site": "https://github.com/RIKEN-RCCS/benchkit/blob/main/docs/guides/add-site.md",
     "add_estimation": "https://github.com/RIKEN-RCCS/benchkit/blob/main/docs/guides/add-estimation.md",
-    "perftools": "https://github.com/masaaki-kondo/PerfTools",
     "benchpark_fn_apps": "https://github.com/RIKEN-RCCS/benchpark/blob/FN_apps/User_Guide.md",
     "benchpark_upstream": "https://github.com/llnl/benchpark",
 }
 
 
-def build_guide_links():
-    links = dict(GUIDE_LINKS)
+def build_home_guide_links():
+    links = dict(HOME_GUIDE_LINKS)
     links["discord"] = os.environ.get("CX_DISCORD_INVITE_URL", "")
     return links
 
 
 def register_home_routes(app, prefix=""):
     def homepage():
-        systems_info = get_all_systems_info()
-        systems = [
-            {
-                "system": system_name,
-                "name": info["name"],
-                "cpu_name": info["cpu_name"],
-                "cpu_per_node": info["cpu_per_node"],
-                "cpu_cores": info["cpu_cores"],
-                "gpu_name": info["gpu_name"],
-                "gpu_per_node": info["gpu_per_node"],
-                "memory": info["memory"],
-            }
-            for system_name, info in systems_info.items()
-        ]
         return render_template(
             "home.html",
-            systems=systems,
-            system_count=len(systems),
-            guide_links=build_guide_links(),
+            guide_links=build_home_guide_links(),
         )
 
     app.add_url_rule(f"{prefix}/", endpoint="home", view_func=homepage, strict_slashes=False)

--- a/result_server/routes/results_detail_routes.py
+++ b/result_server/routes/results_detail_routes.py
@@ -13,6 +13,7 @@ from utils.result_detail_view import build_result_detail_context
 from utils.result_file import (
     load_permitted_result_json,
     serve_permitted_result_file,
+    serve_public_padata_file,
 )
 from utils.result_records import (
     format_numeric_value,
@@ -121,6 +122,12 @@ def register_results_detail_routes(results_bp):
     @results_bp.route("/<filename>")
     def show_result(filename):
         if public_surface():
+            if filename.endswith(".tgz"):
+                return serve_public_padata_file(
+                    filename,
+                    current_app.config["RECEIVED_DIR"],
+                    current_app.config["RECEIVED_PADATA_DIR"],
+                )
             abort(404)
 
         if filename.endswith(".tgz"):

--- a/result_server/templates/_results_table.html
+++ b/result_server/templates/_results_table.html
@@ -106,7 +106,7 @@
 }
 </style>
 
-<p class="results-table-note">Filter first, check the profiler and PA summary when available, and then select visible rows if you want to open compare.</p>
+<p class="results-table-note">Filter first, inspect profiler context when a PA archive is available, and then select visible rows if you want to open compare.</p>
 
 <div class="results-table-wrap">
 <table id="resultsTable" class="results-table">

--- a/result_server/templates/_results_table_cell_profile.html
+++ b/result_server/templates/_results_table_cell_profile.html
@@ -1,21 +1,21 @@
 <td class="profile-cell">
-    {% if row.profile_summary_meta.has_profile_data %}
+    {% if row.data_link %}
+        {% if row.profile_summary_meta.has_profile_data %}
         <span class="tooltip">
             <span class="profile-headline">{{ row.profile_summary_meta.headline }}</span>
-            {% if row.data_link %}
             <a class="profile-data-link" href="{{ row.data_link }}">padata{% if row.profile_summary_meta.archive_count %} x{{ row.profile_summary_meta.archive_count }}{% endif %}</a>
-            {% endif %}
             <span class="tooltiptext">
                 {{ row.profile_summary_meta.headline }}
                 {% if row.profile_summary_meta.subline %}<br>{{ row.profile_summary_meta.subline }}{% endif %}
-                {% if row.data_link %}<br>archive: available{% if row.profile_summary_meta.archive_count %} ({{ row.profile_summary_meta.archive_count }}){% endif %}{% endif %}
+                <br>archive: available{% if row.profile_summary_meta.archive_count %} ({{ row.profile_summary_meta.archive_count }}){% endif %}
                 {% if row.profile_summary_meta.events %}<br>events: {{ row.profile_summary_meta.events | join(', ') }}{% endif %}
                 {% if row.profile_summary_meta.ncu_options %}<br>ncu options: {{ row.profile_summary_meta.ncu_options | join(' ') }}{% endif %}
                 {% if row.profile_summary_meta.report_kinds %}<br>reports: {{ row.profile_summary_meta.report_kinds | join(', ') }}{% endif %}
             </span>
         </span>
-    {% elif row.data_link %}
+        {% else %}
         <a class="profile-data-link profile-data-link-only" href="{{ row.data_link }}">padata</a>
+        {% endif %}
     {% else %}
         -
     {% endif %}

--- a/result_server/templates/estimated_results.html
+++ b/result_server/templates/estimated_results.html
@@ -14,6 +14,7 @@
 
 {% block content %}
 {% if authenticated %}
+{% set estimation_page_links = estimation_links | default({}) %}
 <section class="page-card table-card">
 {% include "_filter_dropdowns.html" %}
 
@@ -25,6 +26,14 @@
     color: #52606d;
     line-height: 1.55;
     font-size: 14px;
+  }
+  .estimated-guide-link {
+    color: #0f766e;
+    font-weight: 600;
+    text-decoration: none;
+  }
+  .estimated-guide-link:hover {
+    text-decoration: underline;
   }
   .estimated-table-wrap {
     overflow-x: auto;
@@ -56,7 +65,14 @@
   }
 </style>
 
-<p class="estimated-table-note">Scan system pairs, applied packages, and ratio here, then open <code>detail</code> for breakdown or fallback context.</p>
+<p class="estimated-table-note">
+  Scan system pairs, applied packages, and ratio here, then open <code>detail</code> for breakdown or fallback context.
+  {% if estimation_page_links.perftools %}
+  GPU kernel-level estimates use
+  <a class="estimated-guide-link" href="{{ estimation_page_links.perftools }}" target="_blank" rel="noopener noreferrer">PerfTools</a>
+  models when an applicable package is selected.
+  {% endif %}
+</p>
 
 {% include "_estimated_results_table.html" %}
 

--- a/result_server/templates/home.html
+++ b/result_server/templates/home.html
@@ -16,71 +16,12 @@ This portal is part of the CX Framework, supporting continuous benchmarking, est
 {% set show_restricted_entries = is_authenticated and not public_portal_mode %}
 {% set is_operator = show_restricted_entries and 'admin' in session.get('user_affiliations', []) %}
 {% set public_surface = public_portal_mode %}
-{% set entry_point_count = 4 if is_operator else (2 if public_surface else 3) %}
 <style>
-    .home-overview-grid {
-        display: grid;
-        grid-template-columns: 1.45fr 1fr;
-        gap: 24px;
-        margin-bottom: 24px;
-    }
-    .home-actions {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 12px;
-        margin-top: 20px;
-    }
-    .home-action-link {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        padding: 11px 16px;
-        border-radius: 999px;
-        text-decoration: none;
-        font-weight: 600;
-        transition: transform 120ms ease, box-shadow 120ms ease;
-    }
-    .home-action-link:hover {
-        transform: translateY(-1px);
-    }
-    .home-action-link-primary {
-        background: #0f766e;
-        color: #fff;
-        box-shadow: 0 10px 20px rgba(15, 118, 110, 0.2);
-    }
-    .home-action-link-secondary {
-        background: #eff6ff;
-        color: #1d4ed8;
-    }
-    .home-action-link-locked {
-        background: #f4f4f5;
-        color: #52525b;
-    }
-    .home-summary-grid {
-        display: grid;
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-        gap: 14px;
-        margin-top: 16px;
-    }
-    .home-summary-card,
-    .home-link-card,
-    .home-system-card {
+    .home-link-card {
         padding: 16px;
         border-radius: 14px;
         border: 1px solid #dce8ee;
         background: #f7fbfc;
-    }
-    .home-summary-value {
-        display: block;
-        font-size: 28px;
-        font-weight: 700;
-        color: #0f172a;
-    }
-    .home-summary-label {
-        display: block;
-        margin-top: 6px;
-        font-size: 13px;
-        color: #52606d;
     }
     .home-content-grid {
         display: grid;
@@ -124,134 +65,13 @@ This portal is part of the CX Framework, supporting continuous benchmarking, est
         font-weight: 600;
         letter-spacing: 0.01em;
     }
-    .home-systems-section {
-        margin-top: 24px;
-    }
-    .home-systems-header {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: baseline;
-        justify-content: space-between;
-        gap: 12px;
-        margin-bottom: 14px;
-    }
-    .home-systems-header h2 {
-        margin: 0;
-        font-size: 28px;
-        letter-spacing: -0.02em;
-    }
-    .home-systems-header p {
-        margin: 0;
-        color: #52606d;
-    }
-    .home-system-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
-        gap: 16px;
-    }
-    .home-system-card-header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 10px;
-        margin-bottom: 12px;
-    }
-    .home-system-card h3 {
-        margin: 0;
-        font-size: 18px;
-    }
-    .home-system-badge {
-        display: inline-flex;
-        align-items: center;
-        padding: 4px 8px;
-        border-radius: 999px;
-        font-size: 12px;
-        font-weight: 600;
-        white-space: nowrap;
-    }
-    .home-system-badge-gpu {
-        background: #eef6ff;
-        color: #1d4ed8;
-    }
-    .home-system-badge-cpu {
-        background: #f3f4f6;
-        color: #4b5563;
-    }
-    .home-system-meta {
-        display: grid;
-        gap: 7px;
-        font-size: 14px;
-        color: #52606d;
-    }
-    .home-system-meta strong {
-        color: #1f2933;
-    }
-    .home-section-footer {
-        margin-top: 16px;
-    }
-    .home-section-footer a {
-        color: #0f766e;
-        font-weight: 600;
-        text-decoration: none;
-    }
-    .home-section-footer a:hover {
-        text-decoration: underline;
-    }
     @media (max-width: 900px) {
-        .home-overview-grid,
         .home-content-grid,
         .home-content-grid-three {
             grid-template-columns: 1fr;
         }
     }
 </style>
-
-<section class="home-overview-grid">
-    <section class="page-card">
-        <h2 class="section-title">Start Here</h2>
-        <p class="section-intro">
-            {% if public_surface %}
-            Browse public measured results, inspect connected systems, and open onboarding guides for applications and sites.
-            {% else %}
-            Browse measured and estimated results, inspect connected systems, and jump directly into onboarding guides for applications and sites.
-            {% endif %}
-        </p>
-        <div class="home-actions">
-            <a class="home-action-link home-action-link-primary" href="{{ url_for('results.results') }}">Browse Results</a>
-            <a class="home-action-link home-action-link-secondary" href="{{ url_for('systemlist') }}">View All Systems</a>
-            {% if show_restricted_entries %}
-            <a class="home-action-link home-action-link-secondary" href="{{ url_for('estimated.estimated_results') }}">Open Estimated Results</a>
-            {% elif not public_portal_mode %}
-            <a class="home-action-link home-action-link-locked" href="{{ url_for('auth.login') }}">Estimated Results (login required)</a>
-            {% endif %}
-        </div>
-    </section>
-
-    <aside class="page-card">
-        <h2 class="section-title">At a Glance</h2>
-        <p class="section-intro">
-            Use this portal to understand how CX connects to real systems, browse portal pages, and find the right onboarding guide for applications or sites.
-        </p>
-        <div class="home-summary-grid">
-            <div class="home-summary-card">
-                <span class="home-summary-value">{{ system_count }}</span>
-                <span class="home-summary-label">Connected systems</span>
-            </div>
-            <div class="home-summary-card">
-                <span class="home-summary-value">{{ entry_point_count }}</span>
-                <span class="home-summary-label">Primary entry points</span>
-            </div>
-            <div class="home-summary-card">
-                <span class="home-summary-value">Results</span>
-                <span class="home-summary-label">{% if public_surface %}Public measured views{% else %}Measured and projected views{% endif %}</span>
-            </div>
-            <div class="home-summary-card">
-                <span class="home-summary-value">Guides</span>
-                <span class="home-summary-label">Guides for apps and sites</span>
-            </div>
-        </div>
-    </aside>
-</section>
 
 <section class="home-content-grid {% if is_operator %}home-content-grid-three{% endif %}">
     <section class="page-card">
@@ -265,7 +85,7 @@ This portal is part of the CX Framework, supporting continuous benchmarking, est
         </p>
         <div class="home-link-list">
             <a class="home-link-card" href="{{ url_for('results.results') }}">
-                <strong>Results</strong>
+                <strong>Browse Results</strong>
                 <span>Browse measured benchmark results, compare runs, and inspect result-quality detail pages.</span>
             </a>
             {% if show_restricted_entries or not public_portal_mode %}
@@ -281,16 +101,16 @@ This portal is part of the CX Framework, supporting continuous benchmarking, est
             </a>
             {% endif %}
             <a class="home-link-card" href="{{ url_for('systemlist') }}">
-                <strong>Systems</strong>
+                <strong>View All Systems</strong>
                 <span>See connected systems, quick hardware summaries, and onboarding-facing system metadata.</span>
             </a>
         </div>
     </section>
 
     <section class="page-card">
-        <h2 class="section-title">For Application Developers</h2>
+        <h2 class="section-title">User Guide</h2>
         <p class="section-intro">
-            These guides explain how to add a new benchmark application, enable a new site, and attach estimation support.
+            These guides explain how to add a new benchmark application, enable a new site, attach estimation support, and relate BenchKit work to BenchPark.
         </p>
         <div class="home-link-list">
             <a class="home-link-card" href="{{ guide_links.add_app }}" target="_blank" rel="noopener noreferrer">
@@ -304,6 +124,14 @@ This portal is part of the CX Framework, supporting continuous benchmarking, est
             <a class="home-link-card" href="{{ guide_links.add_estimation }}" target="_blank" rel="noopener noreferrer">
                 <strong>Add Estimation Support</strong>
                 <span>Connect application-side result emission to estimation inputs and estimation workflows.</span>
+            </a>
+            <a class="home-link-card" href="{{ guide_links.benchpark_fn_apps }}" target="_blank" rel="noopener noreferrer">
+                <strong>Application Onboarding</strong>
+                <span>Use the RIKEN-RCCS BenchPark FN_apps branch for FugakuNEXT/CX application bring-up and local validation.</span>
+            </a>
+            <a class="home-link-card" href="{{ guide_links.benchpark_upstream }}" target="_blank" rel="noopener noreferrer">
+                <strong>Upstream BenchPark</strong>
+                <span>The RIKEN-RCCS fork is an integration window; upstream BenchPark remains the main upstream project.</span>
             </a>
             {% if guide_links.discord %}
             <a class="home-link-card" href="{{ guide_links.discord }}" target="_blank" rel="noopener noreferrer">
@@ -332,61 +160,5 @@ This portal is part of the CX Framework, supporting continuous benchmarking, est
         </div>
     </section>
     {% endif %}
-</section>
-
-<section class="page-card home-systems-section">
-    <h2 class="section-title">GPU Performance Estimation</h2>
-    <p class="section-intro">
-        CX Portal stores GPU kernel-level estimation artifacts together with benchmark results, including prepared inputs, prediction outputs, logs, and package comparison data.
-    </p>
-    <div class="home-link-list home-content-grid-three">
-        <a class="home-link-card" href="{{ guide_links.perftools }}" target="_blank" rel="noopener noreferrer">
-            <strong>PerfTools</strong>
-            <span>GPU performance estimation models used by the current experimental integration.</span>
-        </a>
-        <a class="home-link-card" href="{{ guide_links.benchpark_fn_apps }}" target="_blank" rel="noopener noreferrer">
-            <strong>Application Onboarding</strong>
-            <span>Use the RIKEN-RCCS BenchPark FN_apps branch for FugakuNEXT/CX application bring-up and local validation.</span>
-        </a>
-        <a class="home-link-card" href="{{ guide_links.benchpark_upstream }}" target="_blank" rel="noopener noreferrer">
-            <strong>Upstream BenchPark</strong>
-            <span>The RIKEN-RCCS fork is an integration window; upstream BenchPark remains the main upstream project.</span>
-        </a>
-    </div>
-    <p class="section-intro home-section-footer">
-        GPU kernel estimates are interpreted as source/target scaling factors. Application-level FOM reconstruction also needs application-side section timing for CPU, GPU, communication, and overlap regions.
-    </p>
-</section>
-
-<section class="home-systems-section page-card">
-    <div class="home-systems-header">
-        <div>
-            <h2>Available Systems</h2>
-            <p>Connected systems are sourced from `config/system_info.csv` and shown here for quick orientation.</p>
-        </div>
-    </div>
-    <div class="home-system-grid">
-        {% for system in systems %}
-        <article class="home-system-card">
-            <div class="home-system-card-header">
-                <h3>{{ system.name }}</h3>
-                {% if system.gpu_name != '-' %}
-                <span class="home-system-badge home-system-badge-gpu">GPU-enabled</span>
-                {% else %}
-                <span class="home-system-badge home-system-badge-cpu">CPU-only</span>
-                {% endif %}
-            </div>
-            <div class="home-system-meta">
-                <div><strong>CPU</strong> {{ system.cpu_name }}</div>
-                <div><strong>CPU/node</strong> {{ system.cpu_per_node }} | <strong>Cores</strong> {{ system.cpu_cores }}</div>
-                <div><strong>GPU</strong> {{ system.gpu_name }}{% if system.gpu_per_node != '-' %} ({{ system.gpu_per_node }}/node){% endif %}</div>
-                <div><strong>Memory</strong> {{ system.memory }}</div>
-            </div>
-        </article>
-        {% endfor %}
-    </div>
-    <div class="home-section-footer">
-        <a href="{{ url_for('systemlist') }}">Open the full system list</a>
-    </div>
 </section>
 {% endblock %}

--- a/result_server/test_support.py
+++ b/result_server/test_support.py
@@ -140,9 +140,9 @@ def build_portal_shell_app(
             return ""
 
     if include_systemlist_route:
-        @app.route(f"{prefix}/systemlist")
         def systemlist():
             return ""
+        app.add_url_rule(f"{prefix}/systems", endpoint="systemlist", view_func=systemlist)
 
     return app
 
@@ -260,8 +260,8 @@ def build_portal_route_app(
         app.register_blueprint(profile_requests_bp)
         app.register_blueprint(admin_bp, url_prefix="/admin")
 
-    @app.route("/systemlist")
     def systemlist():
         return ""
+    app.add_url_rule("/systems", endpoint="systemlist", view_func=systemlist)
 
     return app

--- a/result_server/tests/test_home_template.py
+++ b/result_server/tests/test_home_template.py
@@ -24,18 +24,20 @@ def test_home_page_renders_landing_content(monkeypatch):
     html = response.get_data(as_text=True)
     assert "CX Portal" in html
     assert "Main Entry Points" in html
-    assert "For Application Developers" in html
-    assert "GPU Performance Estimation" in html
-    assert "Available Systems" in html
+    assert "User Guide" in html
+    assert "GPU Performance Estimation" not in html
+    assert "Available Systems" not in html
+    assert "At a Glance" not in html
+    assert "Start Here" not in html
     assert "Add a New Site" in html
-    assert "PerfTools" in html
+    assert "PerfTools" not in html
     assert "RIKEN-RCCS BenchPark FN_apps branch" in html
     assert "Upstream BenchPark" in html
-    assert "https://github.com/masaaki-kondo/PerfTools" in html
+    assert "https://github.com/masaaki-kondo/PerfTools" not in html
     assert "https://github.com/RIKEN-RCCS/benchpark/blob/FN_apps/User_Guide.md" in html
     assert "https://github.com/llnl/benchpark" in html
     assert "Browse Results" in html
-    assert "Estimated Results (login required)" in html
+    assert "Estimated Results" in html
     assert "Login required" in html
     assert "Questions and Discussion" not in html
 

--- a/result_server/tests/test_portal_access_policy.py
+++ b/result_server/tests/test_portal_access_policy.py
@@ -57,7 +57,7 @@ def test_representative_route_access_classes():
     assert classify_endpoint("systemlist") == ACCESS_PUBLIC
     assert classify_endpoint("results.results") == ACCESS_PUBLIC
     assert classify_endpoint("results.result_detail") == ACCESS_PUBLIC_CONDITIONAL
-    assert classify_endpoint("results.show_result") == ACCESS_RESTRICTED_VIEWER
+    assert classify_endpoint("results.show_result") == ACCESS_PUBLIC_CONDITIONAL
     assert classify_endpoint("results.results_confidential") == ACCESS_RESTRICTED_VIEWER
     assert classify_endpoint("estimated.estimated_results") == ACCESS_RESTRICTED_VIEWER
     assert classify_endpoint("auth.login") == ACCESS_RESTRICTED_VIEWER
@@ -104,6 +104,20 @@ def test_public_portal_mode_hides_anonymous_restricted_navigation():
     assert "Estimated" not in html
     assert "Confidential" not in html
     assert "Profile" not in html
+
+
+def test_systems_route_is_canonical():
+    app = build_portal_shell_app(
+        templates_dir=os.path.join(os.path.dirname(__file__), "..", "templates"),
+    )
+
+    with app.test_request_context("/"):
+        from flask import url_for
+
+        assert url_for("systemlist") == "/systems"
+
+    with app.test_client() as client:
+        assert client.get("/systems").status_code == 200
 
 
 def test_public_portal_mode_hides_authenticated_restricted_navigation():

--- a/result_server/tests/test_portal_list_templates.py
+++ b/result_server/tests/test_portal_list_templates.py
@@ -22,7 +22,7 @@ def test_results_template_renders_table_note():
                     {"label": "CODE", "key": "code"},
                     {"label": "FOM", "key": "fom", "tooltip": "Figure of Merit - Benchmark performance metric value with its unit when available"},
                     {"label": "Exp", "key": "exp", "tooltip": "Experimental conditions (filtered by CODE)"},
-                    {"label": "Profiler / PA", "key": "profile_summary", "tooltip": "Profiler tool, level, report summary, and PA data download access"},
+                    {"label": "Profiler / PA", "key": "profile_summary", "tooltip": "Profiler tool/level and PA data download access when archive is available"},
                     {"label": "CI", "key": "ci_summary", "tooltip": "CI trigger source and pipeline ID"},
                     {"label": "JSON", "key": "json_link", "tooltip": "Detailed benchmark results in JSON format", "tooltip_class": "tooltip-right"},
                 ],
@@ -80,7 +80,7 @@ def test_results_template_renders_table_note():
             },
         )
 
-    assert "check the profiler and PA summary when available" in html
+    assert "inspect profiler context when a PA archive is available" in html
     assert "results-table-wrap" in html
     assert "Compare" in html
     assert "fapp / detailed" in html
@@ -91,7 +91,7 @@ def test_results_template_renders_table_note():
     assert "1.234 s" in html
 
 
-def test_results_template_renders_ncu_options_tooltip():
+def test_results_template_renders_profile_summary_when_padata_link_is_available():
     app = build_portal_shell_app(
         templates_dir=os.path.join(os.path.dirname(__file__), "..", "templates"),
     )
@@ -151,6 +151,64 @@ def test_results_template_renders_ncu_options_tooltip():
     assert "archive: available (3)" in html
     assert "ncu options: --target-processes all --set basic --launch-count 1" in html
     assert "ncu_report" in html
+
+
+def test_results_template_hides_profile_summary_without_padata_link():
+    app = build_portal_shell_app(
+        templates_dir=os.path.join(os.path.dirname(__file__), "..", "templates"),
+    )
+    with app.test_request_context("/results"):
+        from flask import render_template
+
+        html = render_template(
+            "results.html",
+            columns=[
+                {"label": "Timestamp", "key": "timestamp"},
+                {"label": "Profiler / PA", "key": "profile_summary"},
+            ],
+            rows=[
+                {
+                    "timestamp": "2026-04-13 12:00:00",
+                    "profile_summary": "ncu / single",
+                    "profile_summary_meta": {
+                        "has_profile_data": True,
+                        "headline": "ncu / single",
+                        "subline": "text, 1 run",
+                        "archive_count": None,
+                        "events": [],
+                        "ncu_options": ["--set", "basic"],
+                        "report_kinds": ["ncu_report"],
+                    },
+                    "data_link": None,
+                    "detail_link": "/results/detail/result0.json",
+                    "filename": "result0.json",
+                    "source_info": None,
+                    "quality": {"level": "ready", "label": "Ready", "summary": "Breakdown is present."},
+                    "system": "RC_GH200",
+                    "code": "genesis",
+                    "fom": 1.0,
+                    "exp": "CASE0",
+                    "fom_version": "test",
+                    "nodes": "1",
+                    "numproc_node": "8",
+                    "nthreads": "9",
+                    "ci_trigger": "push",
+                    "pipeline_id": "10",
+                    "source_hash": "-",
+                }
+            ],
+            pagination={"total": 1, "page": 1, "total_pages": 1},
+            current_per_page=50,
+            current_system="",
+            current_code="",
+            current_exp="",
+            filter_options={"systems": ["RC_GH200"], "codes": ["genesis"], "exps": ["CASE0"]},
+            systems_info={},
+        )
+
+    assert "ncu / single" not in html
+    assert "padata" not in html
+    assert "ncu_report" not in html
 
 
 def test_pagination_template_urlencodes_filters_without_inline_javascript():
@@ -295,9 +353,12 @@ def test_estimated_results_template_renders_table_note():
             current_code="",
             current_exp="",
             filter_options={"systems": ["Fugaku"], "codes": ["qws"], "exps": ["CASE0"]},
+            estimation_links={"perftools": "https://github.com/masaaki-kondo/PerfTools"},
         )
 
     assert "Scan system pairs, applied packages, and ratio here" in html
+    assert "PerfTools" in html
+    assert "https://github.com/masaaki-kondo/PerfTools" in html
     assert "estimated-table-wrap" in html
     assert "detail" in html
     assert "fallback -&gt; weakscaling" in html

--- a/result_server/tests/test_result_detail_template.py
+++ b/result_server/tests/test_result_detail_template.py
@@ -232,7 +232,7 @@ class TestResultDetailTemplate:
         assert "results/padata_k003_void_kern_build_pairlist.tgz" in html
         assert f'href="/results/{filename}"' in html
 
-    def test_public_surface_omits_padata_archive_links(self, app):
+    def test_public_surface_keeps_padata_archive_links(self, app):
         result = {
             **FULL_RESULT,
             "_server_uuid": "12345678-1234-1234-1234-123456789abc",
@@ -266,8 +266,8 @@ class TestResultDetailTemplate:
                 public_surface=True,
             )
 
-        assert "PA Data Archives" not in html
-        assert f'href="/results/{filename}"' not in html
+        assert "PA Data Archives" in html
+        assert f'href="/results/{filename}"' in html
 
     def test_vector_data_table(self, app):
         with app.test_request_context():

--- a/result_server/tests/test_result_padata_route.py
+++ b/result_server/tests/test_result_padata_route.py
@@ -52,7 +52,7 @@ def test_results_route_serves_padata_from_received_padata_dir(client, tmp_dirs):
     assert resp.data == b"fake tgz content"
 
 
-def test_public_portal_mode_blocks_anonymous_raw_result_files(client, app, tmp_dirs):
+def test_public_portal_mode_serves_anonymous_public_padata(client, app, tmp_dirs):
     received, received_padata = tmp_dirs
     app.config["PUBLIC_PORTAL_MODE"] = True
     uid = "12345678-1234-1234-1234-123456789abc"
@@ -65,10 +65,12 @@ def test_public_portal_mode_blocks_anonymous_raw_result_files(client, app, tmp_d
         f.write(b"fake tgz content")
 
     assert client.get(f"/results/{json_name}").status_code == 404
-    assert client.get(f"/results/{tgz_name}").status_code == 404
+    resp = client.get(f"/results/{tgz_name}")
+    assert resp.status_code == 200
+    assert resp.data == b"fake tgz content"
 
 
-def test_public_portal_mode_blocks_authenticated_raw_result_files(client, app, tmp_dirs):
+def test_public_portal_mode_serves_authenticated_public_padata(client, app, tmp_dirs):
     received, received_padata = tmp_dirs
     app.config["PUBLIC_PORTAL_MODE"] = True
     uid = "12345678-1234-1234-1234-123456789abc"
@@ -84,6 +86,42 @@ def test_public_portal_mode_blocks_authenticated_raw_result_files(client, app, t
         sess["authenticated"] = True
 
     assert client.get(f"/results/{json_name}").status_code == 404
+    resp = client.get(f"/results/{tgz_name}")
+    assert resp.status_code == 200
+    assert resp.data == b"fake tgz content"
+
+
+def test_public_portal_mode_hides_padata_when_result_is_confidential(client, app, tmp_dirs):
+    received, received_padata = tmp_dirs
+    app.config["PUBLIC_PORTAL_MODE"] = True
+    uid = "12345678-1234-1234-1234-123456789abc"
+    tgz_name = f"padata_20250101_120000_{uid}.tgz"
+
+    with open(os.path.join(received, "result0.json"), "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "code": "qws",
+                "system": "Fugaku",
+                "FOM": 1.0,
+                "_server_uuid": uid,
+                "confidential": ["dev"],
+            },
+            f,
+        )
+    with open(os.path.join(received_padata, tgz_name), "wb") as f:
+        f.write(b"fake tgz content")
+
+    assert client.get(f"/results/{tgz_name}").status_code == 404
+
+
+def test_public_portal_mode_blocks_non_padata_tgz(client, app, tmp_dirs):
+    _received, received_padata = tmp_dirs
+    app.config["PUBLIC_PORTAL_MODE"] = True
+    tgz_name = "debug_bundle.tgz"
+
+    with open(os.path.join(received_padata, tgz_name), "wb") as f:
+        f.write(b"not public padata")
+
     assert client.get(f"/results/{tgz_name}").status_code == 404
 
 

--- a/result_server/tests/test_results_loader.py
+++ b/result_server/tests/test_results_loader.py
@@ -278,7 +278,7 @@ class TestLoadResultsTableExtension:
             {"label": "Nodes", "key": "nodes"},
             {"label": "P/N", "key": "numproc_node", "tooltip": "Number of processes per node"},
             {"label": "T/P", "key": "nthreads", "tooltip": "Number of threads per process"},
-            {"label": "Profiler / PA", "key": "profile_summary", "tooltip": "Profiler tool, level, report summary, and PA data download access"},
+            {"label": "Profiler / PA", "key": "profile_summary", "tooltip": "Profiler tool/level and PA data download access when archive is available"},
             {"label": "Run Cause", "key": "execution_trigger_summary", "tooltip": "Portal trigger metadata explaining why this benchmark run was launched"},
             {"label": "JSON", "key": "json_link", "tooltip": "Detailed benchmark results in JSON format", "tooltip_class": "tooltip-right"},
             {"label": "CI", "key": "ci_summary", "tooltip": "CI trigger source and pipeline ID"},
@@ -322,7 +322,7 @@ class TestLoadResultsTableExtension:
         assert "execution_trigger_summary" not in column_keys
         assert "profile_summary" in column_keys
         assert rows[0]["json_link"] is None
-        assert rows[0]["data_link"] is None
+        assert rows[0]["data_link"] == f"/results/padata_20250101_120000_{uid}.tgz"
         assert rows[0]["source_link"] is None
         assert rows[0]["profile_summary"] == "ncu / single"
         assert rows[0]["profile_summary_meta"]["ncu_options"] == ["--set", "basic"]

--- a/result_server/tests/test_systemlist_template.py
+++ b/result_server/tests/test_systemlist_template.py
@@ -12,7 +12,7 @@ def test_systemlist_page_renders_summary_and_table():
         templates_dir=os.path.join(os.path.dirname(__file__), "..", "templates"),
     )
 
-    with app.test_request_context("/systemlist"):
+    with app.test_request_context("/systems"):
         from flask import render_template
 
         html = render_template(

--- a/result_server/tests/test_totp_security.py
+++ b/result_server/tests/test_totp_security.py
@@ -217,7 +217,7 @@ def admin_app():
     app.config["RECEIVED_DIR"] = temp_dir
     app.config["ESTIMATED_DIR"] = temp_dir
 
-    @app.route("/systemlist")
+    @app.route("/systems", endpoint="systemlist")
     def systemlist():
         return "systems"
 
@@ -252,7 +252,7 @@ def auth_app():
     app.config["RECEIVED_DIR"] = temp_dir
     app.config["ESTIMATED_DIR"] = temp_dir
 
-    @app.route("/systemlist")
+    @app.route("/systems", endpoint="systemlist")
     def systemlist():
         return "systems"
 

--- a/result_server/utils/portal_access.py
+++ b/result_server/utils/portal_access.py
@@ -34,6 +34,7 @@ PUBLIC_CONDITIONAL_ENDPOINTS = frozenset(
     {
         "results.result_compare",
         "results.result_detail",
+        "results.show_result",
     }
 )
 
@@ -47,7 +48,6 @@ RESTRICTED_VIEWER_ENDPOINTS = frozenset(
         "estimated.show_estimated_result",
         "results.environment_snapshot_results",
         "results.results_confidential",
-        "results.show_result",
     }
 )
 

--- a/result_server/utils/result_detail_view.py
+++ b/result_server/utils/result_detail_view.py
@@ -24,9 +24,7 @@ def build_result_detail_context(
         "meta_rows": _build_meta_rows(result, trigger_runs_by_pipeline, public_surface=public_surface),
         "profile_rows": _build_profile_rows(profile_data),
         "quality_rows": [] if public_surface else _build_quality_rows(quality),
-        "profile_artifact_rows": (
-            [] if public_surface else _build_profile_artifact_rows(result, padata_filenames or [])
-        ),
+        "profile_artifact_rows": _build_profile_artifact_rows(result, padata_filenames or []),
         "environment_rows": (
             [] if public_surface else _build_environment_rows(result.get("environment_snapshot"))
         ),

--- a/result_server/utils/result_file.py
+++ b/result_server/utils/result_file.py
@@ -10,6 +10,18 @@ from flask import Response, abort, send_from_directory, session
 from utils.session_user_context import get_session_user_context
 
 
+UUID_PATTERN = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+    re.IGNORECASE,
+)
+PUBLIC_PADATA_FILENAME_RE = re.compile(
+    r"^padata_\d{8}_\d{6}_"
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+    r"(?:_[A-Za-z0-9][A-Za-z0-9_.-]{0,127})?\.tgz$",
+    re.IGNORECASE,
+)
+
+
 def load_result_file(filename: str, save_dir: str):
     filepath = resolve_safe_child_path(filename, save_dir)
     if filepath is None or not os.path.exists(filepath):
@@ -60,30 +72,18 @@ def get_file_confidential_tags(filename: str, save_dir: str):
         return _read_confidential_from_json(filename, save_dir)
 
     # For TGZ files, find the matching JSON by UUID and reuse its tags.
-    uuid_match = re.search(
-        r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
-        filename,
-        re.IGNORECASE,
-    )
-    if not uuid_match:
-        return []
-
-    uuid = uuid_match.group(0).lower()
     tags = []
-    for json_filename in os.listdir(save_dir):
-        if not json_filename.endswith(".json"):
-            continue
-        if uuid in json_filename.lower():
-            tags.extend(_read_confidential_from_json(json_filename, save_dir))
-            continue
-
-        data = _read_json(json_filename, save_dir)
-        if not isinstance(data, dict):
-            continue
-        server_uuid = data.get("_server_uuid")
-        if server_uuid is not None and str(server_uuid).lower() == uuid:
-            tags.extend(_extract_confidential_tags(data))
+    for _json_filename, data in _matching_result_json_for_padata(filename, save_dir):
+        tags.extend(_extract_confidential_tags(data))
     return _unique_tags(tags)
+
+
+def padata_matches_public_result(filename: str, save_dir: str) -> bool:
+    """Return whether a PA archive belongs only to public result metadata."""
+    matches = list(_matching_result_json_for_padata(filename, save_dir))
+    if not matches:
+        return False
+    return all(not _extract_confidential_tags(data) for _json_filename, data in matches)
 
 
 def check_file_permission(filename: str, dir_path: str) -> None:
@@ -109,6 +109,16 @@ def serve_permitted_result_file(filename: str, permission_dir: str, data_dir: Op
     """Check permission tags and then serve the requested file."""
     check_file_permission(filename, permission_dir)
     return load_result_file(filename, data_dir or permission_dir)
+
+
+def serve_public_padata_file(filename: str, permission_dir: str, data_dir: str):
+    """Serve a PA archive only when it belongs to public result metadata."""
+    if (
+        not PUBLIC_PADATA_FILENAME_RE.fullmatch(filename)
+        or not padata_matches_public_result(filename, permission_dir)
+    ):
+        abort(404)
+    return load_result_file(filename, data_dir)
 
 
 def serve_authenticated_result_file(filename: str, data_dir: str, *, message: str):
@@ -167,6 +177,26 @@ def _read_json(json_file: str, save_dir: str):
             return json.load(f)
     except Exception:
         return None
+
+
+def _matching_result_json_for_padata(filename: str, save_dir: str):
+    uuid_match = UUID_PATTERN.search(filename)
+    if not uuid_match:
+        return
+
+    uuid = uuid_match.group(0).lower()
+    for json_filename in os.listdir(save_dir):
+        if not json_filename.endswith(".json"):
+            continue
+        data = _read_json(json_filename, save_dir)
+        if not isinstance(data, dict):
+            continue
+        if uuid in json_filename.lower():
+            yield json_filename, data
+            continue
+        server_uuid = data.get("_server_uuid")
+        if server_uuid is not None and str(server_uuid).lower() == uuid:
+            yield json_filename, data
 
 
 def _extract_confidential_tags(data):

--- a/result_server/utils/result_table_rows.py
+++ b/result_server/utils/result_table_rows.py
@@ -21,11 +21,7 @@ def build_result_table_row(
 ):
     """Build a single row for the public/confidential results index table."""
     timestamp = format_result_timestamp(json_filename)
-    matched_padata = (
-        None
-        if public_surface
-        else _find_matching_padata_archive(json_filename, result_data, padata_filenames)
-    )
+    matched_padata = _find_matching_padata_archive(json_filename, result_data, padata_filenames)
     pipeline_timing = result_data.get("pipeline_timing", {})
     source_info = result_data.get("source_info")
     source_link = None if public_surface else _build_source_link(source_info)

--- a/result_server/utils/results_loader.py
+++ b/result_server/utils/results_loader.py
@@ -27,7 +27,7 @@ RESULT_TABLE_COLUMNS = [
     {"label": "Nodes", "key": "nodes"},
     {"label": "P/N", "key": "numproc_node", "tooltip": "Number of processes per node"},
     {"label": "T/P", "key": "nthreads", "tooltip": "Number of threads per process"},
-    {"label": "Profiler / PA", "key": "profile_summary", "tooltip": "Profiler tool, level, report summary, and PA data download access"},
+    {"label": "Profiler / PA", "key": "profile_summary", "tooltip": "Profiler tool/level and PA data download access when archive is available"},
     {"label": "Run Cause", "key": "execution_trigger_summary", "tooltip": "Portal trigger metadata explaining why this benchmark run was launched"},
     {"label": "JSON", "key": "json_link", "tooltip": "Detailed benchmark results in JSON format", "tooltip_class": "tooltip-right"},
     {"label": "CI", "key": "ci_summary", "tooltip": "CI trigger source and pipeline ID"},


### PR DESCRIPTION
Summary
- simplify the CX Portal home page by removing duplicated system cards and low-signal summary sections
- move PerfTools context to the authenticated Estimated Results page
- expose Systems at /systems and keep public PA archive downloads conditional on public result metadata
- keep raw result JSON, confidential PA data, estimated data, and operator routes outside the public browser surface

Tests
- .venv/bin/python -m pytest result_server/tests
- git diff --check
- python3 scripts/tests/check_text_integrity.py