### PR TITLE
Standardize Benchkit branding and manual CI input

### DIFF
--- a/.github/workflows/gitlab-manual-ci.yml
+++ b/.github/workflows/gitlab-manual-ci.yml
@@ -8,26 +8,26 @@ on:
         required: true
         default: "develop"
       code:
-        description: "BenchKit code filter, for example: qws,genesis"
+        description: "Benchkit code filter, for example: qws,genesis"
         required: false
       system:
         description: "System filter, for example: Fugaku,MiyabiG"
         required: false
       app:
-        description: "BenchPark app filter, for example: osu-micro-benchmarks"
+        description: "Benchpark app filter, for example: osu-micro-benchmarks"
         required: false
       benchpark:
-        description: "Run the BenchPark path together with BenchKit"
+        description: "Run the Benchpark path together with Benchkit"
         required: false
         type: boolean
         default: false
       park_only:
-        description: "Run only the BenchPark path"
+        description: "Run only the Benchpark path"
         required: false
         type: boolean
         default: false
       park_send:
-        description: "Run the BenchPark send-only path"
+        description: "Run the Benchpark send-only path"
         required: false
         type: boolean
         default: false

--- a/.github/workflows/gitlab-manual-ci.yml
+++ b/.github/workflows/gitlab-manual-ci.yml
@@ -13,6 +13,9 @@ on:
       system:
         description: "System filter, for example: Fugaku,MiyabiG"
         required: false
+      allocation_project_id:
+        description: "Optional allocation/project ID passed as BK_ALLOCATION_PROJECT_ID"
+        required: false
       app:
         description: "Benchpark app filter, for example: osu-micro-benchmarks"
         required: false
@@ -95,6 +98,7 @@ jobs:
           GITLAB_PROJECT_PATH: ${{ steps.gitlab-repo.outputs.project-path }}
           CODE_FILTER: ${{ inputs.code }}
           SYSTEM_FILTER: ${{ inputs.system }}
+          ALLOCATION_PROJECT_ID: ${{ inputs.allocation_project_id }}
           BENCHPARK_APP: ${{ inputs.app }}
           BENCHPARK: ${{ inputs.benchpark }}
           PARK_ONLY: ${{ inputs.park_only }}
@@ -123,6 +127,7 @@ jobs:
 
           add_variable("code", os.environ.get("CODE_FILTER", ""))
           add_variable("system", os.environ.get("SYSTEM_FILTER", ""))
+          add_variable("BK_ALLOCATION_PROJECT_ID", os.environ.get("ALLOCATION_PROJECT_ID", ""))
           add_variable("app", os.environ.get("BENCHPARK_APP", ""))
 
           if os.environ.get("BENCHPARK") == "true":

--- a/.gitignore
+++ b/.gitignore
@@ -17,10 +17,10 @@ __pycache__/
 .venv/
 .venv-*/
 
-# BenchPark repository (external reference)
+# Benchpark repository (external reference)
 benchpark/
 
-# BenchPark workspace (generated during CI)
+# Benchpark workspace (generated during CI)
 benchpark-workspace/
 
 # Estimator tool checkouts prepared during CI/local smoke tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -153,7 +153,7 @@ trigger_child_pipeline:
           - "config/system_info.csv"
       when: never
     - when: always
-# BenchPark Monitor Jobs
+# Benchpark Monitor Jobs
 generate_benchpark_matrix:
   stage: generate
   script:
@@ -166,9 +166,9 @@ generate_benchpark_matrix:
     expire_in: 1 hour
   rules:
     - if: '$estimate_result_uuid != ""'
-      when: never  # 推定モードではBenchParkパイプラインも無効化
+      when: never  # 推定モードではBenchparkパイプラインも無効化
     - if: '$code != "" && $benchpark != "true" && $park_only != "true" && $park_send != "true"'
-      when: never  # BenchKit専用のcode指定時はBenchParkを実行しない
+      when: never  # Benchkit専用のcode指定時はBenchparkを実行しない
     - if: '$park_only == "true"'
       when: always  # park_onlyモードでは常に実行
     - if: '$park_send == "true"'
@@ -205,9 +205,9 @@ trigger_benchpark_pipeline:
       optional: true
   rules:
     - if: '$estimate_result_uuid != ""'
-      when: never  # 推定モードではBenchParkパイプラインも無効化
+      when: never  # 推定モードではBenchparkパイプラインも無効化
     - if: '$code != "" && $benchpark != "true" && $park_only != "true" && $park_send != "true"'
-      when: never  # BenchKit専用のcode指定時はBenchParkを実行しない
+      when: never  # Benchkit専用のcode指定時はBenchparkを実行しない
     - if: '$park_only == "true"'
       when: always  # park_onlyモードでは常に実行
     - if: '$park_send == "true"'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to BenchKit
+# Contributing to Benchkit
 
-Thank you for contributing to BenchKit.
+Thank you for contributing to Benchkit.
 
 This project aims to support an open ecosystem around the CX Framework and CX Platform. Contributions from application developers, system operators, and related communities are welcome.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# BenchKit
+# Benchkit
 
-BenchKit is a shell-first benchmarking framework for the CX Framework. It supports build and run workflows for multiple applications and systems, result collection, profiler data handling, estimation workflows, and result portal integration.
+Benchkit is a shell-first benchmarking framework for the CX Framework. It supports build and run workflows for multiple applications and systems, result collection, profiler data handling, estimation workflows, and result portal integration.
 
 ## Origin
 
@@ -32,8 +32,8 @@ Core specifications:
 
 - [CX framework](docs/cx/CX_FRAMEWORK.md): top-level concept and terminology.
 - [CX platform](docs/cx/CX_PLATFORM.md): system-level responsibilities and component boundaries.
-- [BenchKit specification](docs/cx/BENCHKIT_SPEC.md): BenchKit responsibilities, interfaces, and future extension points.
-- [BenchKit gap analysis](docs/cx/BENCHKIT_GAP_ANALYSIS.md): implementation-facing functional gaps against the BenchKit specification.
+- [Benchkit specification](docs/cx/BENCHKIT_SPEC.md): Benchkit responsibilities, interfaces, and future extension points.
+- [Benchkit gap analysis](docs/cx/BENCHKIT_GAP_ANALYSIS.md): implementation-facing functional gaps against the Benchkit specification.
 
 Estimation specifications:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-BenchKit is published as open source, so security fixes and reporting paths
+Benchkit is published as open source, so security fixes and reporting paths
 need to be clear for external users and researchers.
 
 ## Supported Versions

--- a/benchpark-bridge/scripts/ci_generator.sh
+++ b/benchpark-bridge/scripts/ci_generator.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-# BenchPark統合用のGitLab CI YAML生成スクリプト
+# Benchpark統合用のGitLab CI YAML生成スクリプト
 # 既存のmatrix_generate.shとは独立して動作
 
 BENCHPARK_LIST="benchpark-bridge/config/apps.csv"
@@ -33,9 +33,9 @@ ${job_prefix}_convert:
   script:
     - mkdir -p results
     - echo \"convert_started\" > results/convert.txt
-    - echo \"Converting BenchPark results for $app on $system\"
+    - echo \"Converting Benchpark results for $app on $system\"
     - python3 benchpark-bridge/scripts/result_converter.py $system $app
-    - echo \"Results converted to BenchKit format\"
+    - echo \"Results converted to Benchkit format\"
     - echo \"convert_completed\" >> results/convert.txt
     - ls -la results/
   artifacts:
@@ -89,7 +89,7 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
-echo "# Auto-generated BenchPark GitLab CI configuration" > "$OUTPUT_FILE"
+echo "# Auto-generated Benchpark GitLab CI configuration" > "$OUTPUT_FILE"
 echo "
 stages:
   - benchpark_setup
@@ -133,7 +133,7 @@ ${job_prefix}_setup:
     CI_JOB_JWT:
       aud: https://gitlab.swc.r-ccs.riken.jp
   script:
-    - echo \"Setting up BenchPark for $app on $system\"
+    - echo \"Setting up Benchpark for $app on $system\"
     - bash benchpark-bridge/scripts/runner.sh setup $app
 
 ${job_prefix}_run:
@@ -146,7 +146,7 @@ ${job_prefix}_run:
   script:
     - mkdir -p results
     - echo \"run_started\" > results/run.txt
-    - echo \"Running BenchPark experiment $app on $system\"
+    - echo \"Running Benchpark experiment $app on $system\"
     - bash benchpark-bridge/scripts/runner.sh run $app
     - echo \"run_completed\" >> results/run.txt
     - ls -la results/
@@ -157,4 +157,4 @@ ${job_prefix}_run:
 
 done < "$BENCHPARK_LIST"
 
-echo "BenchPark GitLab CI configuration generated: $OUTPUT_FILE"
+echo "Benchpark GitLab CI configuration generated: $OUTPUT_FILE"

--- a/benchpark-bridge/scripts/common.sh
+++ b/benchpark-bridge/scripts/common.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# BenchPark統合用の共通関数
+# Benchpark統合用の共通関数
 
 # TODO: 現在未使用。将来のシステム拡張時に使用予定
-# システムに既存のBenchParkインストールパスを取得
+# システムに既存のBenchparkインストールパスを取得
 get_benchpark_installation_path() {
   local system="$1"
   
@@ -61,7 +61,7 @@ get_benchpark_login_tag() {
 }
 
 # TODO: 現在未使用。将来のシステム拡張時に使用予定
-# BenchParkワークスペースのパスを取得
+# Benchparkワークスペースのパスを取得
 get_benchpark_workspace() {
   local system="$1"
   local app="$2"
@@ -69,7 +69,7 @@ get_benchpark_workspace() {
 }
 
 # TODO: 現在未使用。将来のシステム拡張時に使用予定
-# BenchPark実験設定ファイルのパスを取得（システム既存インストール用）
+# Benchpark実験設定ファイルのパスを取得（システム既存インストール用）
 get_benchpark_experiment_path() {
   local system="$1"
   local app="$2"
@@ -78,7 +78,7 @@ get_benchpark_experiment_path() {
 }
 
 # TODO: 現在未使用。将来のシステム拡張時に使用予定
-# BenchParkシステム設定ファイルのパスを取得（相対パス）
+# Benchparkシステム設定ファイルのパスを取得（相対パス）
 get_benchpark_system_path() {
   local system="$1"
   
@@ -155,7 +155,7 @@ wait_for_ramble_jobs() {
 }
 
 # TODO: 現在未使用。将来のシステム拡張時に使用予定
-# BenchPark結果ディレクトリを取得
+# Benchpark結果ディレクトリを取得
 get_benchpark_results_dir() {
   local workspace="$1"
   echo "${workspace}/experiments/*/results"

--- a/benchpark-bridge/scripts/result_converter.py
+++ b/benchpark-bridge/scripts/result_converter.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
-BenchPark結果をBenchKit形式に変換するスクリプト
+Benchpark結果をBenchkit形式に変換するスクリプト
 
-BenchParkのRamble結果をBenchKitのJSON形式に変換し、
+BenchparkのRamble結果をBenchkitのJSON形式に変換し、
 既存の結果表示システムで表示できるようにします。
 """
 
@@ -18,7 +18,7 @@ def extract_node_count_from_experiment(workspace_path, experiment_name):
     """実験のexecute_experimentスクリプトからノード数を抽出
     
     Args:
-        workspace_path: BenchParkワークスペースのパス
+        workspace_path: Benchparkワークスペースのパス
         experiment_name: 実験名（例: osu-micro-benchmarks.osu_bibw.osu-micro-benchmarks_osu_bibw_test_mpi_2）
     
     Returns:
@@ -78,7 +78,7 @@ def extract_node_count_from_experiment(workspace_path, experiment_name):
 
 
 def find_benchpark_results(workspace_path, system, app):
-    """BenchPark結果ファイルを検索"""
+    """Benchpark結果ファイルを検索"""
     # results.latest.txtを優先的に使用
     latest_results = os.path.join(workspace_path, "results.latest.txt")
     
@@ -91,15 +91,15 @@ def find_benchpark_results(workspace_path, system, app):
     result_files = glob.glob(results_pattern)
     
     if not result_files:
-        print(f"No BenchPark results found in {workspace_path}")
+        print(f"No Benchpark results found in {workspace_path}")
         return []
     
-    print(f"Found {len(result_files)} BenchPark result files")
+    print(f"Found {len(result_files)} Benchpark result files")
     return result_files
 
 
 def parse_benchpark_result(result_file):
-    """BenchPark結果ファイルを解析"""
+    """Benchpark結果ファイルを解析"""
     # results.latest.txtの場合
     if result_file.endswith("results.latest.txt") or result_file.endswith(".txt"):
         return parse_ramble_results_txt(result_file)
@@ -288,13 +288,13 @@ def parse_ramble_results_txt(result_file):
 
 
 def convert_to_benchkit_format(parsed_result, system, app, workspace_path):
-    """BenchKit形式のJSONに変換（ベクトル型メトリクス対応）
+    """Benchkit形式のJSONに変換（ベクトル型メトリクス対応）
     
     Args:
         parsed_result: 解析済みの実験結果
         system: システム名
         app: アプリケーション名
-        workspace_path: BenchParkワークスペースのパス（ノード数抽出用）
+        workspace_path: Benchparkワークスペースのパス（ノード数抽出用）
     """
     
     if not parsed_result:
@@ -404,7 +404,7 @@ def convert_to_benchkit_format(parsed_result, system, app, workspace_path):
     
     # タイムスタンプはサーバ側で自動追加されるため不要
     
-    # BenchKit形式のJSON構造（新形式）
+    # Benchkit形式のJSON構造（新形式）
     result = {
         "code": f"benchpark-{app}",
         "system": system,
@@ -476,10 +476,10 @@ def main():
         print(f"Error: Workspace not found: {workspace_path}")
         sys.exit(1)
     
-    print(f"Converting BenchPark results for {app} on {system}")
+    print(f"Converting Benchpark results for {app} on {system}")
     print(f"Workspace path: {workspace_path}")
     
-    # BenchPark結果を検索
+    # Benchpark結果を検索
     result_files = find_benchpark_results(workspace_path, system, app)
     
     if not result_files:
@@ -509,21 +509,21 @@ def main():
     # 各実験を個別のJSONファイルとして保存
     output_files = []
     for i, experiment in enumerate(all_experiments):
-        # BenchKit形式に変換
+        # Benchkit形式に変換
         benchkit_result = convert_to_benchkit_format(experiment, system, app, workspace_path)
         
         if not benchkit_result:
             print(f"Failed to convert experiment {i+1}")
             continue
         
-        # BenchKit互換のファイル名形式（result*.json）
+        # Benchkit互換のファイル名形式（result*.json）
         # 既存のsend_results.shがそのまま使える
-        # BenchKitはresult0.jsonから始まる
+        # Benchkitはresult0.jsonから始まる
         output_file = f"results/result{i}.json"
         
         with open(output_file, 'w') as f:
             json.dump(benchkit_result, f, indent=2)
-            f.write('\n')  # 末尾に改行を追加（BenchKit互換）
+            f.write('\n')  # 末尾に改行を追加（Benchkit互換）
         
         output_files.append(output_file)
         print(f"Experiment {i+1}/{len(all_experiments)}: {experiment.get('experiment', 'unknown')}")

--- a/benchpark-bridge/scripts/runner.sh
+++ b/benchpark-bridge/scripts/runner.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-# BenchPark実行管理スクリプト（QC-GH200専用）
+# Benchpark実行管理スクリプト（QC-GH200専用）
 
 source ./benchpark-bridge/scripts/common.sh
 
@@ -14,15 +14,15 @@ BENCHPARK_ROOT="/home/users/nakamura/src/benchpark/r-ccs-fork/benchpark"
 
 case "$ACTION" in
   "setup")
-    echo "Setting up BenchPark for $APP on $SYSTEM"
-    echo "Note: Setup is handled by BenchPark workspace initialization"
+    echo "Setting up Benchpark for $APP on $SYSTEM"
+    echo "Note: Setup is handled by Benchpark workspace initialization"
     ;;
     
   "run")
-    echo "Running BenchPark experiment: $APP on $SYSTEM"
+    echo "Running Benchpark experiment: $APP on $SYSTEM"
     
     # setup.shで環境変数を設定
-    echo "Loading BenchPark environment"
+    echo "Loading Benchpark environment"
     . "$BENCHPARK_ROOT/workspace/setup.sh"
     
     # Rambleワークスペースのパス
@@ -49,10 +49,10 @@ case "$ACTION" in
       echo "Extracted SLURM job IDs: $job_ids"
     fi
     
-    echo "BenchPark experiment submitted"
+    echo "Benchpark experiment submitted"
     
     # ジョブ完了を待機（ジョブIDを渡す）
-    echo "Waiting for BenchPark jobs to complete"
+    echo "Waiting for Benchpark jobs to complete"
     wait_for_ramble_jobs "$RAMBLE_WORKSPACE" "$job_ids"
     
     # ジョブ完了後、Rambleワークスペースを解析
@@ -64,13 +64,13 @@ case "$ACTION" in
     # 結果を解析
     ramble workspace analyze
     
-    echo "BenchPark jobs completed and analyzed"
+    echo "Benchpark jobs completed and analyzed"
     ;;
     
   *)
     echo "Usage: $0 {setup|run} <app>"
-    echo "  setup: Prepare BenchPark (QC-GH200)"
-    echo "  run:   Submit BenchPark experiment and wait for completion (QC-GH200)"
+    echo "  setup: Prepare Benchpark (QC-GH200)"
+    echo "  run:   Submit Benchpark experiment and wait for completion (QC-GH200)"
     exit 1
     ;;
 esac

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -72,7 +72,7 @@ The workflow accepts these inputs:
 | `target_ref` | Branch, tag, or SHA in the upstream repository to test / upstreamリポジトリ内でテストするbranch、tag、SHA | `feature/my-change`, `ci/pr-123`, `develop` |
 | `code` | Benchkit program filter / Benchkitプログラムのフィルタ | `qws,genesis` |
 | `system` | Benchkit system filter. Legacy Benchpark bridge jobs in this repo do not honor this as a general system selector. / Benchkit systemフィルタ。このrepo内のlegacy Benchpark bridge jobは汎用system selectorとしては扱いません | `Fugaku,MiyabiG` |
-| `BK_ALLOCATION_PROJECT_ID` | Optional semantic project/allocation ID supplied by the Portal. Benchkit translates it to scheduler syntax only for systems that require it, for example Slurm `--account=<id>` on RIKYU. / Portal が渡す任意の意味的な project/allocation ID。Benchkit は必要な system に限って scheduler 書式へ変換します。例: RIKYU の Slurm `--account=<id>` | `rkp00010` |
+| `allocation_project_id` | Optional semantic project/allocation ID passed to GitLab as `BK_ALLOCATION_PROJECT_ID`. Benchkit translates it to scheduler syntax only for systems that require it, for example Slurm `--account=<id>` on RIKYU. / GitLab へ `BK_ALLOCATION_PROJECT_ID` として渡す任意の意味的な project/allocation ID。Benchkit は必要な system に限って scheduler 書式へ変換します。例: RIKYU の Slurm `--account=<id>` | `rkp00010` |
 | `app` | Legacy Benchpark bridge app filter. Active Benchpark CI/CD/CB result handling is maintained in a separate project. / legacy Benchpark bridge appフィルタ。現行Benchpark CI/CD/CB結果受け取りは別プロジェクト側で管理します | `osu-micro-benchmarks` |
 | `benchpark` | Enable the legacy Benchpark bridge path together with Benchkit / legacy Benchpark bridge pathも有効化 | `true` |
 | `park_only` | Run only the legacy Benchpark bridge path / legacy Benchpark bridgeのみ実行 | `true` |
@@ -90,8 +90,8 @@ The workflow:
 - Uses `ci.skip` for that push so the push itself does not start a full GitLab pipeline.
 - GitLab Pipeline APIを使ってpipelineを明示的に起動します。
 - Starts a GitLab pipeline through the GitLab Pipeline API.
-- `code`, `system`, `app`, `park_only`, `park_send`などの指定変数を渡します。
-- Passes the selected scope variables such as `code`, `system`, `app`, `park_only`, and `park_send`.
+- `code`, `system`, `allocation_project_id`, `app`, `park_only`, `park_send`などの指定変数を渡します。
+- Passes the selected scope variables such as `code`, `system`, `allocation_project_id`, `app`, `park_only`, and `park_send`.
 - GitLab pipelineの完了を待ちます。
 - Waits for the GitLab pipeline to finish.
 - 実行後、一時GitLabブランチを削除します。
@@ -156,6 +156,7 @@ The recommended mechanism is pipeline variables. `GitLab Manual CI` uses pipelin
 |---|---|---|
 | `system` | Benchkit system filter. Legacy Benchpark bridge jobs in this repo are not a general multi-system Benchpark runner. / Benchkit systemフィルタ。このrepo内のlegacy Benchpark bridge jobは汎用multi-system Benchpark runnerではありません | `MiyabiG,MiyabiC,RC_GENOA` |
 | `code` | Benchkit program filter / Benchkit programフィルタ | `qws,genesis` |
+| `BK_ALLOCATION_PROJECT_ID` | Optional semantic project/allocation ID. Benchkit validates the value and derives scheduler arguments only for systems that support it. / 任意の意味的な project/allocation ID。Benchkit は値を検証し、対応 system に限って scheduler 引数へ変換します | `rkp00010` |
 | `app` | Legacy Benchpark bridge app filter. Active Benchpark CI/CD/CB result handling has moved to a separate project. / legacy Benchpark bridge appフィルタ。現行Benchpark CI/CD/CB結果受け取りは別プロジェクト側へ移行済み | `osu-micro-benchmarks` |
 | `benchpark` | Enable the legacy Benchpark bridge path / legacy Benchpark bridge pathを有効化 | `true` |
 | `park_only` | Run the legacy Benchpark bridge and skip the normal Benchkit matrix / legacy Benchpark bridgeのみ実行し通常Benchkit matrixをスキップ | `true` |

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,12 +1,12 @@
 # CI Execution Control / CI実行制御
 
-この文書は、BenchKit における GitHub Actions と GitLab CI の発火条件・運用方針を説明します。
+この文書は、Benchkit における GitHub Actions と GitLab CI の発火条件・運用方針を説明します。
 
-This document describes how BenchKit controls GitHub Actions and GitLab CI execution.
+This document describes how Benchkit controls GitHub Actions and GitLab CI execution.
 
-BenchKit では、GitHub を公開開発リポジトリとして使い、GitLab CI を重いベンチマーク実行に使います。基本方針は、pull request では重いCIを自動発火させず、必要な場合にmaintainerが明示的にGitLab CIを起動することです。
+Benchkit では、GitHub を公開開発リポジトリとして使い、GitLab CI を重いベンチマーク実行に使います。基本方針は、pull request では重いCIを自動発火させず、必要な場合にmaintainerが明示的にGitLab CIを起動することです。
 
-BenchKit uses GitHub as the public development repository and GitLab CI for benchmark execution. The default policy is to keep pull requests lightweight and run heavy benchmark CI only when a maintainer explicitly starts it.
+Benchkit uses GitHub as the public development repository and GitLab CI for benchmark execution. The default policy is to keep pull requests lightweight and run heavy benchmark CI only when a maintainer explicitly starts it.
 
 ## GitHub Workflows / GitHubワークフロー
 
@@ -70,13 +70,13 @@ The workflow accepts these inputs:
 | Input / 入力 | Description / 説明 | Example / 例 |
 |---|---|---|
 | `target_ref` | Branch, tag, or SHA in the upstream repository to test / upstreamリポジトリ内でテストするbranch、tag、SHA | `feature/my-change`, `ci/pr-123`, `develop` |
-| `code` | BenchKit program filter / BenchKitプログラムのフィルタ | `qws,genesis` |
-| `system` | BenchKit system filter. Legacy BenchPark bridge jobs in this repo do not honor this as a general system selector. / BenchKit systemフィルタ。このrepo内のlegacy BenchPark bridge jobは汎用system selectorとしては扱いません | `Fugaku,MiyabiG` |
-| `BK_ALLOCATION_PROJECT_ID` | Optional semantic project/allocation ID supplied by the Portal. BenchKit translates it to scheduler syntax only for systems that require it, for example Slurm `--account=<id>` on RIKYU. / Portal が渡す任意の意味的な project/allocation ID。BenchKit は必要な system に限って scheduler 書式へ変換します。例: RIKYU の Slurm `--account=<id>` | `rkp00010` |
-| `app` | Legacy BenchPark bridge app filter. Active BenchPark CI/CD/CB result handling is maintained in a separate project. / legacy BenchPark bridge appフィルタ。現行BenchPark CI/CD/CB結果受け取りは別プロジェクト側で管理します | `osu-micro-benchmarks` |
-| `benchpark` | Enable the legacy BenchPark bridge path together with BenchKit / legacy BenchPark bridge pathも有効化 | `true` |
-| `park_only` | Run only the legacy BenchPark bridge path / legacy BenchPark bridgeのみ実行 | `true` |
-| `park_send` | Run the legacy BenchPark bridge send-only path / legacy BenchPark bridge送信系のみ実行 | `true` |
+| `code` | Benchkit program filter / Benchkitプログラムのフィルタ | `qws,genesis` |
+| `system` | Benchkit system filter. Legacy Benchpark bridge jobs in this repo do not honor this as a general system selector. / Benchkit systemフィルタ。このrepo内のlegacy Benchpark bridge jobは汎用system selectorとしては扱いません | `Fugaku,MiyabiG` |
+| `BK_ALLOCATION_PROJECT_ID` | Optional semantic project/allocation ID supplied by the Portal. Benchkit translates it to scheduler syntax only for systems that require it, for example Slurm `--account=<id>` on RIKYU. / Portal が渡す任意の意味的な project/allocation ID。Benchkit は必要な system に限って scheduler 書式へ変換します。例: RIKYU の Slurm `--account=<id>` | `rkp00010` |
+| `app` | Legacy Benchpark bridge app filter. Active Benchpark CI/CD/CB result handling is maintained in a separate project. / legacy Benchpark bridge appフィルタ。現行Benchpark CI/CD/CB結果受け取りは別プロジェクト側で管理します | `osu-micro-benchmarks` |
+| `benchpark` | Enable the legacy Benchpark bridge path together with Benchkit / legacy Benchpark bridge pathも有効化 | `true` |
+| `park_only` | Run only the legacy Benchpark bridge path / legacy Benchpark bridgeのみ実行 | `true` |
+| `park_send` | Run the legacy Benchpark bridge send-only path / legacy Benchpark bridge送信系のみ実行 | `true` |
 
 このworkflowは以下を行います。
 
@@ -154,29 +154,29 @@ The recommended mechanism is pipeline variables. `GitLab Manual CI` uses pipelin
 
 | Variable / 変数 | Description / 説明 | Example / 例 |
 |---|---|---|
-| `system` | BenchKit system filter. Legacy BenchPark bridge jobs in this repo are not a general multi-system BenchPark runner. / BenchKit systemフィルタ。このrepo内のlegacy BenchPark bridge jobは汎用multi-system BenchPark runnerではありません | `MiyabiG,MiyabiC,RC_GENOA` |
-| `code` | BenchKit program filter / BenchKit programフィルタ | `qws,genesis` |
-| `app` | Legacy BenchPark bridge app filter. Active BenchPark CI/CD/CB result handling has moved to a separate project. / legacy BenchPark bridge appフィルタ。現行BenchPark CI/CD/CB結果受け取りは別プロジェクト側へ移行済み | `osu-micro-benchmarks` |
-| `benchpark` | Enable the legacy BenchPark bridge path / legacy BenchPark bridge pathを有効化 | `true` |
-| `park_only` | Run the legacy BenchPark bridge and skip the normal BenchKit matrix / legacy BenchPark bridgeのみ実行し通常BenchKit matrixをスキップ | `true` |
-| `park_send` | Run the legacy BenchPark bridge result sending path and skip the normal BenchKit matrix / legacy BenchPark bridge送信系を実行し通常BenchKit matrixをスキップ | `true` |
+| `system` | Benchkit system filter. Legacy Benchpark bridge jobs in this repo are not a general multi-system Benchpark runner. / Benchkit systemフィルタ。このrepo内のlegacy Benchpark bridge jobは汎用multi-system Benchpark runnerではありません | `MiyabiG,MiyabiC,RC_GENOA` |
+| `code` | Benchkit program filter / Benchkit programフィルタ | `qws,genesis` |
+| `app` | Legacy Benchpark bridge app filter. Active Benchpark CI/CD/CB result handling has moved to a separate project. / legacy Benchpark bridge appフィルタ。現行Benchpark CI/CD/CB結果受け取りは別プロジェクト側へ移行済み | `osu-micro-benchmarks` |
+| `benchpark` | Enable the legacy Benchpark bridge path / legacy Benchpark bridge pathを有効化 | `true` |
+| `park_only` | Run the legacy Benchpark bridge and skip the normal Benchkit matrix / legacy Benchpark bridgeのみ実行し通常Benchkit matrixをスキップ | `true` |
+| `park_send` | Run the legacy Benchpark bridge result sending path and skip the normal Benchkit matrix / legacy Benchpark bridge送信系を実行し通常Benchkit matrixをスキップ | `true` |
 
 ### Branching Behavior / 分岐パターン
 
-| Variables / 変数 | BenchKit | Legacy BenchPark bridge | Description / 説明 |
+| Variables / 変数 | Benchkit | Legacy Benchpark bridge | Description / 説明 |
 |---|---|---|---|
-| `code=scale-letkf` | `scale-letkf` only / `scale-letkf`のみ | Skip / スキップ | Run a selected BenchKit code / 指定BenchKit codeのみ実行 |
+| `code=scale-letkf` | `scale-letkf` only / `scale-letkf`のみ | Skip / スキップ | Run a selected Benchkit code / 指定Benchkit codeのみ実行 |
 | `park_only=true` | Skip / スキップ | Legacy bridge apps / legacy bridge app | Run the legacy bridge only / legacy bridgeのみ実行 |
 | `park_only=true app=osu-micro-benchmarks` | Skip / スキップ | OSU only / OSUのみ | Run one legacy bridge app / legacy bridgeの特定appのみ実行 |
 | `park_send=true` | Skip / スキップ | Legacy bridge send-only / legacy bridge送信のみ | Re-send legacy bridge results / legacy bridge結果を再送信 |
 | `park_send=true app=osu-micro-benchmarks` | Skip / スキップ | OSU send-only / OSU送信のみ | Re-send one legacy bridge app / legacy bridgeの特定app結果を再送信 |
-| `benchpark=true` | All / 全実行 | Legacy bridge apps / legacy bridge app | Run BenchKit and the legacy bridge / BenchKitとlegacy bridgeを実行 |
+| `benchpark=true` | All / 全実行 | Legacy bridge apps / legacy bridge app | Run Benchkit and the legacy bridge / Benchkitとlegacy bridgeを実行 |
 | `benchpark=true code=qws app=osu-micro-benchmarks` | `qws` only / `qws`のみ | OSU only / OSUのみ | Run both paths with filters / 両方をフィルタ付きで実行 |
-| No variables / 変数なし | All / 全実行 | Skip / スキップ | Normal BenchKit CI / 通常のBenchKit CI |
+| No variables / 変数なし | All / 全実行 | Skip / スキップ | Normal Benchkit CI / 通常のBenchkit CI |
 
-`code`はBenchKit用のフィルタです。`code`だけを指定してもBenchPark jobは有効化されません。このrepo内のBenchPark bridgeはlegacyで、実行側はQC-GH200系の固定workspaceに依存します。現行のBenchPark CI/CD/CB結果受け取りは別プロジェクト側で管理します。
+`code`はBenchkit用のフィルタです。`code`だけを指定してもBenchpark jobは有効化されません。このrepo内のBenchpark bridgeはlegacyで、実行側はQC-GH200系の固定workspaceに依存します。現行のBenchpark CI/CD/CB結果受け取りは別プロジェクト側で管理します。
 
-`code` is a BenchKit filter. Setting only `code` does not enable BenchPark jobs. The BenchPark bridge in this repository is legacy and its execution side depends on a QC-GH200-style fixed workspace. Active BenchPark CI/CD/CB result handling is maintained in a separate project.
+`code` is a Benchkit filter. Setting only `code` does not enable Benchpark jobs. The Benchpark bridge in this repository is legacy and its execution side depends on a QC-GH200-style fixed workspace. Active Benchpark CI/CD/CB result handling is maintained in a separate project.
 
 ### Legacy Commit Message Tags / 旧コミットメッセージタグ
 
@@ -184,14 +184,14 @@ commit message tagによる制御はlegacy扱いです。新しい運用では�
 
 Commit-message based controls are legacy. For new operation, use `GitLab Manual CI` inputs in the GitHub Actions UI or GitLab Pipeline API variables.
 
-| Tag / タグ | BenchKit | Legacy BenchPark bridge | Purpose / 用途 |
+| Tag / タグ | Benchkit | Legacy Benchpark bridge | Purpose / 用途 |
 |---|---|---|---|
-| No tag / タグなし | Run / 実行 | Skip / スキップ | Normal BenchKit benchmark execution / 通常のBenchKitベンチマーク実行 |
-| `[code:<code>]` | Run selected code / 指定codeのみ実行 | Skip / スキップ | Limit BenchKit jobs to one or more programs / BenchKit jobを特定programに限定 |
-| `[system:<system>]` | Run selected system / 指定systemのみ実行 | Skip / スキップ | Limit BenchKit jobs to one or more systems / BenchKit jobを特定systemに限定 |
+| No tag / タグなし | Run / 実行 | Skip / スキップ | Normal Benchkit benchmark execution / 通常のBenchkitベンチマーク実行 |
+| `[code:<code>]` | Run selected code / 指定codeのみ実行 | Skip / スキップ | Limit Benchkit jobs to one or more programs / Benchkit jobを特定programに限定 |
+| `[system:<system>]` | Run selected system / 指定systemのみ実行 | Skip / スキップ | Limit Benchkit jobs to one or more systems / Benchkit jobを特定systemに限定 |
 | `[park-only]` | Skip / スキップ | Run / 実行 | Legacy bridge development or testing / legacy bridge開発・テスト |
 | `[park-send]` | Skip / スキップ | Send only / 送信のみ | Legacy bridge result conversion and sending / legacy bridge結果変換・送信 |
-| `[benchpark]` | Run / 実行 | Run / 実行 | Run BenchKit and legacy bridge paths / BenchKitとlegacy bridgeの両方を実行 |
+| `[benchpark]` | Run / 実行 | Run / 実行 | Run Benchkit and legacy bridge paths / Benchkitとlegacy bridgeの両方を実行 |
 | `[skip ci]` or `[ci skip]` | Skip / スキップ | Skip / スキップ | Skip CI when supported by the CI service / CIサービスが対応する場合にCIをスキップ |
 
 Examples / 例:
@@ -206,10 +206,10 @@ git commit -m "Update qws [code:qws,genesis]"
 # Combine system and code filters / systemとcodeを組み合わせる
 git commit -m "Test qws on MiyabiG [system:MiyabiG] [code:qws]"
 
-# Run the legacy BenchPark bridge only / legacy BenchPark bridgeのみ実行
-git commit -m "Fix BenchPark runner [park-only]"
+# Run the legacy Benchpark bridge only / legacy Benchpark bridgeのみ実行
+git commit -m "Fix Benchpark runner [park-only]"
 
-# Run legacy BenchPark bridge result conversion and sending only / legacy BenchPark bridge結果変換・送信のみ実行
+# Run legacy Benchpark bridge result conversion and sending only / legacy Benchpark bridge結果変換・送信のみ実行
 git commit -m "Fix result converter [park-send]"
 
 # Skip CI when supported by the CI service / CIサービスが対応する場合にCIをスキップ
@@ -268,7 +268,7 @@ The periodic review should therefore focus on semantic checks that are hard to e
 | Public site config or portal metadata `config/system.csv`, `config/queue.csv`, `config/system_info.csv` / 公開site configまたはportal表示メタデータ`config/system.csv`、`config/queue.csv`、`config/system_info.csv` | `Result Server Tests`, including site config preflight / site config preflightを含む`Result Server Tests` | `config/system.csv` and `config/queue.csv` run by `.gitlab-ci.yml`; `config/system_info.csv` is skipped / `config/system.csv`と`config/queue.csv`は`.gitlab-ci.yml`で実行、`config/system_info.csv`はskip | Public systems listed in `system_info.csv` must also exist in `system.csv` and reference a queue defined in `queue.csv` / `system_info.csv`に載せる公開systemは`system.csv`にも存在し、`queue.csv`定義済みqueueを参照する必要がある |
 | Portal upload or profile-data helper `scripts/bk_functions.sh`, `scripts/result.sh`, `scripts/result_server/**` / portal uploadまたはprofile-data helper `scripts/bk_functions.sh`、`scripts/result.sh`、`scripts/result_server/**` | `Result Server Tests`; `Shellcheck` for `.sh` changes / `Result Server Tests`; `.sh`変更は`Shellcheck` | GitHub pull requests do not start GitLab by default; if a direct/manual GitLab pipeline is started, `scripts/**/*` is treated as benchmark-affecting and runs / GitHub pull requestでは既定でGitLabは起動しない。直接/手動GitLab pipelineを起動した場合、`scripts/**/*` はbenchmark影響ありとして実行される | These helpers shape result JSON / upload behavior. Use lightweight tests first, then start `GitLab Manual CI` when benchmark-side behavior needs validation / これらのhelperはResult JSONやupload挙動へ影響する。まずlightweight testで確認し、benchmark側挙動の検証が必要な場合は`GitLab Manual CI`を起動する |
 | Benchmark app entrypoints `programs/**/build.sh`, `programs/**/estimate.sh`, `programs/**/run.sh`, or app matrix `programs/**/list.csv` / benchmark app entrypoint `programs/**/build.sh`、`programs/**/estimate.sh`、`programs/**/run.sh`、またはapp matrix `programs/**/list.csv` | `Result Server Tests` for portal app-support visibility and diagnostics; `Shellcheck` for `.sh` changes / portal app-support表示とdiagnostics向けに`Result Server Tests`; `.sh`変更は`Shellcheck` | Run through `GitLab Manual CI` when maintainer starts it / maintainerが`GitLab Manual CI`を起動した場合に実行 | App support and diagnostics read list/build/estimate/run for `/results/usage`; these checks provide visibility, not a readiness gate / app supportとdiagnosticsは`/results/usage`用にlist/build/estimate/runを読む。これはvisibilityでありreadiness gateではない |
-| Other benchmark app files, legacy BenchPark bridge, or shared scripts / その他のbenchmark appファイル、legacy BenchPark bridge、または共通script | `Shellcheck` for `.sh` changes when covered; otherwise normal GitHub review checks / 対象`.sh`変更は`Shellcheck`; それ以外は通常のGitHub review check | Run through `GitLab Manual CI` when maintainer starts it / maintainerが`GitLab Manual CI`を起動した場合に実行 | Use `code` and `system` for BenchKit validation. Use `benchpark` or `park_only` only for the legacy bridge path when needed / BenchKit検証には`code`と`system`を使う。legacy bridge pathが必要な場合だけ`benchpark`または`park_only`を使う |
+| Other benchmark app files, legacy Benchpark bridge, or shared scripts / その他のbenchmark appファイル、legacy Benchpark bridge、または共通script | `Shellcheck` for `.sh` changes when covered; otherwise normal GitHub review checks / 対象`.sh`変更は`Shellcheck`; それ以外は通常のGitHub review check | Run through `GitLab Manual CI` when maintainer starts it / maintainerが`GitLab Manual CI`を起動した場合に実行 | Use `code` and `system` for Benchkit validation. Use `benchpark` or `park_only` only for the legacy bridge path when needed / Benchkit検証には`code`と`system`を使う。legacy bridge pathが必要な場合だけ`benchpark`または`park_only`を使う |
 | GitHub workflow/action `.github/**/*` / GitHub workflow/action `.github/**/*` | `Repository Policy`; workflow-specific checks when applicable / `Repository Policy`; 必要に応じてworkflow固有check | Skipped by `.gitlab-ci.yml` rules / `.gitlab-ci.yml` rulesでskip | GitHub workflow/action changes affect API-calling or sync control logic. Review workflow semantics carefully; protected-branch sync pushes them to GitLab with `ci.skip` / GitHub workflow/action変更はAPI呼び出しやsync制御に影響する。workflowの意味を慎重にreviewする。protected-branch syncでは`ci.skip`付きでGitLabへpushされる |
 | `.gitlab-ci.yml` / `.gitlab-ci.yml` | Normal GitHub review checks only / 通常のGitHub review checkのみ | Run through `GitLab Manual CI` when a maintainer needs to validate GitLab pipeline behavior / GitLab pipeline挙動の検証が必要な場合にmaintainerが`GitLab Manual CI`で実行 | This file defines GitLab benchmark pipeline behavior / このファイルはGitLab benchmark pipeline挙動を定義する |
 

--- a/docs/cx/AUDIT_LOG_SPEC.md
+++ b/docs/cx/AUDIT_LOG_SPEC.md
@@ -1,6 +1,6 @@
-# BenchKit Result Server Audit Log Specification
+# Benchkit Result Server Audit Log Specification
 
-This document defines the structured audit events emitted by the BenchKit
+This document defines the structured audit events emitted by the Benchkit
 result server. The audit log is intended for security monitoring and incident
 review, not for storing secrets or full request payloads.
 

--- a/docs/cx/BENCHKIT_GAP_ANALYSIS.md
+++ b/docs/cx/BENCHKIT_GAP_ANALYSIS.md
@@ -1,4 +1,4 @@
-# BenchKit ギャップ分析 / BenchKit Gap Analysis
+# Benchkit ギャップ分析 / Benchkit Gap Analysis
 
 ## 言語方針 / Language Policy
 
@@ -12,7 +12,7 @@ If any discrepancy exists, the Japanese version takes precedence.
 ## 1. 文書の位置づけ / Position of This Document
 
 本書は [BENCHKIT_SPEC.md](./BENCHKIT_SPEC.md) を実装確認用の観点に落とし込んだ補助文書である。
-目的は、BenchKit の主要機能について、
+目的は、Benchkit の主要機能について、
 
 - 仕様上の要求
 - 現状実装
@@ -27,7 +27,7 @@ If any discrepancy exists, the Japanese version takes precedence.
 それらは現状把握や優先度判断の補助情報として扱う。
 
 This document is a companion to [BENCHKIT_SPEC.md](./BENCHKIT_SPEC.md), translating the specification into an implementation-facing checklist.
-Its purpose is to make visible, for each major BenchKit function:
+Its purpose is to make visible, for each major Benchkit function:
 
 - specification requirements
 - current implementation status
@@ -41,7 +41,7 @@ They are used only as supporting context for understanding the current state and
 
 ## 2. 現状の要約 / Current Summary
 
-BenchKit は現時点で、継続的ベンチマークの基盤部分はかなり整っている。
+Benchkit は現時点で、継続的ベンチマークの基盤部分はかなり整っている。
 特に、
 
 - shell-first の実行基盤
@@ -54,7 +54,7 @@ BenchKit は現時点で、継続的ベンチマークの基盤部分はかな�
 
 一方で、継続的推定は入口があるものの横展開が不足しており、AI 駆動最適化連携はまだ接続点の段階にある。
 
-BenchKit already has a solid foundation for continuous benchmarking, especially in:
+Benchkit already has a solid foundation for continuous benchmarking, especially in:
 
 - shell-first execution
 - system.csv-driven CI job generation
@@ -65,7 +65,7 @@ BenchKit already has a solid foundation for continuous benchmarking, especially 
 Continuous estimation has now moved beyond a mere entry point: a common estimation flow, a `weakscaling` reference path, a detailed dummy package for `qws`, and result-provenance handoff have all been implemented.
 However, estimation is still not yet broadly deployed across multiple applications, and AI-driven optimization integration remains mostly at the integration-point stage.
 
-As of the current repository survey, BenchKit has multiple benchmark applications with `build.sh`/`run.sh`; `qws` and `genesis` now provide `estimate.sh`, while the remaining applications still need estimation declarations before they can participate in the detailed estimation flow.
+As of the current repository survey, Benchkit has multiple benchmark applications with `build.sh`/`run.sh`; `qws` and `genesis` now provide `estimate.sh`, while the remaining applications still need estimation declarations before they can participate in the detailed estimation flow.
 The result portal also already has a meaningful pytest-based test suite under `result_server/tests`, and the repository now has a repo-local Python dependency manifest, a standard portal test entrypoint under `result_server/tests`, and a lightweight GitHub Actions verification path for portal-oriented changes.
 The main GitLab pipeline still intentionally skips heavy benchmark execution when a direct or manually triggered GitLab pipeline sees changes limited to `result_server/**/*` or portal display metadata such as `config/system_info.csv`. Protected-branch synchronization itself uses `ci.skip`, so the dedicated lightweight GitHub Actions path should continue to be kept in sync as portal-side files evolve.
 
@@ -75,7 +75,7 @@ The main GitLab pipeline still intentionally skips heavy benchmark execution whe
 この節は、それらを後で見失わないための明示的なメモである。
 
 - 推定 package / flow の境界:
-  BenchKit 共通層と package 側の責務分担はかなり整理されたが、metadata discovery、複数 detailed package 間の一般化、package 間 compare の扱いはまだ固定していない。
+  Benchkit 共通層と package 側の責務分担はかなり整理されたが、metadata discovery、複数 detailed package 間の一般化、package 間 compare の扱いはまだ固定していない。
 - app 側の推定宣言 API:
   `estimate.sh` に current / future package と section 宣言を書く流れは見えてきたが、他 app へ横展開する前提の最終 API はまだ固めていない。
 - 推定結果 compare UI:
@@ -93,7 +93,7 @@ At the current stage, several issues are not simply "missing implementations" bu
 This section keeps those visible so they are not forgotten later.
 
 - estimation package / flow boundary:
-  the separation between BenchKit common flow and package-owned behavior is much clearer now, but metadata discovery, generalization across multiple detailed packages, and package-level comparison are not yet fixed.
+  the separation between Benchkit common flow and package-owned behavior is much clearer now, but metadata discovery, generalization across multiple detailed packages, and package-level comparison are not yet fixed.
 - application-side estimation declaration API:
   the direction of declaring current / future packages and section bindings in `estimate.sh` is becoming clear, but the final cross-application API is not yet frozen.
 - estimation compare UI:
@@ -146,7 +146,7 @@ The following are not standalone gaps unless the SPEC explicitly requires them: 
 - 役割名:
   現時点の repo 変更・PR 確認・手動 CI 運用では、app 担当、拠点担当、推定担当、admin を基本ロールとし、admin が reviewer / approver を兼ねる運用でよい。申請者は将来の portal 申請・承認 workflow のロールであり、現時点の文書整理で解決する責務分担には含めない。将来 workflow を実装する場合にのみ、申請者を含む権限 enforcement を機能 GAP として扱う。
 - 責務分離:
-  app 担当は `programs/<code>/` 配下の build/run/list/estimate と app 固有の採取を主に持つ。拠点担当は `config/system.csv`、`config/queue.csv`、`config/system_info.csv` と runner / scheduler / queue 条件を持つ。推定担当は `scripts/estimation/packages/` と `scripts/estimation/section_packages/` 配下の推定ロジック、metadata、fallback / applicability を持つ。BenchKit 共通層は common flow、JSON 受け渡し、portal 表示、CI / helper を持つ。この分担は `docs/guides/developer-reference.md`、`add-app.md`、`add-site.md`、`add-estimation.md`、`add-estimation-package.md` で案内する。
+  app 担当は `programs/<code>/` 配下の build/run/list/estimate と app 固有の採取を主に持つ。拠点担当は `config/system.csv`、`config/queue.csv`、`config/system_info.csv` と runner / scheduler / queue 条件を持つ。推定担当は `scripts/estimation/packages/` と `scripts/estimation/section_packages/` 配下の推定ロジック、metadata、fallback / applicability を持つ。Benchkit 共通層は common flow、JSON 受け渡し、portal 表示、CI / helper を持つ。この分担は `docs/guides/developer-reference.md`、`add-app.md`、`add-site.md`、`add-estimation.md`、`add-estimation-package.md` で案内する。
 - scaffold:
   scaffold や自動生成は必須要件ではない。既存例と guide から追加できる状態を正とし、必要に応じて任意の支援機能として検討する。
 - coverage matrix:

--- a/docs/cx/BENCHKIT_SPEC.md
+++ b/docs/cx/BENCHKIT_SPEC.md
@@ -1,4 +1,4 @@
-# BenchKit仕様 / BenchKit Specification
+# Benchkit仕様 / Benchkit Specification
 
 ## 言語方針 / Language Policy
 
@@ -15,7 +15,7 @@ If any discrepancy exists, the Japanese version takes precedence.
 特に、本書では以下を区別して読むことが重要である。
 
 - 必須要件:
-  追跡しなければならない情報、満たさなければならない接続条件、BenchKit が責任を持つべき事項。
+  追跡しなければならない情報、満たさなければならない接続条件、Benchkit が責任を持つべき事項。
 - 原則:
   shell-first、ポータル中心、責務分離のような設計原則。
 - 将来拡張:
@@ -25,7 +25,7 @@ This document follows the reading conventions defined in [`CX_FRAMEWORK.md`](./C
 In particular, it is important here to distinguish:
 
 - mandatory requirements:
-  information that must be tracked, connection conditions that must be satisfied, and responsibilities that BenchKit must own.
+  information that must be tracked, connection conditions that must be satisfied, and responsibilities that Benchkit must own.
 - principles:
   design principles such as shell-first, portal-centered interaction, and separation of responsibilities.
 - future extensions:
@@ -33,10 +33,10 @@ In particular, it is important here to distinguish:
 
 ## 1. 目的 / Purpose
 
-BenchKit は、CX基盤を構成する中核ソフトウェアであり、
+Benchkit は、CX基盤を構成する中核ソフトウェアであり、
 継続的ベンチマーク、継続的推定、継続的フィードバックを実用的に回すための基盤ソフトウェア兼ポータルである。
 
-BenchKit は特に以下を担う。
+Benchkit は特に以下を担う。
 
 - ベンチマーク実行定義を保持する
 - CI/CD による継続実行を生成する
@@ -44,9 +44,9 @@ BenchKit は特に以下を担う。
 - ベンチマーク結果・推定結果・使用量を表示する
 - 将来の申請、承認、最適化、AI 指示ワークフローへの接続点を提供する
 
-BenchKit is a core software component of the CX Platform and serves as both infrastructure and portal for practical continuous benchmarking, continuous estimation, and continuous feedback.
+Benchkit is a core software component of the CX Platform and serves as both infrastructure and portal for practical continuous benchmarking, continuous estimation, and continuous feedback.
 
-BenchKit is responsible in particular for:
+Benchkit is responsible in particular for:
 
 - holding benchmark execution definitions
 - generating continuous execution through CI/CD
@@ -56,38 +56,38 @@ BenchKit is responsible in particular for:
 
 ## 1.1 文書の位置づけ / Position of This Document
 
-本書は、[`CX_FRAMEWORK.md`](./CX_FRAMEWORK.md) および [`CX_PLATFORM.md`](./CX_PLATFORM.md) を受けて、BenchKit 自体の責務・構成・接続点を定義する下位仕様である。
+本書は、[`CX_FRAMEWORK.md`](./CX_FRAMEWORK.md) および [`CX_PLATFORM.md`](./CX_PLATFORM.md) を受けて、Benchkit 自体の責務・構成・接続点を定義する下位仕様である。
 
-本書は、BenchKit の外にある外部サービス、外部ツール、実システムを前提とするが、
-それらの内部仕様そのものではなく、BenchKit から見た責務境界と接続要件を記述する。
+本書は、Benchkit の外にある外部サービス、外部ツール、実システムを前提とするが、
+それらの内部仕様そのものではなく、Benchkit から見た責務境界と接続要件を記述する。
 主要用語は [`CX_FRAMEWORK.md`](./CX_FRAMEWORK.md) の用語集に従う。
 
-This document is a lower-level specification derived from [`CX_FRAMEWORK.md`](./CX_FRAMEWORK.md) and [`CX_PLATFORM.md`](./CX_PLATFORM.md), defining BenchKit’s own responsibilities, structure, and integration points.
+This document is a lower-level specification derived from [`CX_FRAMEWORK.md`](./CX_FRAMEWORK.md) and [`CX_PLATFORM.md`](./CX_PLATFORM.md), defining Benchkit’s own responsibilities, structure, and integration points.
 
-It assumes the existence of external services, external tools, and real systems outside BenchKit, but describes not their internal semantics themselves, rather the responsibility boundaries and integration requirements as seen from BenchKit.
+It assumes the existence of external services, external tools, and real systems outside Benchkit, but describes not their internal semantics themselves, rather the responsibility boundaries and integration requirements as seen from Benchkit.
 Core terminology follows the glossary in [`CX_FRAMEWORK.md`](./CX_FRAMEWORK.md).
 
 ## 2. CX基盤における位置づけ / Position Within the CX Platform
 
-BenchKit は CX基盤の中で、実行・結果管理・ポータルの中核を担う。
+Benchkit は CX基盤の中で、実行・結果管理・ポータルの中核を担う。
 
-BenchKit 自体の外側には、以下が存在しうる。
+Benchkit 自体の外側には、以下が存在しうる。
 
 - GitHub / GitLab などの外部サービス
 - GitLab Runner / Jacamar CI などの実行接続機構
 - 実システムおよびスケジューラ
-- BenchPark, Spack, Ramble などの外部ツール
+- Benchpark, Spack, Ramble などの外部ツール
 - 将来の推定モデルサービス
 - 将来の AI サービス
 
-Within the CX Platform, BenchKit is the core for execution, result management, and portal functions.
+Within the CX Platform, Benchkit is the core for execution, result management, and portal functions.
 
-Outside BenchKit itself may exist:
+Outside Benchkit itself may exist:
 
 - external services such as GitHub and GitLab
 - execution integration mechanisms such as GitLab Runner and Jacamar CI
 - real systems and schedulers
-- external tools such as BenchPark, Spack, and Ramble
+- external tools such as Benchpark, Spack, and Ramble
 - future estimation-model services
 - future AI services
 
@@ -95,59 +95,59 @@ Outside BenchKit itself may exist:
 
 ### 3.1 shell-first
 
-BenchKit の下層実行基盤は shell-first である。
+Benchkit の下層実行基盤は shell-first である。
 アプリ開発者や HPC 利用者が、普段の実行運用に近い形で `build.sh` や `run.sh` を記述・理解・保守できることを重視する。
 
 抽象化は必要であるが、Python による過度な隠蔽や依存の増加によって参入障壁を高めることは避ける。
 
-The lower execution layer of BenchKit is shell-first.
+The lower execution layer of Benchkit is shell-first.
 It prioritizes allowing application developers and HPC users to write, understand, and maintain `build.sh` and `run.sh` in a style close to their normal operational practice.
 
-Abstraction is necessary, but BenchKit avoids raising the barrier to entry through excessive Python-based concealment or dependency growth.
+Abstraction is necessary, but Benchkit avoids raising the barrier to entry through excessive Python-based concealment or dependency growth.
 
 ### 3.2 ポータル中心の利用体験（portal-first） / Portal-Centered Interaction
 
-BenchKit の上層利用体験は、ポータル中心の利用体験を基本とする。
+Benchkit の上層利用体験は、ポータル中心の利用体験を基本とする。
 利用者は可能な限りスパコンへ直接ログインすることなく、
 結果参照、推定確認、使用量確認、将来の条件変更申請や AI 指示を行えることを目指す。
 
-The upper user experience of BenchKit is based on portal-centered interaction.
+The upper user experience of Benchkit is based on portal-centered interaction.
 Users should, as much as possible, be able to inspect results, estimation outputs, usage, and future request or AI workflows without directly logging into supercomputers.
 
 ### 3.3 明示的な責務分離 / Explicit Separation of Responsibilities
 
-BenchKit は、アプリ固有差分、システム固有差分、CI 生成、結果正規化、可視化の責務を分離する。
+Benchkit は、アプリ固有差分、システム固有差分、CI 生成、結果正規化、可視化の責務を分離する。
 
-BenchKit separates responsibilities among application-specific differences, system-specific differences, CI generation, result normalization, and visualization.
+Benchkit separates responsibilities among application-specific differences, system-specific differences, CI generation, result normalization, and visualization.
 
 ### 3.4 ロックイン回避と差し替え可能な推定基盤 / Avoiding Lock-In and Preserving Replaceable Estimation
 
-BenchKit は、単一の計測ツールや単一の推定方式に固定されないことを基本とする。
-BenchKit 自身が担うべきなのは、特定手法を埋め込むことよりも、異なる計測方式や推定方式を受け入れ、保存し、表示し、比較できる共通ルールを提供することである。
+Benchkit は、単一の計測ツールや単一の推定方式に固定されないことを基本とする。
+Benchkit 自身が担うべきなのは、特定手法を埋め込むことよりも、異なる計測方式や推定方式を受け入れ、保存し、表示し、比較できる共通ルールを提供することである。
 
-したがって BenchKit は、推定アルゴリズムそのもの、区間分類の完全な体系、区間ごとの複合推定の内部構成、補助アーティファクトの内部フォーマットまでは固定しない。
-それらは推定パッケージ開発者または外部ツール側が定義し、BenchKit はその識別情報、入出力の取り決め、適用可能性、保存形式、表示に必要な共通面を扱う。
+したがって Benchkit は、推定アルゴリズムそのもの、区間分類の完全な体系、区間ごとの複合推定の内部構成、補助アーティファクトの内部フォーマットまでは固定しない。
+それらは推定パッケージ開発者または外部ツール側が定義し、Benchkit はその識別情報、入出力の取り決め、適用可能性、保存形式、表示に必要な共通面を扱う。
 
-そのため BenchKit は、少なくとも概念上、以下を分離して扱えることが望ましい。
+そのため Benchkit は、少なくとも概念上、以下を分離して扱えることが望ましい。
 
 - benchmark 結果そのもの
 - 推定入力となる追加計測情報
 - 推定モデル識別情報
 - 推定結果の標準形式
 
-BenchKit should avoid being fixed to any single measurement tool or estimation method.
+Benchkit should avoid being fixed to any single measurement tool or estimation method.
 Its role is not primarily to embed one specific method, but to provide common rules that can accept, store, present, and compare different measurement and estimation approaches.
 
-For that reason, BenchKit should preferably be able to separate at least:
+For that reason, Benchkit should preferably be able to separate at least:
 
 - benchmark results themselves
 - additional measurement data used as estimation input
 - estimation-model identification information
 - the standard form of estimation results
 
-## 4. BenchKit の主要責務 / Main Responsibilities
+## 4. Benchkit の主要責務 / Main Responsibilities
 
-BenchKit は以下を責務として持つ。
+Benchkit は以下を責務として持つ。
 
 - アプリごとのベンチマーク実行定義を保持すること
 - system ごとの実行条件と queue 情報を参照して CI ジョブを生成すること
@@ -157,7 +157,7 @@ BenchKit は以下を責務として持つ。
 - Web ポータルとして結果、推定、使用量を提示すること
 - 将来の申請・承認・自動 PR・AI 最適化との接続点を提供すること
 
-BenchKit is responsible for:
+Benchkit is responsible for:
 
 - holding per-application benchmark execution definitions
 - generating CI jobs using system-specific execution and queue information
@@ -169,7 +169,7 @@ BenchKit is responsible for:
 
 ## 5. 非責務 / Non-Responsibilities
 
-BenchKit は以下を単独では責務としない。
+Benchkit は以下を単独では責務としない。
 
 - 外部 CI サービス自身の管理
 - 実システムそのものの管理
@@ -177,10 +177,10 @@ BenchKit は以下を単独では責務としない。
 - 外部ツール自身の内部仕様
 - 人間の承認を要する重要判断の代替
 
-ただし、これらが BenchKit に無関係という意味ではない。
-BenchKit は接続条件、前提条件、入力出力条件を明示的に扱う必要がある。
+ただし、これらが Benchkit に無関係という意味ではない。
+Benchkit は接続条件、前提条件、入力出力条件を明示的に扱う必要がある。
 
-BenchKit is not solely responsible for:
+Benchkit is not solely responsible for:
 
 - administering external CI services themselves
 - administering real systems themselves
@@ -188,12 +188,12 @@ BenchKit is not solely responsible for:
 - the internal semantics of external tools
 - replacing critical human approvals
 
-However, this does not mean they are irrelevant to BenchKit.
-BenchKit must explicitly handle their integration conditions, assumptions, and input/output contracts.
+However, this does not mean they are irrelevant to Benchkit.
+Benchkit must explicitly handle their integration conditions, assumptions, and input/output contracts.
 
 ## 6. 構成 / Structure
 
-BenchKit は概ね以下の論理構成を持つ。
+Benchkit は概ね以下の論理構成を持つ。
 
 ### 6.1 アプリ実装層 / Application Implementation Layer
 
@@ -219,7 +219,7 @@ This layer defines application-specific behavior such as source acquisition, bui
 
 ### 6.2 共通実行基盤層 / Shared Execution Foundation
 
-BenchKit の共通実行基盤である。
+Benchkit の共通実行基盤である。
 ここでは主に以下を担う。
 
 - 共通関数
@@ -230,7 +230,7 @@ BenchKit の共通実行基盤である。
 
 `bk_functions.sh` のような共通関数は、shell-first を維持しながら定型処理を吸収する中核である。
 
-This is the shared execution foundation of BenchKit.
+This is the shared execution foundation of Benchkit.
 It mainly provides:
 
 - common functions
@@ -243,7 +243,7 @@ Common shell functions such as those in `bk_functions.sh` are central to absorbi
 
 ### 6.3 system・queue 定義層 / System and Queue Definition Layer
 
-BenchKit の system / queue 定義層である。
+Benchkit の system / queue 定義層である。
 
 主な役割:
 
@@ -267,7 +267,7 @@ Activity-specific project accounts, allocations, and budget owners are not stabl
 
 ### 6.4 ポータル層 / Portal Layer
 
-BenchKit のポータル層である。
+Benchkit のポータル層である。
 
 主な役割:
 
@@ -287,9 +287,9 @@ BenchKit のポータル層である。
 - 認証・権限制御
 - 将来の申請・承認ワークフローへの接続点
 
-Execution profile は、対象活動における実行 profile である。対象 app / exp / system、system 単位の allocation project ID、有効状態、承認状態、有効期間を site-local に管理する。account や project ID などの実値を OSS repo に載せず、CX Portal の admin 管理情報として SQLite registry に保持する。manual / scheduled / event trigger は profile とは別の trigger definition として管理し、必要な profile に紐づける。scheduler ごとの具体的な投入書式は、Portal ではなく BenchKit の CI 生成層で扱う。
+Execution profile は、対象活動における実行 profile である。対象 app / exp / system、system 単位の allocation project ID、有効状態、承認状態、有効期間を site-local に管理する。account や project ID などの実値を OSS repo に載せず、CX Portal の admin 管理情報として SQLite registry に保持する。manual / scheduled / event trigger は profile とは別の trigger definition として管理し、必要な profile に紐づける。scheduler ごとの具体的な投入書式は、Portal ではなく Benchkit の CI 生成層で扱う。
 
-This is the portal layer of BenchKit.
+This is the portal layer of Benchkit.
 
 Main roles:
 
@@ -309,11 +309,11 @@ Main roles:
 - authentication and authorization
 - future integration points for request and approval workflows
 
-Execution profiles are operational execution records for a target activity. They define the target app / exp / system scope, system-specific allocation project ID, enabled state, approval state, and validity period as site-local data. Concrete account or project ID values are stored in the CX Portal admin SQLite registry instead of being committed to the OSS repository. Manual, scheduled, and event triggers are managed as separate trigger definitions linked to the relevant profile. Scheduler-specific submit formatting belongs to the BenchKit CI generation layer, not to Portal profile records.
+Execution profiles are operational execution records for a target activity. They define the target app / exp / system scope, system-specific allocation project ID, enabled state, approval state, and validity period as site-local data. Concrete account or project ID values are stored in the CX Portal admin SQLite registry instead of being committed to the OSS repository. Manual, scheduled, and event triggers are managed as separate trigger definitions linked to the relevant profile. Scheduler-specific submit formatting belongs to the Benchkit CI generation layer, not to Portal profile records.
 
 ## 7. データモデルの基本 / Core Data Model
 
-BenchKit は少なくとも以下のデータを中心に扱う。
+Benchkit は少なくとも以下のデータを中心に扱う。
 
 - 実行条件
 - ベンチマーク結果
@@ -321,7 +321,7 @@ BenchKit は少なくとも以下のデータを中心に扱う。
 - 使用量情報
 - ソース出自情報
 
-BenchKit mainly handles at least the following data:
+Benchkit mainly handles at least the following data:
 
 - execution conditions
 - benchmark results
@@ -369,13 +369,13 @@ They may include at least:
 
 ### 7.3 ソース出自情報 / Source Provenance
 
-BenchKit は、少なくとも最上位アプリケーションのソース出自情報を追跡できなければならない。
+Benchkit は、少なくとも最上位アプリケーションのソース出自情報を追跡できなければならない。
 特に、最上位アプリケーションの commit hash は必須追跡項目とする。
 
 これは、AI 駆動の開発・最適化において、branch 上で細かく commit が進み、
 tag や公式 version が付与されない段階でも性能評価・推定・最適化ループが進行することを想定するためである。
 
-BenchKit が最低限追跡すべき項目は以下である。
+Benchkit が最低限追跡すべき項目は以下である。
 
 - 最上位アプリケーションの source repository
 - 最上位アプリケーションの branch
@@ -389,20 +389,20 @@ BenchKit が最低限追跡すべき項目は以下である。
 また、ポータル上では `/results/usage` を通じて、各 app / system の最新 result を基準に source tracking の current-state を確認できることが望ましい。
 ここでは `source_status`、`source_type`、`source_reference`、不足している source field を軽く見られる形が自然である。
 
-一方で、依存パッケージやビルド環境全体の完全な provenance 追跡は、現時点では BenchKit の必須責務とはしない。
-この領域は、BenchPark、Ramble、Spack などの外部ツールが本来強みを持つ領域であり、
+一方で、依存パッケージやビルド環境全体の完全な provenance 追跡は、現時点では Benchkit の必須責務とはしない。
+この領域は、Benchpark、Ramble、Spack などの外部ツールが本来強みを持つ領域であり、
 国際協力および役割分担の観点からも、それらに委ねることを基本方針とする。
 
 ただし、将来的に CX 基盤全体として依存関係 provenance をより広く扱う必要が生じた場合には、
-BenchKit はそれら外部ツールと接続する接続点として拡張されうる。
+Benchkit はそれら外部ツールと接続する接続点として拡張されうる。
 
-BenchKit must be able to track source provenance for at least the top-level application.
+Benchkit must be able to track source provenance for at least the top-level application.
 In particular, the commit hash of the top-level application is a mandatory tracked item.
 
 This is required because AI-driven development and optimization may advance through many commits on a branch,
 even before tags or official versions are created, while benchmarking, estimation, and optimization loops are already running.
 
-At minimum, BenchKit should track:
+At minimum, Benchkit should track:
 
 - the source repository of the top-level application
 - the branch of the top-level application
@@ -411,26 +411,26 @@ At minimum, BenchKit should track:
 - version or tag information as supporting metadata
 
 Example:
-If the top-level application is `qws` on GitHub, BenchKit must be able to trace which commit hash on the `main` branch produced the result.
+If the top-level application is `qws` on GitHub, Benchkit must be able to trace which commit hash on the `main` branch produced the result.
 
 It is also desirable for the portal to expose source-tracking current state through `/results/usage`, based on the latest result for each application/system pair.
 A lightweight view of `source_status`, `source_type`, `source_reference`, and missing source fields is a natural form for that visibility.
 
-By contrast, complete provenance tracking for dependency packages and the full build environment is not currently a mandatory responsibility of BenchKit.
-That area is a natural strength of external tools such as BenchPark, Ramble, and Spack, and from the perspective of international collaboration and role sharing, it should generally be delegated to them.
+By contrast, complete provenance tracking for dependency packages and the full build environment is not currently a mandatory responsibility of Benchkit.
+That area is a natural strength of external tools such as Benchpark, Ramble, and Spack, and from the perspective of international collaboration and role sharing, it should generally be delegated to them.
 
-However, if the broader CX Platform later requires wider dependency provenance support, BenchKit may be extended as an integration point for those external tools.
+However, if the broader CX Platform later requires wider dependency provenance support, Benchkit may be extended as an integration point for those external tools.
 
 ### 7.4 推定結果 / Estimation Results
 
 推定結果は、実測結果やモデルに基づいて生成される Estimate JSON である。
-BenchKit は、`weakscaling` を最小経路とする推定結果と、より詳細な推定結果の両方を扱えることが望ましい。
+Benchkit は、`weakscaling` を最小経路とする推定結果と、より詳細な推定結果の両方を扱えることが望ましい。
 また、推定方式や計測方式の違いを将来的に比較できるよう、推定結果には方式識別のための拡張余地を持たせるべきである。
 
 Estimation results are Estimate JSON records generated from measured results and estimation models.
-BenchKit should preferably be able to handle both `weakscaling`-based minimum estimation outputs and more detailed estimation outputs.
+Benchkit should preferably be able to handle both `weakscaling`-based minimum estimation outputs and more detailed estimation outputs.
 It should also preserve room for method-identification metadata so that different measurement and estimation approaches can be compared in the future.
-さらに、BenchKit は少なくとも次の 2 種類の出自情報を保持できることが望ましい。
+さらに、Benchkit は少なくとも次の 2 種類の出自情報を保持できることが望ましい。
 - 各推定側の参照ベンチマークの出自情報
 - 保存対象としての推定結果そのものの出自情報
 
@@ -439,13 +439,13 @@ It should also preserve both:
 - side-specific reference benchmark provenance
 - estimate-result provenance as a stored object
 
-さらに BenchKit は、`intra_system_scaling_model` と `cross_system_projection_model` の両方を扱え、各 system 側で必要に応じてそれらを使い分けられることが望ましい。
+さらに Benchkit は、`intra_system_scaling_model` と `cross_system_projection_model` の両方を扱え、各 system 側で必要に応じてそれらを使い分けられることが望ましい。
 
-In addition, BenchKit should preferably be able to handle both `intra_system_scaling_model` and `cross_system_projection_model`, and use them as needed on each system side.
+In addition, Benchkit should preferably be able to handle both `intra_system_scaling_model` and `cross_system_projection_model`, and use them as needed on each system side.
 
 ## 8. 実行モデル / Execution Model
 
-BenchKit の典型的な実行フローは以下である。
+Benchkit の典型的な実行フローは以下である。
 
 1. app ごとに `programs/<code>/list.csv` が実験条件を定義する
 2. `system.csv` と `queue.csv` が system 側条件を与える
@@ -455,7 +455,7 @@ BenchKit の典型的な実行フローは以下である。
 6. `result.sh` が Result JSON を生成する
 7. 結果が result_server へ送られ、一覧・current-state 表示・集計に使われ、将来の比較にも備えて保持される
 
-The typical execution flow in BenchKit is:
+The typical execution flow in Benchkit is:
 
 1. `programs/<code>/list.csv` defines execution conditions for each app
 2. `system.csv` and `queue.csv` provide system-side conditions
@@ -467,7 +467,7 @@ The typical execution flow in BenchKit is:
 
 ## 9. 拠点接続 / Site Integration
 
-BenchKit は実システムを直接管理しないが、
+Benchkit は実システムを直接管理しないが、
 runner、Jacamar CI、scheduler、module 環境、共有ストレージなどの実行条件を接続可能な形で定義しなければならない。
 
 そのため、拠点接続では少なくとも以下を扱う必要がある。
@@ -485,7 +485,7 @@ runner、Jacamar CI、scheduler、module 環境、共有ストレージなどの
 例:
 `RC_GH200`、`RC_DGXSP`、`RC_GENOA`、`RC_FX700` では、runner tag、queue、module load、MPI 実行方法、結果回収先が定義されていて、CI からその条件で実行できなければならない。
 
-BenchKit does not directly manage real systems, but it must define runners, Jacamar CI, scheduler behavior, module environments, shared storage, and similar execution conditions in an integrable form.
+Benchkit does not directly manage real systems, but it must define runners, Jacamar CI, scheduler behavior, module environments, shared storage, and similar execution conditions in an integrable form.
 
 Therefore, site integration must handle at least:
 
@@ -504,36 +504,36 @@ For `RC_GH200`, `RC_DGXSP`, `RC_GENOA`, and `RC_FX700`, the runner tag, queue, m
 
 ## 10. 将来拡張 / Future Extensions
 
-BenchKit は将来的に以下へ拡張されうる。
+Benchkit は将来的に以下へ拡張されうる。
 
 - app 追加申請フォーム
 - 実験条件変更申請フォーム
 - 承認付き自動 PR 生成
 - 推定条件変更ワークフロー
 - AI 駆動最適化ワークフロー
-- BenchKit から BenchPark 定義を生成する支援
+- Benchkit から Benchpark 定義を生成する支援
 - MCP サーバとしての公開
 
-これらは BenchKit を CX基盤の中核ポータルへ発展させる方向である。
+これらは Benchkit を CX基盤の中核ポータルへ発展させる方向である。
 
-BenchKit may be extended in the future with:
+Benchkit may be extended in the future with:
 
 - app onboarding request forms
 - execution-condition change request forms
 - approval-based automatic PR generation
 - estimation-condition update workflows
 - AI-driven optimization workflows
-- support for generating BenchPark definitions from BenchKit data
+- support for generating Benchpark definitions from Benchkit data
 - exposure as an MCP server
 
-These extensions move BenchKit toward the role of the central portal of the CX Platform.
+These extensions move Benchkit toward the role of the central portal of the CX Platform.
 
-## 11. 利用者視点での BenchKit / BenchKit from the User Perspective
+## 11. 利用者視点での Benchkit / Benchkit from the User Perspective
 
-利用者にとって BenchKit は、単なる実行スクリプト集ではなく、
+利用者にとって Benchkit は、単なる実行スクリプト集ではなく、
 スパコンへ逐一ログインすることなく性能データを扱うための窓口である。
 
-利用者は BenchKit を通じて、少なくとも以下を行えることが望ましい。
+利用者は Benchkit を通じて、少なくとも以下を行えることが望ましい。
 
 - ベンチマーク結果の確認
 - 推定結果の確認
@@ -542,10 +542,10 @@ These extensions move BenchKit toward the role of the central portal of the CX P
 - 小さな推定条件変更の要求
 - 将来的には AI への指示
 
-From the user perspective, BenchKit is not just a collection of execution scripts.
+From the user perspective, Benchkit is not just a collection of execution scripts.
 It is the main interface for working with performance data without repeatedly logging into supercomputers.
 
-Users should ideally be able to use BenchKit to:
+Users should ideally be able to use Benchkit to:
 
 - inspect benchmark results
 - inspect estimation results

--- a/docs/cx/CX_FRAMEWORK.md
+++ b/docs/cx/CX_FRAMEWORK.md
@@ -54,7 +54,7 @@ It is a higher-level framework that organizes the roles of platforms, tools, ser
 下位には、少なくとも以下の仕様がぶら下がる。
 
 - [`CX_PLATFORM.md`](./CX_PLATFORM.md): CX フレームワークを実装する全体システムの仕様
-- [`BENCHKIT_SPEC.md`](./BENCHKIT_SPEC.md): BenchKit の責務・構成・接続点の仕様
+- [`BENCHKIT_SPEC.md`](./BENCHKIT_SPEC.md): Benchkit の責務・構成・接続点の仕様
 
 This document is the top-level conceptual specification for CX as a whole.
 It defines what should run continuously, and does not specify implementation details of individual software components or services.
@@ -62,7 +62,7 @@ It defines what should run continuously, and does not specify implementation det
 At least the following lower-level specifications are expected beneath it:
 
 - [`CX_PLATFORM.md`](./CX_PLATFORM.md): the specification of the overall system implementing the CX Framework
-- [`BENCHKIT_SPEC.md`](./BENCHKIT_SPEC.md): the specification of BenchKit responsibilities, structure, and integration points
+- [`BENCHKIT_SPEC.md`](./BENCHKIT_SPEC.md): the specification of Benchkit responsibilities, structure, and integration points
 
 ## 2. 適用範囲 / Scope
 
@@ -113,7 +113,7 @@ It applies to:
 - `CA`:
   継続的高度化。個別アプリケーションの最適化ではなく、CX 基盤全体、モデル、ワークフロー、ポータル、AI 連携、運用方式を継続的にエンハンスすること。
 - `拠点接続`:
-  実システム、runner、Jacamar CI、scheduler、module 環境、共有ストレージ、実行アカウント、結果回収条件などを、CX 基盤や BenchKit から接続可能な形で定義・管理すること。
+  実システム、runner、Jacamar CI、scheduler、module 環境、共有ストレージ、実行アカウント、結果回収条件などを、CX 基盤や Benchkit から接続可能な形で定義・管理すること。
 - `ソース出自情報`:
   実行結果や推定結果が、どのソースコード状態に由来するかを追跡するための情報。少なくとも最上位アプリケーションの source repository、branch、commit hash を含みうる。
 - `最上位アプリケーション`:
@@ -132,7 +132,7 @@ In this specification and its lower-level specifications, the following terms ar
 - `CA`:
   Continuous Advancement. Not the optimization of a single application, but the continuous enhancement of the CX Platform as a whole, including models, workflows, portal capabilities, AI integration, and operating methods.
 - `site integration`:
-  The definition and management of real systems, runners, Jacamar CI, scheduler behavior, module environments, shared storage, execution accounts, and result-collection conditions in a form that can be integrated with the CX Platform and BenchKit.
+  The definition and management of real systems, runners, Jacamar CI, scheduler behavior, module environments, shared storage, execution accounts, and result-collection conditions in a form that can be integrated with the CX Platform and Benchkit.
 - `source provenance`:
   Information used to trace which source-code state produced a benchmark or estimation result. At minimum, it may include the source repository, branch, and commit hash of the top-level application.
 - `top-level application`:
@@ -326,7 +326,7 @@ Outputs:
 目的:
 - CX基盤そのものの能力向上
 - 推定モデル、スケーリングモデル、最適化モデルの改良
-- BenchKit や周辺ポータル機能の高度化
+- Benchkit や周辺ポータル機能の高度化
 - AI・外部ツール・外部サービスとの連携方式の改善
 - 将来アーキテクチャ評価や調達支援の仕組み強化
 
@@ -354,7 +354,7 @@ In other words, CA is the loop that **continuously enhances the entire CX system
 Goals:
 - improve the capabilities of the CX Platform itself
 - refine estimation, scaling, and optimization models
-- enhance BenchKit and surrounding portal functionality
+- enhance Benchkit and surrounding portal functionality
 - improve integration with AI, external tools, and external services
 - strengthen support for future-architecture evaluation and procurement
 
@@ -494,12 +494,12 @@ The CX Framework does not require:
 - fully autonomous execution without human approval
 - a single mandatory measurement or estimation toolchain
 
-## 9. CX基盤およびBenchKitとの関係 / Relationship to CX Platform and BenchKit
+## 9. CX基盤およびBenchkitとの関係 / Relationship to CX Platform and Benchkit
 
 - CXフレームワークは上位の概念・機能モデルを定義する
 - CX基盤はそのモデルを実装する全体システムである
-- BenchKit は CX基盤を構成する中核ソフトウェアの1つである
+- Benchkit は CX基盤を構成する中核ソフトウェアの1つである
 
 - The CX Framework defines the conceptual and functional model.
 - The CX Platform is the overall system implementing that model.
-- BenchKit is one of the core software components within the CX Platform.
+- Benchkit is one of the core software components within the CX Platform.

--- a/docs/cx/CX_PLATFORM.md
+++ b/docs/cx/CX_PLATFORM.md
@@ -48,14 +48,14 @@ It integrates software components, external tools, external services, compute sy
 本書は、構成要素、責務境界、接続要件を定義する。
 個別ソフトウェアの詳細仕様は必要に応じて下位仕様で定義する。
 
-BenchKit に関する詳細は [`BENCHKIT_SPEC.md`](./BENCHKIT_SPEC.md) を参照する。
+Benchkit に関する詳細は [`BENCHKIT_SPEC.md`](./BENCHKIT_SPEC.md) を参照する。
 主要用語は [`CX_FRAMEWORK.md`](./CX_FRAMEWORK.md) の用語集に従う。
 
 This document defines the CX Platform as the overall system that implements [`CX_FRAMEWORK.md`](./CX_FRAMEWORK.md).
 It defines components, responsibility boundaries, and connection requirements.
 Software-specific details may be defined in lower-level specifications where needed.
 
-For BenchKit-specific details, see [`BENCHKIT_SPEC.md`](./BENCHKIT_SPEC.md).
+For Benchkit-specific details, see [`BENCHKIT_SPEC.md`](./BENCHKIT_SPEC.md).
 Core terminology follows the glossary in [`CX_FRAMEWORK.md`](./CX_FRAMEWORK.md).
 
 ## 2. 適用範囲 / Scope
@@ -84,27 +84,27 @@ The CX Platform includes:
 - integration infrastructure for replaceable measurement and estimation methods
 - operational infrastructure that allows minimum and more detailed estimation paths to coexist
 
-## 3. BenchKit の位置づけ / Position of BenchKit
+## 3. Benchkit の位置づけ / Position of Benchkit
 
-BenchKit は CX基盤を構成する中核ソフトウェアの1つである。
-BenchKit は主として、CX 基盤におけるベンチマーク実行、結果正規化、結果表示、および関連ワークフローへの接続点を担う。
+Benchkit は CX基盤を構成する中核ソフトウェアの1つである。
+Benchkit は主として、CX 基盤におけるベンチマーク実行、結果正規化、結果表示、および関連ワークフローへの接続点を担う。
 詳細は [`BENCHKIT_SPEC.md`](./BENCHKIT_SPEC.md) を参照する。
 
-BenchKit is one of the core software components of the CX Platform.
-BenchKit is primarily responsible for benchmark execution, result normalization, result presentation, and integration points for related workflows within the CX Platform.
+Benchkit is one of the core software components of the CX Platform.
+Benchkit is primarily responsible for benchmark execution, result normalization, result presentation, and integration points for related workflows within the CX Platform.
 For details, see [`BENCHKIT_SPEC.md`](./BENCHKIT_SPEC.md).
 
 ## 4. CX基盤の構成要素 / Platform Components
 
 ### 4.1 内部中核コンポーネント / Core Internal Components
 
-#### BenchKit
+#### Benchkit
 
-BenchKit は CX 基盤における中核ソフトウェアである。
-本書では、BenchKit を CX 基盤の主要構成要素として位置づけるにとどめる。
+Benchkit は CX 基盤における中核ソフトウェアである。
+本書では、Benchkit を CX 基盤の主要構成要素として位置づけるにとどめる。
 
-BenchKit is a core software component within the CX Platform.
-This document only positions BenchKit as one of the major components of the CX Platform.
+Benchkit is a core software component within the CX Platform.
+This document only positions Benchkit as one of the major components of the CX Platform.
 
 #### 結果ポータル / Result Portal
 
@@ -159,31 +159,31 @@ It is currently an emerging layer.
 
 ### 4.2 外部ツール / External Tools
 
-外部ツールとは、CX基盤が利用するが BenchKit 自身の内部実装ではないツールを指す。
+外部ツールとは、CX基盤が利用するが Benchkit 自身の内部実装ではないツールを指す。
 
 例:
-- BenchPark
+- Benchpark
 - Spack
 - Ramble
 - コンパイラツールチェイン
 - スケジューラコマンド
 - 性能解析ツール
 
-ここでいう外部ツールには、BenchKit が直接規定しないが、実行結果や運用成立性に強く影響する実行時の細かな動作仕様も含まれる。
+ここでいう外部ツールには、Benchkit が直接規定しないが、実行結果や運用成立性に強く影響する実行時の細かな動作仕様も含まれる。
 例えば、ジョブ投入方法、ジョブ完了判定、MPI ランチャの使い方、module 環境、共有ストレージ配置、標準出力やログの扱いなどである。
 ただし、これらは CX 基盤にとって無関係なものではなく、拠点接続要件として明示的に把握・管理・接続されるべき対象である。
 
-External tools are tools used by the CX Platform but not owned as part of BenchKit itself.
+External tools are tools used by the CX Platform but not owned as part of Benchkit itself.
 
 Examples:
-- BenchPark
+- Benchpark
 - Spack
 - Ramble
 - compiler toolchains
 - scheduler commands
 - performance analysis tools
 
-External tools here also include detailed runtime behaviors that are not directly specified by BenchKit but strongly affect execution outcomes and operational viability.
+External tools here also include detailed runtime behaviors that are not directly specified by Benchkit but strongly affect execution outcomes and operational viability.
 Examples include job submission semantics, job completion semantics, MPI launcher behavior, module environments, shared storage layout, and stdout/log handling.
 These are not irrelevant to the CX Platform; they must be explicitly captured and managed as site integration requirements.
 
@@ -245,9 +245,9 @@ For each execution environment, the CX Platform must define site integration con
 
 ## 5. 責務境界 / Responsibility Boundaries
 
-### 5.1 BenchKit の責務 / BenchKit Responsibilities
+### 5.1 Benchkit の責務 / Benchkit Responsibilities
 
-BenchKit が責任を持つもの:
+Benchkit が責任を持つもの:
 - ベンチマーク実行定義
 - system / queue とベンチ実行の対応付け
 - runner / scheduler / 実システムの接続条件の整理
@@ -257,7 +257,7 @@ BenchKit が責任を持つもの:
 - 使用量集計表示と、それに関連する運用上の current-state 可視化
 - アプリ追加の受け皿
 
-BenchKit owns:
+Benchkit owns:
 - benchmark execution definitions
 - mapping between systems/queues and benchmark workflows
 - organization of runner / scheduler / real-system integration conditions
@@ -271,18 +271,18 @@ BenchKit owns:
 
 外部ツールが責任を持つもの:
 - パッケージビルドフレームワーク
-- BenchKit 外部のベンチマーク定義体系
+- Benchkit 外部のベンチマーク定義体系
 - システム固有パッケージ解決
-- BenchKit が直接規定しない実行時の細かな動作仕様
+- Benchkit が直接規定しない実行時の細かな動作仕様
 
 ただし、外部ツールに依存する実行時仕様であっても、CX 基盤側はそれを拠点接続要件として把握し、runner 登録、Jacamar 設定、ジョブ完了判定、結果回収条件などに落とし込まなければならない。
 したがって、ここでいう外部責務は「CX 基盤が考慮しなくてよい領域」を意味しない。
 
 External tools own:
 - package build frameworks
-- benchmark definition semantics outside BenchKit
+- benchmark definition semantics outside Benchkit
 - system-specific package resolution
-- detailed runtime behaviors not directly specified by BenchKit
+- detailed runtime behaviors not directly specified by Benchkit
 
 However, even when runtime behavior is governed by external tools, the CX Platform must still capture it as site integration requirements and translate it into runner registration, Jacamar configuration, job completion rules, and result collection conditions.
 External responsibility here does not mean the CX Platform may ignore the area.
@@ -450,7 +450,7 @@ The platform should support:
 - 外部ツール・外部サービスとの境界を明示する
 - 計測方式、推定方式、AI 連携方式は差し替え可能であることを基本とする
 - 申請・承認・自動PR・AI連携を段階的に追加する
-- BenchKit を CX基盤の中核ポータルへ発展させる
+- Benchkit を CX基盤の中核ポータルへ発展させる
 
 The long-term direction is:
 
@@ -459,13 +459,13 @@ The long-term direction is:
 - explicit boundaries with external tools and services
 - replaceability of measurement methods, estimation methods, and AI integration methods
 - gradual addition of request, approval, auto-PR, and AI integrations
-- evolution of BenchKit toward the core portal of the CX Platform
+- evolution of Benchkit toward the core portal of the CX Platform
 
 ## 10. 下位仕様との関係 / Relationship to Lower-Level Specifications
 
 CX基盤仕様は、以下の親仕様となる。
 
-- BenchKit 仕様
+- Benchkit 仕様
 - Result / Estimate データモデル仕様
 - 申請・承認ワークフロー仕様
 - 最適化ワークフロー仕様
@@ -473,7 +473,7 @@ CX基盤仕様は、以下の親仕様となる。
 
 The CX Platform specification is the parent specification for:
 
-- BenchKit specifications
+- Benchkit specifications
 - Result / Estimate data model specifications
 - request and approval workflow specifications
 - optimization workflow specifications

--- a/docs/cx/ESTIMATE_JSON_SPEC.md
+++ b/docs/cx/ESTIMATE_JSON_SPEC.md
@@ -11,9 +11,9 @@ If any discrepancy exists, the Japanese version takes precedence.
 
 ## 1. 文書の位置づけ / Position of This Document
 
-本書は [`ESTIMATION_SPEC.md`](./ESTIMATION_SPEC.md) に対するデータ形式仕様であり、BenchKit が保存・表示し、将来の比較や再推定にも使えるように保持する Estimate JSON の最小要件を定義する。
+本書は [`ESTIMATION_SPEC.md`](./ESTIMATION_SPEC.md) に対するデータ形式仕様であり、Benchkit が保存・表示し、将来の比較や再推定にも使えるように保持する Estimate JSON の最小要件を定義する。
 
-This document is the data-format specification corresponding to [`ESTIMATION_SPEC.md`](./ESTIMATION_SPEC.md), defining the minimum requirements for Estimate JSON as stored, presented, and preserved by BenchKit so that future comparison and re-estimation remain possible.
+This document is the data-format specification corresponding to [`ESTIMATION_SPEC.md`](./ESTIMATION_SPEC.md), defining the minimum requirements for Estimate JSON as stored, presented, and preserved by Benchkit so that future comparison and re-estimation remain possible.
 
 ## 2. 目的 / Purpose
 
@@ -195,7 +195,7 @@ Estimate JSON may include the following extension fields:
 - `confidence`
 - `notes`
 
-In addition, BenchKit may retain result-compatible CI provenance at the top level, such as `execution_mode`, `ci_trigger`, `pipeline_id`, and `estimate_job`, so that the estimate can be traced back to the CI pipeline that produced it.
+In addition, Benchkit may retain result-compatible CI provenance at the top level, such as `execution_mode`, `ci_trigger`, `pipeline_id`, and `estimate_job`, so that the estimate can be traced back to the CI pipeline that produced it.
 
 ### 6.1 estimate_metadata
 
@@ -441,7 +441,7 @@ This field may include assumptions such as:
   - 推定は試みられたが、最終的に推定結果として成立しなかった
 
 `not_applicable` はパイプライン失敗を意味しない。
-BenchKit は、推定不成立であっても、その試行結果を Estimate JSON として保存・表示してよい。
+Benchkit は、推定不成立であっても、その試行結果を Estimate JSON として保存・表示してよい。
 
 When fallback occurs, `applicability` should preferably record why the requested package could not be applied.
 In such a case, `estimate_metadata.requested_estimation_package` identifies the originally requested package, while `estimate_metadata.estimation_package` identifies the package actually applied.
@@ -628,7 +628,7 @@ However, more detailed estimation methods may instead use traces, counters, or m
 
 ## 8. 将来拡張時の互換性 / Compatibility for Future Extensions
 
-BenchKit は、最小必須項目が満たされていれば、未知の任意項目を原則として破棄せず保持できることが望ましい。
+Benchkit は、最小必須項目が満たされていれば、未知の任意項目を原則として破棄せず保持できることが望ましい。
 
 これにより、
 
@@ -638,7 +638,7 @@ BenchKit は、最小必須項目が満たされていれば、未知の任意�
 
 を段階的に追加しやすくする。
 
-BenchKit should preferably preserve unknown optional fields as long as the minimum required fields are present.
+Benchkit should preferably preserve unknown optional fields as long as the minimum required fields are present.
 
 This makes it easier to introduce:
 

--- a/docs/cx/ESTIMATION_INPUT_ACQUISITION_SPEC.md
+++ b/docs/cx/ESTIMATION_INPUT_ACQUISITION_SPEC.md
@@ -22,13 +22,13 @@ This document follows the reading conventions defined in [`CX_FRAMEWORK.md`](./C
 
 ## 1. 文書の位置づけ / Position of This Document
 
-本書は [`ESTIMATION_SPEC.md`](./ESTIMATION_SPEC.md) および [`ESTIMATION_PACKAGE_SPEC.md`](./ESTIMATION_PACKAGE_SPEC.md) を補う下位仕様であり、推定に必要な入力をどのように採取し、どのように BenchKit へ受け渡すかを定義する。
+本書は [`ESTIMATION_SPEC.md`](./ESTIMATION_SPEC.md) および [`ESTIMATION_PACKAGE_SPEC.md`](./ESTIMATION_PACKAGE_SPEC.md) を補う下位仕様であり、推定に必要な入力をどのように採取し、どのように Benchkit へ受け渡すかを定義する。
 
-本書の主眼は推定アルゴリズムそのものではなく、アプリ、BenchKit、推定パッケージの接続面を整理することである。
+本書の主眼は推定アルゴリズムそのものではなく、アプリ、Benchkit、推定パッケージの接続面を整理することである。
 
-This document is a lower-level specification that complements [`ESTIMATION_SPEC.md`](./ESTIMATION_SPEC.md) and [`ESTIMATION_PACKAGE_SPEC.md`](./ESTIMATION_PACKAGE_SPEC.md), defining how inputs required for estimation are collected and handed off into BenchKit.
+This document is a lower-level specification that complements [`ESTIMATION_SPEC.md`](./ESTIMATION_SPEC.md) and [`ESTIMATION_PACKAGE_SPEC.md`](./ESTIMATION_PACKAGE_SPEC.md), defining how inputs required for estimation are collected and handed off into Benchkit.
 
-Its focus is not the estimation algorithm itself, but the interface boundary among the application, BenchKit, and estimation packages.
+Its focus is not the estimation algorithm itself, but the interface boundary among the application, Benchkit, and estimation packages.
 
 ## 2. 目的 / Purpose
 
@@ -38,7 +38,7 @@ Its focus is not the estimation algorithm itself, but the interface boundary amo
 
 - アプリ開発者がどこまで準備すればよいかを明確にする
 - 推定パッケージ開発者がどの入力を期待してよいかを明確にする
-- BenchKit がどの形式で入力を受け取り、保存し、引き渡すかを明確にする
+- Benchkit がどの形式で入力を受け取り、保存し、引き渡すかを明確にする
 - 入力採取失敗時の扱いを曖昧にしない
 - `weakscaling` を最小経路としつつ、より詳細な推定も同じ枠組みで扱えるようにする
 
@@ -48,7 +48,7 @@ It aims at least to:
 
 - clarify what application developers need to prepare
 - clarify what estimation-package developers may expect as inputs
-- clarify how BenchKit receives, stores, and passes those inputs
+- clarify how Benchkit receives, stores, and passes those inputs
 - avoid ambiguity when input acquisition fails
 - handle a `weakscaling`-based minimum path and more detailed estimation within the same framework
 
@@ -88,7 +88,7 @@ app 側は原則として、
 - section ごとの補助データ参照
 - 必要なら app 固有の補助メタデータ
 
-を BenchKit に渡せればよい形を目指す。
+を Benchkit に渡せればよい形を目指す。
 
 The application side should not be forced to own unnecessarily complex logic merely for estimation input acquisition.
 The target is that the application side only needs to provide:
@@ -100,7 +100,7 @@ The target is that the application side only needs to provide:
 
 ### 3.3 採取方式は差し替え可能である / Acquisition Methods Must Be Replaceable
 
-BenchKit は、単一の採取方式に固定されてはならない。
+Benchkit は、単一の採取方式に固定されてはならない。
 少なくとも以下を受け入れられることが望ましい。
 
 - アプリ自前の stdout 出力
@@ -108,7 +108,7 @@ BenchKit は、単一の採取方式に固定されてはならない。
 - 外部ツールによる trace / profile / counter dump
 - site 側 wrapper や vendor tool による採取
 
-BenchKit must not be fixed to a single acquisition method.
+Benchkit must not be fixed to a single acquisition method.
 It should preferably be able to accept at least:
 
 - application-emitted stdout
@@ -138,7 +138,7 @@ Estimation input acquisition consists conceptually of at least:
 
 ### 4.1 採取対象 / Acquisition Targets
 
-BenchKit は、少なくとも以下の入力種別を受け入れられることが望ましい。
+Benchkit は、少なくとも以下の入力種別を受け入れられることが望ましい。
 
 - FOM
 - section 時間
@@ -148,7 +148,7 @@ BenchKit は、少なくとも以下の入力種別を受け入れられるこ�
 - trace / profile
 - 推定入力に必要な補助メタデータ
 
-BenchKit should preferably be able to accept at least the following input kinds:
+Benchkit should preferably be able to accept at least the following input kinds:
 
 - FOM
 - section timings
@@ -163,7 +163,7 @@ BenchKit should preferably be able to accept at least the following input kinds:
 採取主体は少なくとも次を許容する。
 
 - アプリ自前
-- BenchKit の共通 shell
+- Benchkit の共通 shell
 - 外部ツール
 - site 側 wrapper
 - vendor 提供ツール
@@ -171,7 +171,7 @@ BenchKit should preferably be able to accept at least the following input kinds:
 The following acquisition actors should be allowed at minimum:
 
 - the application itself
-- BenchKit common shell
+- Benchkit common shell
 - external tools
 - site-side wrappers
 - vendor-provided tools
@@ -192,16 +192,16 @@ The following timings should be allowed at minimum:
 - extracted by postprocessing after execution
 - converted from external-tool output after execution
 
-## 5. BenchKit への受け渡し方法 / Handoff into BenchKit
+## 5. Benchkit への受け渡し方法 / Handoff into Benchkit
 
 ### 5.1 基本方針 / Basic Policy
 
-BenchKit への受け渡し方法は、少なくとも次の 2 層で考える。
+Benchkit への受け渡し方法は、少なくとも次の 2 層で考える。
 
 - Result JSON へ直接正規化される入力
 - 推定専用の補助入力として補助ファイル / artifact として参照される入力
 
-Handoff into BenchKit should be thought of in at least two layers:
+Handoff into Benchkit should be thought of in at least two layers:
 
 - inputs normalized directly into Result JSON
 - inputs referenced as estimation-specific auxiliary files or artifact data
@@ -293,7 +293,7 @@ Overlap should likewise preferably be registerable, at least conceptually, as a 
 - shell 関数 API にするか
 
 までは固定しない。
-ただし、最終的に BenchKit が受け取る意味要素は上記のように揃っていることが望ましい。
+ただし、最終的に Benchkit が受け取る意味要素は上記のように揃っていることが望ましい。
 
 At this stage, this document does not fix whether section / overlap registration is:
 
@@ -301,7 +301,7 @@ At this stage, this document does not fix whether section / overlap registration
 - auxiliary-JSON-based
 - exposed as a shell function API
 
-However, the semantic elements ultimately received by BenchKit should preferably be aligned as described above.
+However, the semantic elements ultimately received by Benchkit should preferably be aligned as described above.
 
 ### 6.4 app 側宣言ブロック / Application-Side Declaration Block
 
@@ -309,7 +309,7 @@ app 側の推定関連の記述は、原則として `estimate.sh` にまとめ�
 `estimate.sh` は次の 2 つの役割を兼ねてよい。
 
 - section / overlap と `estimation_package` の対応を宣言する
-- app ごとの推定入口として、BenchKit が読む既定値や補助関数を提供する
+- app ごとの推定入口として、Benchkit が読む既定値や補助関数を提供する
 
 `run.sh` は通常実行を担当し、必要であれば `estimate.sh` を読み込んで宣言を再利用する。
 `run.sh` が package 名や採取手順の詳細を個別に持つ必要はない。
@@ -318,13 +318,13 @@ app 側に求める最低限の責務は次のとおりである。
 
 - `estimate.sh` に section / overlap の package 割当てを書く
 - `run.sh` は通常実行と FOM 出力に集中する
-- 追加採取の実行は BenchKit の共通入口に委ねる
+- 追加採取の実行は Benchkit の共通入口に委ねる
 
 app 側の責務を最小化するためには、`estimate.sh` で section / overlap と `estimation_package` の対応を宣言し、`run.sh` では `bk_emit_declared_section` / `bk_emit_declared_overlap` によって値だけを出す形が望ましい。
 
 - `estimate.sh`: package の対応を宣言する
 - `run.sh`: 通常実行と実測値の出力を担う
-- BenchKit: 宣言された package 名の対応付けを共通関数で引き受ける
+- Benchkit: 宣言された package 名の対応付けを共通関数で引き受ける
 
 詳細推定では、app 側が `estimate.sh` の中に推定用の宣言ブロックを持てる形が望ましい。`run.sh` は必要に応じて `estimate.sh` を読み込み、`estimate.sh` 自身は CI や再推定の入口としても使える形にしてよい。
 
@@ -343,7 +343,7 @@ app 側の責務を最小化するためには、`estimate.sh` で section / ove
 この形により、少なくとも次の 3 通りが同居できる。
 - app 実行中に直接得られた section 時間を `bk_emit_section` で出す
 - 実行後のログ解析で得た値を `bk_emit_section` で出す
-- 追加採取実行の結果を BenchKit 側でまとめて反映する
+- 追加採取実行の結果を Benchkit 側でまとめて反映する
 
 ### 6.6 追加採取実行 / Additional Data-Collection Run
 
@@ -357,7 +357,7 @@ PAPI のように、通常実行とは別に追加採取実行が必要な入力
    - 例: `bk_run_estimation_data_collection mpiexec a.out ...`
    - package metadata を見て必要な counter / trace / 追加ログ採取を行う
 
-このとき、どの追加採取が必要か、複数回実行が必要か、保存先をどうするかは BenchKit 側で共通化して扱うのが望ましい。app 側は原則として、通常実行コマンドと section / overlap への package 割当てを示せばよい。
+このとき、どの追加採取が必要か、複数回実行が必要か、保存先をどうするかは Benchkit 側で共通化して扱うのが望ましい。app 側は原則として、通常実行コマンドと section / overlap への package 割当てを示せばよい。
 
 `bk_run_estimation_data_collection` は、app が宣言した package 一覧を見て、特殊採取が必要な package があればその package の実行規約に合わせてコマンドを組み立てる共通入口である。
 特殊採取が不要な package しか宣言されていない場合は、追加実行を行わずに戻ってよい。
@@ -432,9 +432,9 @@ The estimation-package developer is generally responsible for defining:
 - which acquisition failures are considered fallback-eligible
 - how sections / overlaps are interpreted
 
-### 8.3 BenchKit の責務 / BenchKit Responsibility
+### 8.3 Benchkit の責務 / Benchkit Responsibility
 
-BenchKit は、原則として次を担う。
+Benchkit は、原則として次を担う。
 
 - Result JSON への正規化
 - 補助アーティファクト参照の保持
@@ -442,7 +442,7 @@ BenchKit は、原則として次を担う。
 - 推定パッケージへの受け渡し
 - 保存形式と表示形式の統一
 
-BenchKit is generally responsible for:
+Benchkit is generally responsible for:
 
 - normalization into Result JSON
 - retention of auxiliary artifact references
@@ -450,12 +450,12 @@ BenchKit is generally responsible for:
 - handoff into estimation packages
 - unified storage and presentation formats
 
-詳細推定では、さらに次も BenchKit 側で扱うのが望ましい。
+詳細推定では、さらに次も Benchkit 側で扱うのが望ましい。
 - `estimate.sh` 内の宣言ブロックの読込み
 - package metadata を見た追加採取実行の組立て
 - `bk_emit_*` で与えられた値と追加採取結果の合流
 
-一方で `weakscaling` のような artifact 不要 package では、BenchKit 側は追加採取を組み立てるのではなく、app 側が出した section / overlap 時間に対して `identity` / `logp` を dispatch し、top-level FOM を合成する責務を持つ。
+一方で `weakscaling` のような artifact 不要 package では、Benchkit 側は追加採取を組み立てるのではなく、app 側が出した section / overlap 時間に対して `identity` / `logp` を dispatch し、top-level FOM を合成する責務を持つ。
 
 ## 9. 現時点で固定しないこと / Items Intentionally Left Open
 

--- a/docs/cx/ESTIMATION_PACKAGE_METADATA_SPEC.md
+++ b/docs/cx/ESTIMATION_PACKAGE_METADATA_SPEC.md
@@ -28,7 +28,7 @@ This document is a lower-level specification under [`ESTIMATION_PACKAGE_SPEC.md`
 
 ## 2. 目的 / Purpose
 
-推定パッケージ metadata の目的は、BenchKit が推定パッケージを登録し、選択し、適用可能性や fallback を判断し、将来の比較や置き換えにも耐えられる形で扱えるようにすることである。
+推定パッケージ metadata の目的は、Benchkit が推定パッケージを登録し、選択し、適用可能性や fallback を判断し、将来の比較や置き換えにも耐えられる形で扱えるようにすることである。
 
 主な用途は以下である。
 
@@ -38,7 +38,7 @@ This document is a lower-level specification under [`ESTIMATION_PACKAGE_SPEC.md`
 - フォールバック方針の共有
 - Estimate JSON への写像の補助
 
-The purpose of estimation-package metadata is to allow BenchKit to register and select estimation packages, evaluate applicability and fallback, and preserve future comparison and replacement in a consistent way.
+The purpose of estimation-package metadata is to allow Benchkit to register and select estimation packages, evaluate applicability and fallback, and preserve future comparison and replacement in a consistent way.
 
 Typical uses include:
 
@@ -211,7 +211,7 @@ Estimation-package metadata may optionally contain:
 - `vendor_provided`
 - `external_service`
 
-これは、推定方式の実装本体が BenchKit と同じ公開リポジトリに同梱されるのか、別の公開または非公開リポジトリで管理されるのか、あるいはローカルやベンダー指定の形で扱われるのかを BenchKit から識別するための補助情報である。
+これは、推定方式の実装本体が Benchkit と同じ公開リポジトリに同梱されるのか、別の公開または非公開リポジトリで管理されるのか、あるいはローカルやベンダー指定の形で扱われるのかを Benchkit から識別するための補助情報である。
 
 Represents how the package is placed or provided.
 At the initial stage, it should preferably be able to express at least:
@@ -222,7 +222,7 @@ At the initial stage, it should preferably be able to express at least:
 - `vendor_provided`
 - `external_service`
 
-This helps BenchKit identify whether the package implementation is bundled in the same public repository as BenchKit, managed in a separate public or private repository, or handled locally or by vendor-specific means.
+This helps Benchkit identify whether the package implementation is bundled in the same public repository as Benchkit, managed in a separate public or private repository, or handled locally or by vendor-specific means.
 
 ### 5.2 package_location
 

--- a/docs/cx/ESTIMATION_PACKAGE_SHELL_API_SPEC.md
+++ b/docs/cx/ESTIMATION_PACKAGE_SHELL_API_SPEC.md
@@ -22,9 +22,9 @@ This document follows the reading conventions defined in [`CX_FRAMEWORK.md`](./C
 
 ## 1. 文書の位置づけ / Position of This Document
 
-本書は [`ESTIMATION_PACKAGE_SPEC.md`](./ESTIMATION_PACKAGE_SPEC.md) の下位仕様であり、BenchKit と推定パッケージの間でやり取りする shell API の最小規約を定義する。
+本書は [`ESTIMATION_PACKAGE_SPEC.md`](./ESTIMATION_PACKAGE_SPEC.md) の下位仕様であり、Benchkit と推定パッケージの間でやり取りする shell API の最小規約を定義する。
 
-This document is a lower-level specification under [`ESTIMATION_PACKAGE_SPEC.md`](./ESTIMATION_PACKAGE_SPEC.md). It defines the minimum shell API conventions between BenchKit and estimation packages.
+This document is a lower-level specification under [`ESTIMATION_PACKAGE_SPEC.md`](./ESTIMATION_PACKAGE_SPEC.md). It defines the minimum shell API conventions between Benchkit and estimation packages.
 
 ## 2. 目的 / Purpose
 
@@ -51,10 +51,10 @@ At the initial stage, it is sufficient to make the following four phases explici
 4. propagation into Estimate JSON
 
 また、この shell API は推定パッケージの実装本体が常にリポジトリ内 shell ファイルであることを前提にしない。
-package の実体は、リポジトリ内 shell、ローカルファイル、ベンダー指定ラッパー、外部サービス呼び出しのいずれであってもよく、shell API はそれらを BenchKit から統一的に扱うための境界面として定義する。
+package の実体は、リポジトリ内 shell、ローカルファイル、ベンダー指定ラッパー、外部サービス呼び出しのいずれであってもよく、shell API はそれらを Benchkit から統一的に扱うための境界面として定義する。
 
 This shell API also does not assume that the implementation body of a package is always a shell file inside the repository.
-The package body may instead be a repository shell file, a local file, a vendor-specified wrapper, or an external service call, and the shell API is defined as the interface boundary through which BenchKit handles them uniformly.
+The package body may instead be a repository shell file, a local file, a vendor-specified wrapper, or an external service call, and the shell API is defined as the interface boundary through which Benchkit handles them uniformly.
 
 ## 4. 推奨 API / Recommended API
 

--- a/docs/cx/ESTIMATION_PACKAGE_SPEC.md
+++ b/docs/cx/ESTIMATION_PACKAGE_SPEC.md
@@ -22,13 +22,13 @@ This document follows the reading conventions defined in [`CX_FRAMEWORK.md`](./C
 
 ## 1. 文書の位置づけ / Position of This Document
 
-本書は [`ESTIMATION_SPEC.md`](./ESTIMATION_SPEC.md) の下位仕様であり、BenchKit が推定方式をどのような単位で受け入れ、再利用し、差し替えるかを定義する。
-推定入力をどのように採取し BenchKit へ受け渡すかは、[`ESTIMATION_INPUT_ACQUISITION_SPEC.md`](./ESTIMATION_INPUT_ACQUISITION_SPEC.md) を参照する。
+本書は [`ESTIMATION_SPEC.md`](./ESTIMATION_SPEC.md) の下位仕様であり、Benchkit が推定方式をどのような単位で受け入れ、再利用し、差し替えるかを定義する。
+推定入力をどのように採取し Benchkit へ受け渡すかは、[`ESTIMATION_INPUT_ACQUISITION_SPEC.md`](./ESTIMATION_INPUT_ACQUISITION_SPEC.md) を参照する。
 
 本書でいう推定パッケージは、推定モデル単体ではなく、計測入力の前提、必要入力、前処理、適用可能性判定、フォールバック方針、Estimate JSON への写像までを含む再利用単位である。
 
-This document is a lower-level specification under [`ESTIMATION_SPEC.md`](./ESTIMATION_SPEC.md). It defines the unit by which BenchKit accepts, reuses, and replaces estimation methods.
-For how estimation inputs are acquired and handed into BenchKit, see [`ESTIMATION_INPUT_ACQUISITION_SPEC.md`](./ESTIMATION_INPUT_ACQUISITION_SPEC.md).
+This document is a lower-level specification under [`ESTIMATION_SPEC.md`](./ESTIMATION_SPEC.md). It defines the unit by which Benchkit accepts, reuses, and replaces estimation methods.
+For how estimation inputs are acquired and handed into Benchkit, see [`ESTIMATION_INPUT_ACQUISITION_SPEC.md`](./ESTIMATION_INPUT_ACQUISITION_SPEC.md).
 
 An estimation package in this document is not just an estimation model. It is a reusable unit that includes measurement prerequisites, required inputs, preprocessing, applicability evaluation, fallback policy, and mapping into Estimate JSON.
 
@@ -101,10 +101,10 @@ The target design is that the application side only needs to specify:
 ### 3.3 計測と推定の結合を明示する / Make Measurement-Estimation Coupling Explicit
 
 推定方式は、必要な計測情報の取り方と強く結び付いている。
-したがって BenchKit は、推定モデルだけでなく、どのような計測結果を前提にする方式かをパッケージとして明示できることが望ましい。
+したがって Benchkit は、推定モデルだけでなく、どのような計測結果を前提にする方式かをパッケージとして明示できることが望ましい。
 
 Estimation methods are strongly coupled with how the required measurement data is obtained.
-Therefore BenchKit should preferably be able to represent not only the estimation model, but also the measurement assumptions of the method as part of the package.
+Therefore Benchkit should preferably be able to represent not only the estimation model, but also the measurement assumptions of the method as part of the package.
 
 ### 3.3.1 取得方式ごとの詳細パッケージ / Detailed Packages by Acquisition Path
 
@@ -137,7 +137,7 @@ They should preferably be distinguishable at least by acquisition path, for exam
 - 別の区間はトレースベース
 - その他の区間は区間時間ベース
 
-この場合、BenchKit は最終 FOM が複数区間の推定結果の合成であることを受け入れられるべきである。
+この場合、Benchkit は最終 FOM が複数区間の推定結果の合成であることを受け入れられるべきである。
 
 An estimation package may be a composite package that combines different estimation methods for different sections, rather than a single method.
 In particular, the framework should allow cases such as:
@@ -146,7 +146,7 @@ In particular, the framework should allow cases such as:
 - other sections estimated with trace-based methods
 - other sections estimated from interval timings
 
-In such cases, BenchKit should be able to accept that the final FOM is composed from multiple section-wise estimation results.
+In such cases, Benchkit should be able to accept that the final FOM is composed from multiple section-wise estimation results.
 
 overlap 区間も、section ごとの複合推定の一部として扱ってよい。
 すなわち、overlap は単なる補正値に限らず、二つ以上の section が同時進行しうる区間として独立した推定部品で表現してよい。
@@ -214,26 +214,26 @@ This makes it possible, for example, for an `intra_system_scaling_model` to allo
 推定パッケージは、常に Git 管理下に置けるとは限らない。
 将来アーキテクチャの仕様、ベンダー提供のツールチェイン、契約上の制約、非公開管理の必要性などにより、推定パッケージが以下の形を取ることを許容しなければならない。
 
-- BenchKit と同じ公開リポジトリに同梱される package
+- Benchkit と同じ公開リポジトリに同梱される package
 - ローカルファイルとして配置される package
 - 別の公開もしくは非公開リポジトリで管理される package
 - ベンダー指定の配置や呼び出し方法に従う package
 - 外部ツールや外部サービスを経由して実行される package
 
-したがって BenchKit は、推定パッケージの内容そのものを常に Git に格納することを必須要件としてはならない。
-BenchKit に求められるのは、推定パッケージの所在、識別情報、呼び出し規約、必要入力、適用条件を扱えることである。
+したがって Benchkit は、推定パッケージの内容そのものを常に Git に格納することを必須要件としてはならない。
+Benchkit に求められるのは、推定パッケージの所在、識別情報、呼び出し規約、必要入力、適用条件を扱えることである。
 
 An estimation package cannot always be stored under Git control.
 Future-architecture specifications, vendor-provided toolchains, contractual restrictions, and private-management requirements may require packages to take forms such as:
 
-- a package bundled in the same public repository as BenchKit
+- a package bundled in the same public repository as Benchkit
 - a package stored as a local file
 - a package managed in a separate public or private repository
 - a package that follows vendor-specified placement or invocation rules
 - a package executed through an external tool or service
 
-Therefore BenchKit must not require that the package implementation itself always be stored in Git.
-What BenchKit needs is the ability to handle the package location, identity, invocation rules, required inputs, and applicability conditions.
+Therefore Benchkit must not require that the package implementation itself always be stored in Git.
+What Benchkit needs is the ability to handle the package location, identity, invocation rules, required inputs, and applicability conditions.
 
 ## 4. 推定パッケージの論理構成 / Logical Structure of an Estimation Package
 
@@ -356,7 +356,7 @@ At the final Estimate JSON level, a package-level fallback may appear either as 
 The package should preferably be able to define which lighter-weight method may be used as fallback when required inputs are missing, or whether execution must stop without fallback.
 When fallback is used, the requested package identity should remain visible separately from the actually applied package identity.
 When no acceptable fallback exists, the package may return `not_applicable`.
-In that case, BenchKit may still store and present the resulting record as a `not_applicable` estimate attempt rather than treating it as a pipeline failure.
+In that case, Benchkit may still store and present the resulting record as a `not_applicable` estimate attempt rather than treating it as a pipeline failure.
 
 ### 4.6 Estimate JSON への写像 / Mapping into Estimate JSON
 
@@ -406,11 +406,11 @@ The package should preferably be able to map its information into at least the f
 - `fom_breakdown.sections`
 - `fom_breakdown.overlaps`
 
-## 5. BenchKit における責務分担 / Responsibility Split in BenchKit
+## 5. Benchkit における責務分担 / Responsibility Split in Benchkit
 
 ### 5.1 フレームワーク側責務 / Framework-Side Responsibilities
 
-BenchKit 側は、原則として以下を提供することが望ましい。
+Benchkit 側は、原則として以下を提供することが望ましい。
 
 - 推定パッケージの登録機構
 - 推定パッケージの呼び出し機構
@@ -419,7 +419,7 @@ BenchKit 側は、原則として以下を提供することが望ましい。
 - Estimate JSON の標準化
 - パッケージ識別情報の保持
 
-BenchKit should preferably provide the following:
+Benchkit should preferably provide the following:
 
 - a registration mechanism for estimation packages
 - an invocation mechanism for estimation packages
@@ -456,7 +456,7 @@ The application side should preferably be limited to:
 - 補助アーティファクトの内部フォーマット
 - 必要に応じたフォールバック規則
 
-すなわち、BenchKit が共通ルールを提供し、app 側が package を選択し、package 開発者が推定方式の具体的意味を定める、という責務分離を基本とする。
+すなわち、Benchkit が共通ルールを提供し、app 側が package を選択し、package 開発者が推定方式の具体的意味を定める、という責務分離を基本とする。
 
 The estimation-package developer is primarily responsible for defining:
 
@@ -467,7 +467,7 @@ The estimation-package developer is primarily responsible for defining:
 - the internal format of auxiliary artifacts
 - fallback rules when needed
 
-In other words, the intended separation is that BenchKit provides the common rules, the application side selects the package, and the package developer defines the concrete meaning of the estimation method.
+In other words, the intended separation is that Benchkit provides the common rules, the application side selects the package, and the package developer defines the concrete meaning of the estimation method.
 
 ## 6. 推奨される導入形態 / Recommended Adoption Forms
 
@@ -509,7 +509,7 @@ These are suitable for deeper analysis and future-system evaluation.
 
 ## 7. 参照実装イメージ / Reference Implementation Direction
 
-BenchKit においては、将来的に app 側の `estimate.sh` が毎回すべてを書くのではなく、例えば以下のような形へ寄せることが望ましい。
+Benchkit においては、将来的に app 側の `estimate.sh` が毎回すべてを書くのではなく、例えば以下のような形へ寄せることが望ましい。
 
 ```sh
 BK_ESTIMATION_CURRENT_PACKAGE=weakscaling
@@ -522,7 +522,7 @@ bk_estimation_run_declared_future_package result.json
 
 この形では、app 側はパッケージ選択と最小限の app 固有設定を担い、推定方式の詳細はパッケージ側へ集約される。
 
-In BenchKit, a desirable future direction is that application-side `estimate.sh` no longer implements everything each time, but instead looks like:
+In Benchkit, a desirable future direction is that application-side `estimate.sh` no longer implements everything each time, but instead looks like:
 
 ```sh
 BK_ESTIMATION_CURRENT_PACKAGE=weakscaling

--- a/docs/cx/ESTIMATION_SPEC.md
+++ b/docs/cx/ESTIMATION_SPEC.md
@@ -23,14 +23,14 @@ This document follows the reading conventions defined in [`CX_FRAMEWORK.md`](./C
 ## 1. 文書の位置づけ / Position of This Document
 
 本書は [`BENCHKIT_SPEC.md`](./BENCHKIT_SPEC.md) のうち性能推定機能を詳細化する下位仕様である。
-本書は、推定手法の内部アルゴリズムそのものを固定する文書ではなく、BenchKit が推定機能を受け入れ、実行し、保存し、表示するための共通ルールを定義する。
+本書は、推定手法の内部アルゴリズムそのものを固定する文書ではなく、Benchkit が推定機能を受け入れ、実行し、保存し、表示するための共通ルールを定義する。
 
 This document is a lower-level specification that details the estimation function described in [`BENCHKIT_SPEC.md`](./BENCHKIT_SPEC.md).
-It does not fix a single estimation algorithm. Instead, it defines the common rules by which BenchKit accepts, runs, stores, and presents estimation functions.
+It does not fix a single estimation algorithm. Instead, it defines the common rules by which Benchkit accepts, runs, stores, and presents estimation functions.
 
 ## 2. 目的 / Purpose
 
-BenchKit の性能推定機能は、ベンチマーク結果から以下を推定できるようにすることを目的とする。
+Benchkit の性能推定機能は、ベンチマーク結果から以下を推定できるようにすることを目的とする。
 
 - 本番規模 FOM
 - 異なるノード数でのスケーリング挙動
@@ -45,7 +45,7 @@ BenchKit の性能推定機能は、ベンチマーク結果から以下を推�
 - 推定結果の前提、根拠、比較元が追跡可能であること
 - 推定に必要な入力が不足している場合の扱いを明示できること
 
-The purpose of BenchKit estimation is to make it possible to estimate:
+The purpose of Benchkit estimation is to make it possible to estimate:
 
 - production-scale FOM
 - scaling behavior at different node counts
@@ -64,7 +64,7 @@ At the same time, the estimation function must satisfy the following:
 
 ### 3.1 手法差し替え可能性 / Method Replaceability
 
-BenchKit は、単一の性能カウンター採取方法、単一のアノテーション方式、単一の推定ツール、単一の推定モデルにロックインしてはならない。
+Benchkit は、単一の性能カウンター採取方法、単一のアノテーション方式、単一の推定ツール、単一の推定モデルにロックインしてはならない。
 
 推定処理は、少なくとも概念上、以下を分離して扱えるべきである。
 
@@ -73,7 +73,7 @@ BenchKit は、単一の性能カウンター採取方法、単一のアノテ�
 - 推定モデル
 - 推定結果の出力形式
 
-BenchKit must not be locked into a single counter collection method, annotation scheme, estimation tool, or estimation model.
+Benchkit must not be locked into a single counter collection method, annotation scheme, estimation tool, or estimation model.
 
 At least conceptually, the estimation flow should separate:
 
@@ -141,9 +141,9 @@ An estimation result must be traceable at least to:
 ### 3.4 適用可能性判定 / Applicability Evaluation
 
 推定方式ごとに、必要な入力の集合を定義できなければならない。
-BenchKit は、指定された推定方式に対して入力が十分かどうかを判定できることを基本とする。
+Benchkit は、指定された推定方式に対して入力が十分かどうかを判定できることを基本とする。
 
-必要入力が不足する場合、BenchKit または推定方式は、少なくとも以下のいずれかを明示しなければならない。
+必要入力が不足する場合、Benchkit または推定方式は、少なくとも以下のいずれかを明示しなければならない。
 
 - 不適用として終了する
 - 軽量な別方式へフォールバックする
@@ -152,12 +152,12 @@ BenchKit は、指定された推定方式に対して入力が十分かどう�
 不足したまま成功扱いの推定結果を返してはならない。
 
 Each estimation method must be able to define its required input set.
-BenchKit should be able to judge whether the inputs are sufficient for a requested estimation method.
-フォールバックが用いられた場合、BenchKit は、最初に要求された推定パッケージと、実際に適用された推定パッケージを区別して扱えなければならない。
+Benchkit should be able to judge whether the inputs are sufficient for a requested estimation method.
+フォールバックが用いられた場合、Benchkit は、最初に要求された推定パッケージと、実際に適用された推定パッケージを区別して扱えなければならない。
 また、その切り替え理由を applicability の結果に保持できることが望ましい。
-When fallback is used, BenchKit should distinguish the originally requested estimation package from the actually applied package, and should preserve the reason for the switch in the applicability result.
+When fallback is used, Benchkit should distinguish the originally requested estimation package from the actually applied package, and should preserve the reason for the switch in the applicability result.
 
-When required inputs are missing, BenchKit or the estimation method must explicitly do at least one of the following:
+When required inputs are missing, Benchkit or the estimation method must explicitly do at least one of the following:
 
 - terminate as not applicable
 - fall back to a lighter-weight method
@@ -165,9 +165,9 @@ When required inputs are missing, BenchKit or the estimation method must explici
 
 It must not return a successful estimate while silently ignoring missing required inputs.
 
-### 3.5 BenchKit と推定パッケージ開発者の責務境界 / Boundary Between BenchKit and Package Developers
+### 3.5 Benchkit と推定パッケージ開発者の責務境界 / Boundary Between Benchkit and Package Developers
 
-BenchKit は、推定機構について共通ルール、識別情報、入出力、適用可能性判定結果、保存形式、比較可能性を扱う。
+Benchkit は、推定機構について共通ルール、識別情報、入出力、適用可能性判定結果、保存形式、比較可能性を扱う。
 一方で、各推定パッケージの開発者は、少なくとも以下を定義できるものとして扱う。
 
 - 具体的な推定アルゴリズム
@@ -179,7 +179,7 @@ BenchKit は、推定機構について共通ルール、識別情報、入出�
 
 したがって、本書で未定義のまま残す項目は、原則として package 開発者または外部ツール側へ委ねられる。
 
-BenchKit handles the common rules, identifiers, inputs/outputs, applicability results, storage format, and comparability of estimation.
+Benchkit handles the common rules, identifiers, inputs/outputs, applicability results, storage format, and comparability of estimation.
 By contrast, each estimation-package developer is expected to define at least:
 
 - the concrete estimation algorithm
@@ -267,12 +267,12 @@ For measurement inputs used by estimation, it should be possible to identify at 
 
 ### 4.3 推定モデル / Estimation Model
 
-推定モデルは、BenchKit に埋め込まれた単一モデルである必要はない。
+推定モデルは、Benchkit に埋め込まれた単一モデルである必要はない。
 アプリ固有スクリプト、共通 shell ライブラリ、外部ツール、外部サービスのいずれでもよい。
 
-BenchKit における実装単位としては、これらを単独のモデルとして扱うだけでなく、計測前提や適用可能性判定を含む推定パッケージとして束ねて扱ってもよい。
+Benchkit における実装単位としては、これらを単独のモデルとして扱うだけでなく、計測前提や適用可能性判定を含む推定パッケージとして束ねて扱ってもよい。
 
-ただし BenchKit から見て、少なくとも以下を識別可能にすべきである。
+ただし Benchkit から見て、少なくとも以下を識別可能にすべきである。
 
 - モデル種別
 - モデル名
@@ -280,12 +280,12 @@ BenchKit における実装単位としては、これらを単独のモデル�
 - スケーリング方式
 - 将来システム仮定
 
-The estimation model need not be a single built-in BenchKit model.
+The estimation model need not be a single built-in Benchkit model.
 It may be an application-specific script, a shared shell library, an external tool, or an external service.
 
-As an implementation unit in BenchKit, these may be handled not only as standalone models but also as estimation packages that bundle measurement assumptions and applicability evaluation.
+As an implementation unit in Benchkit, these may be handled not only as standalone models but also as estimation packages that bundle measurement assumptions and applicability evaluation.
 
-However, from the perspective of BenchKit, the following should be identifiable:
+However, from the perspective of Benchkit, the following should be identifiable:
 
 - model type
 - model name
@@ -301,7 +301,7 @@ The estimation model need not always be a single monolithic model.
 Composite estimation that combines different estimation methods for different sections should be allowed.
 In particular, it is desirable to apply different input types or estimation methods to compute, communication, and I/O sections.
 
-さらに、BenchKit は少なくとも次の二種類の推定モデルを区別して扱えることが望ましい。
+さらに、Benchkit は少なくとも次の二種類の推定モデルを区別して扱えることが望ましい。
 
 - `intra_system_scaling_model`
   - 少ノード benchmark result から、同種または同一系統のシステム上の target nodes へ伸長する推定モデル
@@ -313,7 +313,7 @@ In particular, it is desirable to apply different input types or estimation meth
 
 これらは同一の推定モデルであってもよいが、別個のモデル、別個の推定パッケージ、あるいは複合推定パッケージ内の別部品として扱ってよい。
 
-In addition, BenchKit should preferably be able to distinguish at least the following two kinds of estimation models:
+In addition, Benchkit should preferably be able to distinguish at least the following two kinds of estimation models:
 
 - `intra_system_scaling_model`
   - a model that scales a small-node benchmark result to target nodes on the same or closely related system line
@@ -409,12 +409,12 @@ However, the same scaling rule need not be forced on both the `current_system` s
 Also, the `current_system` side need not always be an intra-system scaling case.
 When using `intra_system_scaling_model`, a rule such as "FOM is constant by default, with selective corrections only for some sections" is natural, whereas when using `cross_system_projection_model`, a projection model that changes section timings themselves according to CPU/GPU performance, communication performance, or memory performance is natural.
 
-したがって、BenchKit は少なくとも次を検証できることが望ましい。
+したがって、Benchkit は少なくとも次を検証できることが望ましい。
 
 - `intra_system_scaling_model` が指定されたとき、入力 benchmark result の `system` と推定出力側の対象 `system` が一致または同一系統であること
 - `cross_system_projection_model` が指定されたとき、入力 benchmark result の `system` が推定元、推定出力側の対象 `system` が推定先として解釈できること
 
-Accordingly, BenchKit should preferably be able to validate at least the following:
+Accordingly, Benchkit should preferably be able to validate at least the following:
 
 - when `intra_system_scaling_model` is specified, the input benchmark-result `system` and the output-side target `system` are the same or from the same system line
 - when `cross_system_projection_model` is specified, the input benchmark-result `system` can be interpreted as the source system and the output-side target `system` as the destination system
@@ -463,7 +463,7 @@ More detailed methods may instead use an explicit model, trace, counters, or int
 - フォールバック
 - 不適用
 
-BenchKit should preferably be able to evaluate whether the required inputs for a chosen estimation method are present before execution.
+Benchkit should preferably be able to evaluate whether the required inputs for a chosen estimation method are present before execution.
 This evaluation should preferably be able to distinguish at least the following final states:
 
 - applicable
@@ -476,7 +476,7 @@ This evaluation should preferably be able to distinguish at least the following 
 `not_applicable` means that estimation was attempted but did not succeed as an estimate result.
 
 `not_applicable` does not necessarily imply pipeline failure.
-BenchKit may still preserve and present a `not_applicable` estimate result as a record of an estimation attempt.
+Benchkit may still preserve and present a `not_applicable` estimate result as a record of an estimation attempt.
 
 applicability 評価が fallback を返す場合、少なくとも次を識別できることが望ましい。
 
@@ -495,14 +495,14 @@ When only part of the section / overlap / component chain falls back while the o
 ### 4.6 履歴と再推定 / History and Re-Estimation
 
 推定は一度きりの計算ではなく、モデルや仮定の更新に応じて再推定できることが重要である。
-BenchKit は、少なくとも以下を扱えるべきである。
+Benchkit は、少なくとも以下を扱えるべきである。
 
 - benchmark result を再指定しての再推定
 - 推定結果の履歴保持
 - 異なる推定方式の比較可能性の保持
 
 Estimation is not a one-time calculation. Re-estimation in response to updated models or assumptions is important.
-BenchKit should be able to handle at least:
+Benchkit should be able to handle at least:
 
 - re-estimation from a specified benchmark result
 - history retention of estimation results
@@ -510,7 +510,7 @@ BenchKit should be able to handle at least:
 
 ## 5. 推定方式の分類 / Classes of Estimation Methods
 
-BenchKit は少なくとも、以下の推定方式を受け入れられることが望ましい。
+Benchkit は少なくとも、以下の推定方式を受け入れられることが望ましい。
 
 ### 5.1 最小構成の区間分割推定 / Minimum Section-Wise Estimation (`weakscaling`)
 
@@ -545,7 +545,7 @@ BenchKit は少なくとも、以下の推定方式を受け入れられるこ�
 - 将来機評価
 - AI 駆動最適化の高精度評価
 
-BenchKit should preferably support at least the following estimation classes:
+Benchkit should preferably support at least the following estimation classes:
 
 ### 5.1 Minimum Section-Wise Estimation (`weakscaling`)
 
@@ -586,9 +586,9 @@ Typical use:
 - future-system evaluation
 - higher-fidelity evaluation for AI-driven optimization
 
-## 6. BenchKit における推定実装要件 / BenchKit-Side Requirements
+## 6. Benchkit における推定実装要件 / Benchkit-Side Requirements
 
-BenchKit は、推定機能について少なくとも以下を満たすべきである。
+Benchkit は、推定機能について少なくとも以下を満たすべきである。
 
 1. app ごとの推定処理を呼び出せること
 2. Result JSON を推定入力として受け渡せること
@@ -597,7 +597,7 @@ BenchKit は、推定機能について少なくとも以下を満たすべき�
 5. 推定結果を一覧・詳細で表示できること
 6. 推定方式の違いを将来的に比較可能な形で保持できること
 
-BenchKit should satisfy at least the following:
+Benchkit should satisfy at least the following:
 
 1. it should be able to invoke per-application estimation logic
 2. it should pass Result JSON as estimation input

--- a/docs/cx/REESTIMATION_SPEC.md
+++ b/docs/cx/REESTIMATION_SPEC.md
@@ -54,11 +54,11 @@ Typical use cases include:
 
 再推定では、入力となる benchmark result を明示的に固定しなければならない。
 この識別には、少なくとも result の UUID を用いることを基本とする。
-再推定の利用者向け入口は `estimate_result_uuid` に統一する。BenchKit はその estimate が保持する `source_result_uuid` を内部的に解決し、元 result を辿る。
+再推定の利用者向け入口は `estimate_result_uuid` に統一する。Benchkit はその estimate が保持する `source_result_uuid` を内部的に解決し、元 result を辿る。
 
 In re-estimation, the input benchmark result must be explicitly fixed.
 The documented user-facing entrypoint is `estimate_result_uuid`.
-BenchKit internally resolves the original benchmark result through the `source_result_uuid` stored in that estimate.
+Benchkit internally resolves the original benchmark result through the `source_result_uuid` stored in that estimate.
 
 ### 3.2 比較可能性 / Comparability
 
@@ -98,20 +98,20 @@ It must not silently ignore missing inputs and still report a successful estimat
 
 ## 4. 再推定フロー / Re-Estimation Flow
 
-BenchKit における再推定の典型フローは以下である。
+Benchkit における再推定の典型フローは以下である。
 
 1. 利用者またはワークフローが `estimate_result_uuid` を指定する
-2. BenchKit は estimate JSON を取得し、そこから `source_result_uuid` を解決する
-3. BenchKit が対応する Result JSON を取得する
+2. Benchkit は estimate JSON を取得し、そこから `source_result_uuid` を解決する
+3. Benchkit が対応する Result JSON を取得する
 4. 対象 app の `estimate.sh` を起動する
 5. `Estimate JSON` を生成する
 6. 生成結果を保存し、ポータルで参照可能にする
 
-The typical re-estimation flow in BenchKit is:
+The typical re-estimation flow in Benchkit is:
 
 1. a user or workflow specifies an `estimate_result_uuid`
-2. BenchKit fetches the estimate JSON and resolves `source_result_uuid`
-3. BenchKit fetches the corresponding Result JSON
+2. Benchkit fetches the estimate JSON and resolves `source_result_uuid`
+3. Benchkit fetches the corresponding Result JSON
 4. the app-specific `estimate.sh` is invoked
 5. an `Estimate JSON` is generated
 6. the generated result is stored and made available through the portal
@@ -144,7 +144,7 @@ Optionally, the following may also be supplied:
 - baseline-selection conditions
 - fallback policy
 
-## 6. BenchKit における現行実装 / Current Implementation in BenchKit
+## 6. Benchkit における現行実装 / Current Implementation in Benchkit
 
 現行実装では、以下の要素が存在する。
 
@@ -290,7 +290,7 @@ At least the following need to be clarified:
 
 ## 8. 推奨要件 / Recommended Requirements
 
-BenchKit における再推定は、少なくとも以下を満たすことが望ましい。
+Benchkit における再推定は、少なくとも以下を満たすことが望ましい。
 
 1. `estimate_result_uuid` 指定で benchmark result を再取得できること
 2. app ごとの `estimate.sh` を同じ入力に対して繰り返し実行できること
@@ -299,7 +299,7 @@ BenchKit における再推定は、少なくとも以下を満たすことが�
 5. `weakscaling` を最小経路とする推定と詳細推定を同一の比較軸で扱えること
 6. 必要入力不足時に、不適用・フォールバック・再計測要求を明示できること
 
-Re-estimation in BenchKit should preferably satisfy at least:
+Re-estimation in Benchkit should preferably satisfy at least:
 
 1. the benchmark result can be re-fetched from `estimate_result_uuid`
 2. app-specific `estimate.sh` can be run repeatedly for the same input
@@ -343,7 +343,7 @@ Candidate next steps include:
 
 ## 10. 現在の実装状態の補遺 / Addendum on Current Status
 
-現時点の BenchKit では、再推定について次が成立している。
+現時点の Benchkit では、再推定について次が成立している。
 
 - 利用者向け入口として `estimate_result_uuid` を使える
 - `estimate_result_uuid` から stored estimate JSON を取得し、そこから `source_result_uuid` を解決できる

--- a/docs/guides/add-app.md
+++ b/docs/guides/add-app.md
@@ -1,6 +1,6 @@
 # アプリ追加手順（開発者向け）
 
-このドキュメントは、BenchKit に新しいアプリ（プログラム）を追加する手順を開発者向けにまとめたものです。
+このドキュメントは、Benchkit に新しいアプリ（プログラム）を追加する手順を開発者向けにまとめたものです。
 サンプルアプリ `qws` を参考に、新しいアプリ `<code>` を追加して PR を作成するまでを説明します。
 
 ## このガイドでの app 担当の責務
@@ -96,7 +96,7 @@ RC_FX700,yes,1,4,12,0:10:00
 
 ### `config/system.csv` との責務分担
 
-BenchKit では、実行条件とシステム運用設定を明確に分けます。
+Benchkit では、実行条件とシステム運用設定を明確に分けます。
 
 - `programs/<code>/list.csv`
   - そのアプリをどのシステム・どのノード数・どのMPI/OpenMP条件で流すか
@@ -114,7 +114,7 @@ BenchKit では、実行条件とシステム運用設定を明確に分けま�
 
 ### `source_info` の現時点の方針
 
-BenchKit では、まず **top-level application の source provenance** を追えることを優先します。
+Benchkit では、まず **top-level application の source provenance** を追えることを優先します。
 具体的には、Git 管理のアプリであれば `repo_url`、`branch`、`commit_hash` を `source_info` として入れられる形が望ましいです。
 
 一方で、ローカルファイルや依存ライブラリを含む完全な provenance を、現時点ですべての app に必須化する方針ではありません。
@@ -320,7 +320,7 @@ bk_emit_overlap compute_kernel,communication 0.05 >> results/result
 
 ### 最低限必要な出力
 
-新しい app を BenchKit に接続する最低ラインは、`run.sh` が `results/result` に少なくとも `FOM:<数値>` 相当の結果を書けることです。
+新しい app を Benchkit に接続する最低ラインは、`run.sh` が `results/result` に少なくとも `FOM:<数値>` 相当の結果を書けることです。
 ただし FOM には単位が含まれないため、`FOM_unit:s` のように単位も出してください。
 多くのアプリでは経過時間の `s` で十分ですが、システムソフトウェアやライブラリでは `GB/s`、`GFLOPS`、`token/s` などになることがあります。
 `bk_emit_result --fom ... --fom-unit ...` を使うと、FOM、単位、実験名、ノード数、プロセス数、スレッド数を同じ形式で出力できます。
@@ -339,8 +339,8 @@ tar -czf ../results/padata0.tgz ./pa
 
 ### Fugaku で `fapp` を使う場合
 
-Fugaku 系アプリでは、アプリ側が profiler tool を内部で選び、BenchKit 共通の `bk_profiler` helper に渡す形が扱いやすいです。
-`bk_profiler` は profiler ごとの raw data / postprocess report をまとめて `results/padata*.tgz` に保存し、archive 内の `bk_profiler_artifact/meta.json` に metadata を入れます。BenchKit や推定 package はこの `meta.json` を見て、tool、level、report kind を機械的に判断できます。
+Fugaku 系アプリでは、アプリ側が profiler tool を内部で選び、Benchkit 共通の `bk_profiler` helper に渡す形が扱いやすいです。
+`bk_profiler` は profiler ごとの raw data / postprocess report をまとめて `results/padata*.tgz` に保存し、archive 内の `bk_profiler_artifact/meta.json` に metadata を入れます。Benchkit や推定 package はこの `meta.json` を見て、tool、level、report kind を機械的に判断できます。
 
 `fapp` では共通 level として次を扱います。
 

--- a/docs/guides/add-estimation-package.md
+++ b/docs/guides/add-estimation-package.md
@@ -1,7 +1,7 @@
 # 推定パッケージ追加手順（開発者向け）
 
-このドキュメントは、BenchKit に新しい推定 package を追加する開発者向けガイドです。
-現在の実装では、package は「推定ロジックと package 固有 metadata を持つ側」、BenchKit 共通層は「flow と JSON 受け渡しを持つ側」として考えると整理しやすいです。
+このドキュメントは、Benchkit に新しい推定 package を追加する開発者向けガイドです。
+現在の実装では、package は「推定ロジックと package 固有 metadata を持つ側」、Benchkit 共通層は「flow と JSON 受け渡しを持つ側」として考えると整理しやすいです。
 
 ## 1. 最初に決めること
 
@@ -31,7 +31,7 @@
   - `scripts/estimation/section_packages/`
 
 この配置は現時点の約束です。将来、推定 package が増えた場合にディレクトリ名や登録方法を見直す可能性があります。
-そのため、package 固有のロジック、metadata、applicability 判定はこの配下に閉じ、BenchKit 共通層へ app 固有・package 固有の処理を混ぜないようにしてください。
+そのため、package 固有のロジック、metadata、applicability 判定はこの配下に閉じ、Benchkit 共通層へ app 固有・package 固有の処理を混ぜないようにしてください。
 
 `qws` の詳細ダミー推定では、たとえば次のような分担です。
 
@@ -69,7 +69,7 @@ section package はもっと小さくてかまいません。
 - applicability
 - 1 区間の変換結果
 
-ここでは「1 区間の変換規則」に集中し、Estimate JSON 全体の組み立てや current / future の side 管理は BenchKit 共通層や top-level package 側へ寄せる方が自然です。
+ここでは「1 区間の変換規則」に集中し、Estimate JSON 全体の組み立てや current / future の side 管理は Benchkit 共通層や top-level package 側へ寄せる方が自然です。
 
 GPU kernel 単位の外部推定ツールは、通常は section package として扱います。
 たとえば次の package は、PerfTools の各モデルを「GPU 区間だけを変換する package」として接続します。
@@ -99,7 +99,7 @@ kernel selector が無く複数 kernel family が混在している場合、候�
 アプリ側 GPU section time が未取得の場合、GPU kernel estimator は FOM 合成には使えず、まずアプリログ、NVTX、または別のアプリ側計時で掛け先となる section time を用意する必要があります。
 未指定時の既定値は接続確認中の実装に合わせて変わることがあるため、検証や再現性が必要な場合は明示してください。
 
-PerfTools 本体は BenchKit に vendoring せず、実行時に次の環境変数で渡します。
+PerfTools 本体は Benchkit に vendoring せず、実行時に次の環境変数で渡します。
 
 ```bash
 export BK_GPU_MLP_PERFTOOLS_ROOT=/path/to/PerfTools
@@ -110,7 +110,7 @@ export BK_GPU_LIGHTGBM_PYTHON=python3.11
 ```
 
 section artifact は PerfTools 側の static GPU spec sheet から作られた prepared CSV を想定します。
-BenchKit 実行時に GPU spec を動的採取しません。
+Benchkit 実行時に GPU spec を動的採取しません。
 テストやデバッグでは、既に作成済みの prediction CSV を使えます。
 
 ```bash
@@ -124,7 +124,7 @@ MLP package は `Execution Time [ns]`、LightGBM package は `O-Execution Time` 
 prepared input CSV から source-side の kernel 実測時間を読める場合は、Estimate JSON の metrics に `source_time_ns`, `predicted_time_ns`, `time_ratio_predicted_over_source`, `speedup_factor_source_over_predicted` を出します。
 `ncu` の採取 window はアプリ全体の GPU 区間時間ではなく限定された kernel sample なので、実運用ではこの source/target 比を、profiler overhead のないアプリ区間 timing に掛けて FOM を再構築する想定です。
 GPU kernel を手で事前調査して `kernel_regex` や launch window を固定することは最終形ではありません。
-BenchKit 共通層では `nsys stats` の CUDA kernel summary から `kernel_discovery.json` と `ncu_plan.json` を生成する helper を用意し、推定 package が必要とする NCU 深掘り対象を自動選定する方向に寄せます。
+Benchkit 共通層では `nsys stats` の CUDA kernel summary から `kernel_discovery.json` と `ncu_plan.json` を生成する helper を用意し、推定 package が必要とする NCU 深掘り対象を自動選定する方向に寄せます。
 最初の段階ではアプリ全体の上位 kernel を対象にし、NVTX や app section timing が使える場合は section-aware discovery に拡張します。
 
 CI 配管や app 固有の smoke test は、`programs/<code>/estimate.sh` や `scripts/tests/` 側で扱います。
@@ -169,7 +169,7 @@ MLP package には Python 3.11 以上と numpy/pandas/torch、LightGBM package �
 - `defaults.notes`
 - `defaults.assumptions`
 
-BenchKit 共通層は、これらを読んで Estimate JSON に写像する役割を主に持ちます。
+Benchkit 共通層は、これらを読んで Estimate JSON に写像する役割を主に持ちます。
 
 ## 6. package 側に持たせるべきもの
 
@@ -239,7 +239,7 @@ section 名そのものより、
 
 ## 10. いまの見方
 
-現状の BenchKit では、package を書き始める土台はかなり整っています。
+現状の Benchkit では、package を書き始める土台はかなり整っています。
 
 - package metadata を共通層へ写像する流れがある
 - current / future package を分けられる

--- a/docs/guides/add-estimation-to-app.md
+++ b/docs/guides/add-estimation-to-app.md
@@ -1,10 +1,10 @@
 # アプリに性能推定を追加する
 
-このガイドは、BenchKit の既存アプリに性能推定を追加する開発者向けの実務メモです。
+このガイドは、Benchkit の既存アプリに性能推定を追加する開発者向けの実務メモです。
 
 最初に押さえるべき点は次の 2 つです。
 - app 側でまず決めるのは、FOM と section / overlap の名前、および各 section / overlap に使う `estimation_package`
-- 採取手順、保存形式、再推定時の復元方法は、共通化できるものから BenchKit 側へ寄せる
+- 採取手順、保存形式、再推定時の復元方法は、共通化できるものから Benchkit 側へ寄せる
 
 ## 目次
 
@@ -108,7 +108,7 @@ bk_estimation_write_output "results/estimate_${est_code}_0.json"
 - package 側
   - `identity` は補正なし
   - `logp` は node 数比較にもとづく補正
-- BenchKit 側
+- Benchkit 側
   - section package の呼び分け
   - current / future の合成
   - top-level applicability の整理
@@ -217,7 +217,7 @@ mpiexec ./a.out "$@"
 bk_run_estimation_data_collection mpiexec ./a.out "$@"
 ```
 
-`bk_run_estimation_data_collection` は BenchKit の共通入口です。内部では割り当てられた package や site 側の wrapper に応じて必要な採取を分岐します。PAPI や GPU profiler のように追加実行が必要なものは、ここでまとめて扱う方が app 側が軽くなります。
+`bk_run_estimation_data_collection` は Benchkit の共通入口です。内部では割り当てられた package や site 側の wrapper に応じて必要な採取を分岐します。PAPI や GPU profiler のように追加実行が必要なものは、ここでまとめて扱う方が app 側が軽くなります。
 
 ---
 
@@ -285,9 +285,9 @@ bk_estimation_write_output "results/estimate_${est_code}_0.json"
 
 ただし `weakscaling` の場合は、追加採取を前提にしません。app 側が通常実行の中で section / overlap 時間を書き、`identity` と `logp` だけで推定する前提です。
 
-app 側では、まず section 名と `estimation_package` を決めることを優先してください。採取手順、複数回実行の要否、保存先、再推定時の復元方法は、共通化できるものから BenchKit 側へ寄せるのがよいです。
+app 側では、まず section 名と `estimation_package` を決めることを優先してください。採取手順、複数回実行の要否、保存先、再推定時の復元方法は、共通化できるものから Benchkit 側へ寄せるのがよいです。
 
-特に PAPI のように複数回実行が必要になる採取は、app 側に細かく書かせすぎると重くなります。package 側は「`papi` が必要」と定義し、BenchKit 側が採取や保存の共通処理を引き受ける形が自然です。
+特に PAPI のように複数回実行が必要になる採取は、app 側に細かく書かせすぎると重くなります。package 側は「`papi` が必要」と定義し、Benchkit 側が採取や保存の共通処理を引き受ける形が自然です。
 
 現状の参照実装では `results/estimation_artifacts/` を使う例がありますが、これは将来も app 側が細かく書き続けるべきという意味ではありません。
 
@@ -330,5 +330,5 @@ app 側では、まず section 名と `estimation_package` を決めることを
 
 今後の改善:
 - app 側に書く採取手順をさらに減らすこと
-- 詳細推定の採取・保存・復元を BenchKit 側へより集約すること
+- 詳細推定の採取・保存・復元を Benchkit 側へより集約すること
 - 複数アプリへの横展開を進めること

--- a/docs/guides/add-estimation.md
+++ b/docs/guides/add-estimation.md
@@ -1,19 +1,19 @@
 # 性能推定の導入ガイド
 
-このドキュメントは、BenchKit の性能推定まわりの入口ページです。
+このドキュメントは、Benchkit の性能推定まわりの入口ページです。
 実際の作業は「アプリ側の導入」と「推定 package 側の追加」に分かれるので、まずは自分の立場に近いガイドから見てください。
 
 ## 推定まわりの現時点の責務分担
 
 推定まわりはまだ整理中の部分がありますが、現時点では次の分担で考えると実装しやすいです。
-配置場所や細かな API は今後変わる可能性があります。package 固有の処理と BenchKit 共通処理を分けておくと、後で配置が変わっても追従しやすくなります。
+配置場所や細かな API は今後変わる可能性があります。package 固有の処理と Benchkit 共通処理を分けておくと、後で配置が変わっても追従しやすくなります。
 
 | 担当 | 主に決めること | 主に触る場所 |
 |---|---|---|
 | app 担当 | FOM、section / overlap 名、各 item に使う推定 package、app 固有の採取・実行方法 | `programs/<code>/run.sh`, `programs/<code>/estimate.sh`, `programs/<code>/list.csv` |
 | 推定担当 | 推定ロジック、必要入力、不足時の fallback / not_applicable、model metadata、assumptions / measurement / confidence / notes | `scripts/estimation/packages/`, `scripts/estimation/section_packages/` |
 | 拠点担当 | system / queue / runner / scheduler の登録、拠点表示情報、接続確認、ジョブ投入条件 | `config/system.csv`, `config/queue.csv`, `config/system_info.csv`, [add-site.md](./add-site.md) |
-| BenchKit 共通層 | current / future flow、Estimate JSON 組み立て、requested / applied package 記録、portal 表示、共通 helper | `scripts/estimation/common.sh`, `scripts/result.sh`, `scripts/result_server/`, `result_server/` |
+| Benchkit 共通層 | current / future flow、Estimate JSON 組み立て、requested / applied package 記録、portal 表示、共通 helper | `scripts/estimation/common.sh`, `scripts/result.sh`, `scripts/result_server/`, `result_server/` |
 | admin / reviewer / approver | 現時点では同じ運用ロールとして、推定関連の変更内容の確認、手動 CI、PR 取込判断を行う | GitHub PR、GitLab manual CI、portal admin |
 
 scaffold や自動生成は、あると便利な支援機能ですが必須ではありません。
@@ -22,7 +22,7 @@ scaffold や自動生成は、あると便利な支援機能ですが必須で�
 ## 境界面として固定するもの
 
 責務分担を保つため、層をまたいで渡してよいものは境界面として定義された artifact / metadata に限定します。
-個別アプリや個別 package の環境変数を、BenchKit 共通層や別 package が知っている前提にしてはいけません。
+個別アプリや個別 package の環境変数を、Benchkit 共通層や別 package が知っている前提にしてはいけません。
 
 ### app wrapper が共通層へ渡すもの
 
@@ -65,9 +65,9 @@ app 固有の kernel 名、入力短縮、launch window、module、compiler、si
 推定 package は、`programs/<code>/` 固有の環境変数や app 名を直接見て分岐しないでください。
 app 固有の対応付けが必要な場合は、app wrapper が `SECTION:` metadata、artifact path、kernel selector などの package が理解できる入力に変換します。
 
-### BenchKit 共通層が担当するもの
+### Benchkit 共通層が担当するもの
 
-BenchKit 共通層は、app や package の内部意味を解釈せず、宣言された共通 metadata を使って処理します。
+Benchkit 共通層は、app や package の内部意味を解釈せず、宣言された共通 metadata を使って処理します。
 
 - current / future flow
 - package dispatch
@@ -109,14 +109,14 @@ BenchKit 共通層は、app や package の内部意味を解釈せず、宣言�
 
 ## 先にざっくり知りたいこと
 
-現時点の BenchKit では、次の整理で見ると分かりやすいです。
+現時点の Benchkit では、次の整理で見ると分かりやすいです。
 
 - 最小の導入経路は `weakscaling`
 - 詳細推定は `qws` が参照実装
 - app 側は「何を測って何を渡すか」を主に担当
 - package 側は「どう推定して、入力不足をどう扱うか」を主に担当
 - model 名、model type、measurement / confidence / notes / assumptions の既定値は package metadata 側へ寄せる方向で整理が進んでいる
-- BenchKit 共通層は current / future の flow、Estimate JSON の組み立て、requested/applied package や applicability の保持を主に担当する
+- Benchkit 共通層は current / future の flow、Estimate JSON の組み立て、requested/applied package や applicability の保持を主に担当する
 - 要求パッケージ / 実適用パッケージ、applicability、UUID / timestamp、portal の list/detail 表示に必要な基本情報は共通層でかなり吸収できている
 
 ## 仕様を見たい場合

--- a/docs/guides/add-site.md
+++ b/docs/guides/add-site.md
@@ -1,6 +1,6 @@
 # 拠点追加手順（拠点管理者向け）
 
-このドキュメントは、BenchKit に新しいベンチマーク実行拠点を追加する手順を拠点管理者向けにまとめたものです。
+このドキュメントは、Benchkit に新しいベンチマーク実行拠点を追加する手順を拠点管理者向けにまとめたものです。
 GitLab Runner と Jacamar-CI をユーザ権限でセットアップし、CI/CD パイプラインからバッチジョブを投入できるようにするまでを説明します。
 
 ## 目次
@@ -14,7 +14,7 @@ GitLab Runner と Jacamar-CI をユーザ権限でセットアップし、CI/CD 
 7. [ランナーの登録](#6-ランナーの登録)
 8. [Jacamar 用ランナーの設定](#7-jacamar-用ランナーの設定)
 9. [config.toml の設定](#8-configtoml-の設定)
-10. [BenchKit への拠点登録](#9-benchkit-への拠点登録)
+10. [Benchkit への拠点登録](#9-benchkit-への拠点登録)
 11. [ランナーの常駐化（systemd user mode）](#10-ランナーの常駐化systemd-user-mode)
 12. [トラブルシューティング](#11-トラブルシューティング)
 
@@ -540,9 +540,9 @@ command_delay = "30s"
 
 ---
 
-## 9. BenchKit への拠点登録
+## 9. Benchkit への拠点登録
 
-ランナーが動作したら、BenchKit リポジトリに拠点情報を追加します。
+ランナーが動作したら、Benchkit リポジトリに拠点情報を追加します。
 
 ### `config/system.csv` にシステムを追加
 
@@ -579,7 +579,7 @@ PBS_NewSystem,qsub,"-q ${queue_group} -l select=${nodes} -l walltime=${elapse} -
 
 GitLab CI では scheduler parameter は `matrix_generate.sh` 実行時に展開されるため、この値は対象 runner だけでなく matrix 生成 job からも見える必要があります。機密 token ではなく、scheduler に表示されてもよい project/account/group 引数だけに使ってください。
 
-定期実行や契機実行で app 条件と project budget / account の対応を管理する場合は、CX Portal の execution profile に寄せます。Portal は system 単位の allocation project ID を扱い、scheduler ごとの具体的な投入書式は BenchKit の CI 生成層で解釈します。`BK_SCHEDULER_EXTRA_ARGS*` は、profile 連携前の bring-up や、profile を使わない site の低レベル escape hatch として残します。
+定期実行や契機実行で app 条件と project budget / account の対応を管理する場合は、CX Portal の execution profile に寄せます。Portal は system 単位の allocation project ID を扱い、scheduler ごとの具体的な投入書式は Benchkit の CI 生成層で解釈します。`BK_SCHEDULER_EXTRA_ARGS*` は、profile 連携前の bring-up や、profile を使わない site の低レベル escape hatch として残します。
 
 Execution profile の正本は OSS repo ではなく、Portal の実行環境に置く site-local SQLite DB です。`RESULT_SERVER_DB_PATH` で指定できます。指定しない場合は Portal data directory 配下の `cx_portal.sqlite3` を使います。
 
@@ -662,9 +662,9 @@ NewSystem,NewSystem,Example CPU,2,64,Example GPU,4,512GB,10
 
 `system.csv` に追加したのに `system_info.csv` を追加しないと、実行自体は通っても UI 側で説明情報が欠けることがあります。
 
-### BenchKit 側の責務分担
+### Benchkit 側の責務分担
 
-拠点追加時に迷いやすい点ですが、BenchKit では設定の置き場所を次のように分けます。
+拠点追加時に迷いやすい点ですが、Benchkit では設定の置き場所を次のように分けます。
 
 - `config/system.csv`
   - システム固有の実行モード、Runner タグ、キュー種別、キューグループを持つ

--- a/docs/guides/developer-reference.md
+++ b/docs/guides/developer-reference.md
@@ -1,6 +1,6 @@
 # Developer Reference
 
-This document is intended for CX Framework and BenchKit developers. It collects structural and operational details that are too implementation-focused for the top-level README.
+This document is intended for CX Framework and Benchkit developers. It collects structural and operational details that are too implementation-focused for the top-level README.
 
 ## Project Structure
 
@@ -38,7 +38,7 @@ benchkit/
 - `programs/<code>/`
   App-specific build, run, and estimation entry points.
 - `benchpark-bridge/`
-  Legacy BenchPark bridge and conversion support. Active BenchPark CI/CD/CB
+  Legacy Benchpark bridge and conversion support. Active Benchpark CI/CD/CB
   result handling has moved to a separate project.
 - `result_server/`
   Flask-based result portal, ingest API, authentication, admin pages, and tests.
@@ -60,7 +60,7 @@ A future "requester" or "applicant" role belongs to the not-yet-implemented requ
 | App maintainer | App-specific build, run, result emission, app-side estimation declarations, and app-local test cases. | `programs/<code>/build.sh`, `programs/<code>/run.sh`, `programs/<code>/estimate.sh`, `programs/<code>/list.csv` |
 | Site maintainer | System registration, queue/scheduler settings, runner setup assumptions, and portal display metadata for systems. | `config/system.csv`, `config/queue.csv`, `config/system_info.csv`, [add-site.md](./add-site.md) |
 | Estimation package maintainer | Estimation algorithm, required inputs, metadata, applicability, fallback, and package-specific assumptions. | `scripts/estimation/packages/`, `scripts/estimation/section_packages/`, [add-estimation-package.md](./add-estimation-package.md) |
-| BenchKit common maintainer | Shared shell helpers, Result/Estimate JSON handoff, portal implementation, common CI checks, and repository-wide contracts. | `scripts/bk_functions.sh`, `scripts/result.sh`, `scripts/estimation/common.sh`, `scripts/result_server/`, `result_server/`, `.github/`, `.gitlab-ci.yml` |
+| Benchkit common maintainer | Shared shell helpers, Result/Estimate JSON handoff, portal implementation, common CI checks, and repository-wide contracts. | `scripts/bk_functions.sh`, `scripts/result.sh`, `scripts/estimation/common.sh`, `scripts/result_server/`, `result_server/`, `.github/`, `.gitlab-ci.yml` |
 | Admin / reviewer / approver | Review, manual CI judgment, PR acceptance, and portal admin operations. In the current workflow these are the same operational role. | GitHub PRs, GitLab manual CI, portal admin pages |
 
 Scaffolding or code generation may be added later as convenience tooling, but it is not required for contributors.
@@ -193,11 +193,11 @@ Data or `*.ncu-rep`.
 - Shared helpers live under `scripts/estimation/`.
 - Re-estimation uses result UUIDs as the main input contract.
 
-## 5. BenchPark Integration
+## 5. Benchpark Integration
 
-- Legacy BenchPark-specific conversion and bridge logic remains under
+- Legacy Benchpark-specific conversion and bridge logic remains under
   `benchpark-bridge/`.
-- Active BenchPark CI/CD/CB result handling is maintained in a separate project. Treat this repository's bridge as legacy and QC-GH200-oriented unless a
+- Active Benchpark CI/CD/CB result handling is maintained in a separate project. Treat this repository's bridge as legacy and QC-GH200-oriented unless a
   future PR explicitly reworks it.
 
 ## Configuration Files
@@ -213,7 +213,7 @@ Data or `*.ncu-rep`.
 
 ## CI Execution Control
 
-BenchKit uses GitHub for source hosting and GitLab CI for benchmark execution.
+Benchkit uses GitHub for source hosting and GitLab CI for benchmark execution.
 
 The current policy keeps pull requests lightweight. Heavy GitLab benchmark CI is not started automatically for pull requests or protected-branch synchronization; maintainers start it explicitly through GitHub Actions when needed.
 
@@ -270,7 +270,7 @@ For production portal deployments:
 
 ### Result Quality Visibility
 
-BenchKit keeps result-quality scoring inside the portal. Normal pull requests should not be blocked on quality scoring beyond producing valid result JSON with a FOM value.
+Benchkit keeps result-quality scoring inside the portal. Normal pull requests should not be blocked on quality scoring beyond producing valid result JSON with a FOM value.
 
 Portal quality visibility currently lives in:
 

--- a/docs/guides/portal-execution-profiles-handoff.md
+++ b/docs/guides/portal-execution-profiles-handoff.md
@@ -60,7 +60,7 @@ Completed:
   into a Result JSON `environment_snapshot` reference block. The Portal indexes
   the snapshot payload by hash in `environment_snapshots` and links received
   results through `environment_snapshot_results`. Result detail pages show the
-  snapshot hash, allocation project ID, scheduler, runner, and BenchKit commit.
+  snapshot hash, allocation project ID, scheduler, runner, and Benchkit commit.
 
 Remaining follow-up:
 
@@ -78,12 +78,12 @@ The current GitLab CI entry point consumes `code`, `system`, and the resolved
 allocation project ID. Execution profile fields such as `exp` remain
 Portal-side matching and audit metadata until the GitLab matrix generator grows
 a matching selector. Scheduler-specific command-line formatting belongs to the
-BenchKit CI generation layer, not to Portal profile records. Allocation project
+Benchkit CI generation layer, not to Portal profile records. Allocation project
 ID is optional. Slurm systems that require an explicit charged project, such as
 RIKYU, derive `--account=<BK_ALLOCATION_PROJECT_ID>` when the value is present,
 unless a site-local `BK_SCHEDULER_EXTRA_ARGS*` override is already set. Systems
-without such a scheduler requirement should leave the field empty. BenchPark
-bridge controls in this repository are legacy; active BenchPark CI/CD/CB result
+without such a scheduler requirement should leave the field empty. Benchpark
+bridge controls in this repository are legacy; active Benchpark CI/CD/CB result
 handling has moved to a separate project.
 
 Node-hour accounting follows the Result JSON `execution_mode` value. `cross`

--- a/docs/guides/profiler-level-reference.md
+++ b/docs/guides/profiler-level-reference.md
@@ -1,6 +1,6 @@
 # Profiler Level Reference
 
-This note complements `bk_profiler` and focuses on the shared level names used by BenchKit.
+This note complements `bk_profiler` and focuses on the shared level names used by Benchkit.
 
 ## Shared Levels
 
@@ -13,7 +13,7 @@ This note complements `bk_profiler` and focuses on the shared level names used b
 - `detailed`
   - detailed profile coverage
 
-These names are BenchKit-level presets. Each profiler adapter defines the concrete behavior behind them.
+These names are Benchkit-level presets. Each profiler adapter defines the concrete behavior behind them.
 For example, `fapp` maps these levels to multiple event-set runs, while `ncu` maps them to Nsight Compute options such as section set, launch count, and NVTX filtering.
 
 ## Current `fapp` Mapping
@@ -52,9 +52,9 @@ Here `both` means text summaries plus CSV reports.
   - `--set full --nvtx`
 
 Default report behavior for `ncu` is `text`.
-BenchKit stores the Nsight Compute raw report under `bk_profiler_artifact/raw/rep1/` and, when import succeeds, a text details page under `bk_profiler_artifact/reports/ncu_import_rep1.txt`.
+Benchkit stores the Nsight Compute raw report under `bk_profiler_artifact/raw/rep1/` and, when import succeeds, a text details page under `bk_profiler_artifact/reports/ncu_import_rep1.txt`.
 
-For GPU estimation bring-up, BenchKit also has an offline NCU plan generator:
+For GPU estimation bring-up, Benchkit also has an offline NCU plan generator:
 `scripts/profiling/generate_ncu_plan.py`.
 It reads an Nsight Systems CUDA kernel summary CSV and writes `kernel_discovery.json`
 plus `ncu_plan.json`.  This is intentionally separate from the `single/simple`
@@ -63,7 +63,7 @@ while `bk_profiler ncu` still owns the concrete Nsight Compute collection.
 
 ## Portal Summary
 
-BenchKit stores profiler metadata in `bk_profiler_artifact/meta.json` inside `padata.tgz`, and also copies a compact summary into `result.json` as `profile_data`.
+Benchkit stores profiler metadata in `bk_profiler_artifact/meta.json` inside `padata.tgz`, and also copies a compact summary into `result.json` as `profile_data`.
 
 This makes it possible to inspect profiler coverage without downloading the archive first.
 

--- a/docs/guides/profiler-support.md
+++ b/docs/guides/profiler-support.md
@@ -1,6 +1,6 @@
 # Profiler Support Guide
 
-このドキュメントは、BenchKit で profiler を使うときの共通 helper 設計をまとめたものです。
+このドキュメントは、Benchkit で profiler を使うときの共通 helper 設計をまとめたものです。
 
 ## Language Policy
 
@@ -8,7 +8,7 @@
 
 ## 1. 基本方針
 
-BenchKit では、アプリ側が
+Benchkit では、アプリ側が
 
 - profiler tool
 - profiler level
@@ -24,7 +24,7 @@ BenchKit では、アプリ側が
 
 を担当する。
 
-つまり、アプリ側は「何を使うか」を決め、BenchKit 共通層は「どうまとめるか」を担当する。
+つまり、アプリ側は「何を使うか」を決め、Benchkit 共通層は「どうまとめるか」を担当する。
 
 ## 2. 共通 API
 
@@ -60,7 +60,7 @@ bk_profiler <tool> [options] -- <command ...>
 
 ## 3. 共通語彙としての level
 
-`single/simple/standard/detailed` は BenchKit の共通語彙として扱う。
+`single/simple/standard/detailed` は Benchkit の共通語彙として扱う。
 ただし、その具体的意味は profiler tool ごとに adapter が定義する。
 
 このため、ある tool では複数の測定 run に対応し、別の tool では単一 run の profiler option や採取範囲に対応してよい。
@@ -82,7 +82,7 @@ bk_profiler <tool> [options] -- <command ...>
 - `detailed` → `both`
 
 ここでいう CSV は `fapp` 固有の CPU performance analysis report を指す。
-BenchKit は「CSV があること」を共通必須にはしない。
+Benchkit は「CSV があること」を共通必須にはしない。
 
 ## 5. `ncu` の level 定義
 
@@ -105,7 +105,7 @@ MPI launcher 経由の GPU application では、既定で `--target-processes al
 ### 5.1 GPU kernel discovery と NCU plan
 
 GPU 性能推定では、アプリ側が kernel 名、launch skip/count、NCU metric list を事前調査して手書きする運用を最終形にしない。
-BenchKit 共通層は、次の段階的 flow を目標にする。
+Benchkit 共通層は、次の段階的 flow を目標にする。
 
 1. profiler overhead のない通常実行で FOM と app section timing を取る。
 2. 軽量な discovery 実行で `nsys stats --report cuda_gpu_kern_sum --format csv` 相当の kernel summary を得る。
@@ -190,7 +190,7 @@ bk_profiler_artifact/
 
 ## 7. `meta.json` の役割
 
-`meta.json` は、archive の内容を BenchKit や推定 package が機械的に判断するための最小 metadata とする。
+`meta.json` は、archive の内容を Benchkit や推定 package が機械的に判断するための最小 metadata とする。
 
 例:
 
@@ -214,7 +214,7 @@ bk_profiler_artifact/
 }
 ```
 
-これにより、将来は BenchKit や estimation package が
+これにより、将来は Benchkit や estimation package が
 
 - `tool`
 - `level`
@@ -241,7 +241,7 @@ bk_profiler_artifact/
 だけを持つ。
 
 GPU アプリごとの kernel window、module、compiler wrapper、短縮 input、profile 回数、archive の分割方針はアプリ wrapper の責務です。
-BenchKit 共通層と推定 package 層は、これらのアプリ固有値を直接解釈しません。
+Benchkit 共通層と推定 package 層は、これらのアプリ固有値を直接解釈しません。
 共通層が扱うのは、app wrapper が生成した `padata*.tgz`、`SECTION:` metadata、`meta.json` などの共通 artifact だけです。
 
 アプリ固有の環境変数は `programs/<code>/build.sh`、`programs/<code>/run.sh`、`programs/<code>/estimate.sh` の内部で、同じアプリ内の重複を減らすために使います。

--- a/docs/guides/salmon-genoa-fx700-handoff.md
+++ b/docs/guides/salmon-genoa-fx700-handoff.md
@@ -27,7 +27,7 @@ The current repository state contains:
 
 ### Expected platform configuration
 
-BenchPark's GENOA definition uses:
+Benchpark's GENOA definition uses:
 
 - module: `system/genoa mpi/openmpi-x86_64`
 - MPI: OpenMPI, currently `/usr/lib64/openmpi`

--- a/docs/repository-history.md
+++ b/docs/repository-history.md
@@ -1,6 +1,6 @@
 # Repository History
 
-BenchKit was originally developed in an internal GitLab repository.
+Benchkit was originally developed in an internal GitLab repository.
 
 It was later relocated to the active GitHub repository with its Git history preserved:
 

--- a/programs/genesis/README.md
+++ b/programs/genesis/README.md
@@ -1,7 +1,7 @@
-# GENESIS BenchKit Integration Notes
+# GENESIS Benchkit Integration Notes
 
 This directory owns GENESIS-specific build, run, profiler, and estimation
-settings. Shared BenchKit CI and estimation packages should not depend on the
+settings. Shared Benchkit CI and estimation packages should not depend on the
 environment variables documented here. They are local conveniences for
 `programs/genesis/*.sh` only; the app wrapper passes information to the shared
 layers through common artifacts such as `results/result`, `SECTION:` metadata,
@@ -134,7 +134,7 @@ used from `run.sh`, `estimate.sh`, or local diagnostics.
 `estimate.sh` should stay limited to GENESIS-owned decisions: section names,
 how to extract section timings from the GENESIS log, and which section package
 each section should use. Package loading, fallback, FOM composition, and
-Estimate JSON construction are handled by the shared BenchKit estimation layer.
+Estimate JSON construction are handled by the shared Benchkit estimation layer.
 
 Current section names are:
 
@@ -190,7 +190,7 @@ which concrete GPU estimator packages to run. This keeps GENESIS-side ownership
 limited to app concepts: section names, timing extraction, artifact candidates,
 and kernel selectors.
 
-BenchKit operators can override the concrete GPU estimator package set with the
+Benchkit operators can override the concrete GPU estimator package set with the
 generic `BK_GPU_KERNEL_ENSEMBLE_PACKAGES` variable when needed. That knob is not
 GENESIS-specific and should not be required for normal GENESIS maintenance.
 

--- a/programs/qws/README.md
+++ b/programs/qws/README.md
@@ -1,14 +1,14 @@
-# QWS BenchKit Integration Notes
+# QWS Benchkit Integration Notes
 
 This directory owns QWS-specific build, run, and estimation settings. Shared
-BenchKit CI, top-level estimation packages, and section packages should not
+Benchkit CI, top-level estimation packages, and section packages should not
 depend on QWS-local variables or dummy section names.
 
 ## Estimation Sections
 
 `programs/qws/estimate.sh` is a reference lightweight app wrapper. It declares
 the section names and the section-package mapping locally, then passes measured
-or synthetic section timings to the common BenchKit estimation layer.
+or synthetic section timings to the common Benchkit estimation layer.
 
 Current reference sections are:
 
@@ -39,7 +39,7 @@ QWS-owned code should decide:
 - how section timings are obtained from QWS output or test fixtures
 - which section package each section should use
 
-Common BenchKit code should handle:
+Common Benchkit code should handle:
 
 - package loading and fallback
 - section and overlap composition

--- a/result_server/app.py
+++ b/result_server/app.py
@@ -79,7 +79,7 @@ def _configure_user_store(app):
 
 def _configure_totp_issuer(app, prefix):
     """Set the issuer label shown by authenticator apps."""
-    base_issuer = os.environ.get("TOTP_ISSUER", "BenchKit")
+    base_issuer = os.environ.get("TOTP_ISSUER", "Benchkit")
     app.config["TOTP_ISSUER"] = f"{base_issuer}-Dev" if prefix == "/dev" else base_issuer
 
 

--- a/result_server/app_dev.py
+++ b/result_server/app_dev.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-BenchKit result server local development launcher.
+Benchkit result server local development launcher.
 
 This script starts the portal without Redis, OTP verification, or API key
 dependencies. It can also generate sample JSON data so the results pages can
@@ -80,9 +80,9 @@ def dev_debug_enabled():
 def _create_stub_totp_manager():
     """Return a stub TOTP module that always validates setup and login."""
     mod = types.ModuleType("utils.totp_manager")
-    mod.ISSUER_NAME = "BenchKit"
+    mod.ISSUER_NAME = "Benchkit"
     mod.generate_secret = lambda: "DEVDEVDEVDEVDEVDEV"
-    mod.generate_totp_uri = lambda s, e, **kw: f"otpauth://totp/BenchKit:{e}?secret={s}"
+    mod.generate_totp_uri = lambda s, e, **kw: f"otpauth://totp/Benchkit:{e}?secret={s}"
     mod.generate_qr_base64 = lambda s, e, **kw: ""
     mod.verify_code = lambda s, c: True
     mod.check_code_reuse = lambda *a, **kw: False
@@ -217,7 +217,7 @@ def create_dev_app(base_dir):
     stub_store = _StubUserStore()
     stub_store.create_user("admin@localhost", "DEVDEVDEVDEVDEVDEV", ["dev", "admin"])
     app.config["USER_STORE"] = stub_store
-    app.config["TOTP_ISSUER"] = f"{os.environ.get('TOTP_ISSUER', 'BenchKit')}-Local"
+    app.config["TOTP_ISSUER"] = f"{os.environ.get('TOTP_ISSUER', 'Benchkit')}-Local"
 
     received_dir = os.path.join(base_dir, "main", "received")
     received_padata_dir = os.path.join(base_dir, "main", "received_padata")
@@ -523,7 +523,7 @@ def generate_sample_data(received_dir):
     }
     samples.append(("gpcnet_72", gpcnet_72, now))
 
-    # 6. Legacy BenchKit-style scalar-only result.
+    # 6. Legacy Benchkit-style scalar-only result.
     benchkit_sample = {
         "code": "scale-letkf",
         "system": "Fugaku",
@@ -555,7 +555,7 @@ def generate_sample_data(received_dir):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="BenchKit Result Server - Dev Mode")
+    parser = argparse.ArgumentParser(description="Benchkit Result Server - Dev Mode")
     parser.add_argument(
         "--host",
         default="127.0.0.1",

--- a/result_server/routes/home.py
+++ b/result_server/routes/home.py
@@ -5,8 +5,6 @@ from flask import render_template
 
 HOME_GUIDE_LINKS = {
     "add_app": "https://github.com/RIKEN-RCCS/benchkit/blob/main/docs/guides/add-app.md",
-    "add_site": "https://github.com/RIKEN-RCCS/benchkit/blob/main/docs/guides/add-site.md",
-    "add_estimation": "https://github.com/RIKEN-RCCS/benchkit/blob/main/docs/guides/add-estimation.md",
     "benchpark_fn_apps": "https://github.com/RIKEN-RCCS/benchpark/blob/FN_apps/User_Guide.md",
     "benchpark_upstream": "https://github.com/llnl/benchpark",
 }

--- a/result_server/templates/admin_execution_profiles.html
+++ b/result_server/templates/admin_execution_profiles.html
@@ -379,7 +379,7 @@
         <label>
             Allocation Project ID
             <input type="text" name="allocation_project_id" placeholder="rkp00010" value="{{ edit_profile.allocation_project_id if edit_profile else '' }}">
-            <span class="field-help">Optional. When set, this ID belongs to one system. BenchKit enables scheduler-specific account options only where supported.</span>
+            <span class="field-help">Optional. When set, this ID belongs to one system. Benchkit enables scheduler-specific account options only where supported.</span>
         </label>
         <label>
             Valid From

--- a/result_server/templates/environment_snapshot_results.html
+++ b/result_server/templates/environment_snapshot_results.html
@@ -34,7 +34,7 @@
     {"label": "Allocation Project ID", "value": summary.allocation_project_id or system_payload.allocation_project_id or "not specified"},
     {"label": "Scheduler", "value": summary.scheduler or scheduler_payload.kind or "N/A"},
     {"label": "Runner", "value": summary.runner or runner_payload.description or "N/A"},
-    {"label": "BenchKit Commit", "value": summary.benchkit_commit or benchkit_payload.commit_hash or "N/A"},
+    {"label": "Benchkit Commit", "value": summary.benchkit_commit or benchkit_payload.commit_hash or "N/A"},
     {"label": "Result Count", "value": snapshot.result_count},
     {"label": "First Seen", "value": snapshot.first_seen_at},
     {"label": "Last Seen", "value": snapshot.last_seen_at},

--- a/result_server/templates/home.html
+++ b/result_server/templates/home.html
@@ -108,35 +108,27 @@ This portal is part of the CX Framework, supporting continuous benchmarking, est
     </section>
 
     <section class="page-card">
-        <h2 class="section-title">User Guide</h2>
+        <h2 class="section-title">User Guide: Add a New Application</h2>
         <p class="section-intro">
-            These guides explain how to add a new benchmark application, enable a new site, attach estimation support, and relate BenchKit work to BenchPark.
+            These guides explain how to add benchmark applications with Benchkit and coordinate Benchpark-based application bring-up.
         </p>
         <div class="home-link-list">
             <a class="home-link-card" href="{{ guide_links.add_app }}" target="_blank" rel="noopener noreferrer">
-                <strong>Add a New Application</strong>
+                <strong>Benchkit Application Guide</strong>
                 <span>Define `build.sh`, `run.sh`, `list.csv`, and result emission for a supported benchmark application.</span>
             </a>
-            <a class="home-link-card" href="{{ guide_links.add_site }}" target="_blank" rel="noopener noreferrer">
-                <strong>Add a New Site</strong>
-                <span>Register new systems, queue templates, display metadata, and site-specific runner setup.</span>
-            </a>
-            <a class="home-link-card" href="{{ guide_links.add_estimation }}" target="_blank" rel="noopener noreferrer">
-                <strong>Add Estimation Support</strong>
-                <span>Connect application-side result emission to estimation inputs and estimation workflows.</span>
-            </a>
             <a class="home-link-card" href="{{ guide_links.benchpark_fn_apps }}" target="_blank" rel="noopener noreferrer">
-                <strong>Application Onboarding</strong>
-                <span>Use the RIKEN-RCCS BenchPark FN_apps branch for FugakuNEXT/CX application bring-up and local validation.</span>
+                <strong>Benchpark FN_apps Onboarding</strong>
+                <span>Use the RIKEN-RCCS Benchpark FN_apps branch for FugakuNEXT/CX application bring-up and local validation.</span>
             </a>
             <a class="home-link-card" href="{{ guide_links.benchpark_upstream }}" target="_blank" rel="noopener noreferrer">
-                <strong>Upstream BenchPark</strong>
-                <span>The RIKEN-RCCS fork is an integration window; upstream BenchPark remains the main upstream project.</span>
+                <strong>Benchpark Upstream Project</strong>
+                <span>The RIKEN-RCCS fork is an integration window; upstream Benchpark remains the main upstream project.</span>
             </a>
             {% if guide_links.discord %}
             <a class="home-link-card" href="{{ guide_links.discord }}" target="_blank" rel="noopener noreferrer">
                 <strong>Questions and Discussion</strong>
-                <span>Use the invitation-only Discord for lightweight questions, onboarding support, and early coordination before opening issues or pull requests.</span>
+                <span>Use the invitation-only Discord for lightweight questions and early application-onboarding coordination before opening issues or pull requests.</span>
             </a>
             {% endif %}
         </div>

--- a/result_server/tests/test_home_template.py
+++ b/result_server/tests/test_home_template.py
@@ -24,15 +24,20 @@ def test_home_page_renders_landing_content(monkeypatch):
     html = response.get_data(as_text=True)
     assert "CX Portal" in html
     assert "Main Entry Points" in html
-    assert "User Guide" in html
+    assert "User Guide: Add a New Application" in html
     assert "GPU Performance Estimation" not in html
     assert "Available Systems" not in html
     assert "At a Glance" not in html
     assert "Start Here" not in html
-    assert "Add a New Site" in html
+    assert "Add a New Site" not in html
+    assert "Add Estimation Support" not in html
     assert "PerfTools" not in html
-    assert "RIKEN-RCCS BenchPark FN_apps branch" in html
-    assert "Upstream BenchPark" in html
+    assert "Benchkit Application Guide" in html
+    assert "Benchpark FN_apps Onboarding" in html
+    assert "Benchpark Upstream Project" in html
+    assert "RIKEN-RCCS Benchpark FN_apps branch" in html
+    assert "https://github.com/RIKEN-RCCS/benchkit/blob/main/docs/guides/add-site.md" not in html
+    assert "https://github.com/RIKEN-RCCS/benchkit/blob/main/docs/guides/add-estimation.md" not in html
     assert "https://github.com/masaaki-kondo/PerfTools" not in html
     assert "https://github.com/RIKEN-RCCS/benchpark/blob/FN_apps/User_Guide.md" in html
     assert "https://github.com/llnl/benchpark" in html
@@ -57,4 +62,5 @@ def test_home_page_renders_discord_link_when_configured(monkeypatch):
     html = response.get_data(as_text=True)
     assert "Questions and Discussion" in html
     assert "invitation-only Discord" in html
+    assert "application-onboarding coordination" in html
     assert "https://discord.gg/example" in html

--- a/result_server/tests/test_usage_route.py
+++ b/result_server/tests/test_usage_route.py
@@ -40,7 +40,7 @@ def app(tmp_dirs):
                 "user@example.com": ["dev"],
             }
         ),
-        totp_issuer="BenchKit-Test",
+        totp_issuer="Benchkit-Test",
     )
 
 

--- a/result_server/utils/estimated_detail_view.py
+++ b/result_server/utils/estimated_detail_view.py
@@ -354,7 +354,7 @@ def _build_applicability_summary(estimate_meta, applicability, breakdown_fallbac
             "tone": "warn",
             "headline": "Estimate succeeded after switching the top-level package.",
             "body": (
-                "The originally requested package did not apply cleanly, so BenchKit stored a successful estimate with "
+                "The originally requested package did not apply cleanly, so Benchkit stored a successful estimate with "
                 "a different top-level package. Compare requested versus applied packages before reusing this result."
             ),
             "highlights": highlights,
@@ -376,7 +376,7 @@ def _build_applicability_summary(estimate_meta, applicability, breakdown_fallbac
             "tone": "danger",
             "headline": "Estimate needs additional measurement data before it can be completed.",
             "body": (
-                "BenchKit stored the attempt, but more input data is required before the requested estimate can be "
+                "Benchkit stored the attempt, but more input data is required before the requested estimate can be "
                 "considered usable."
             ),
             "highlights": highlights,

--- a/result_server/utils/result_detail_view.py
+++ b/result_server/utils/result_detail_view.py
@@ -226,7 +226,7 @@ def _build_environment_rows(environment_snapshot):
         ("Scheduler", summary.get("scheduler") or scheduler.get("kind") or "N/A"),
         ("Runner", summary.get("runner") or runner.get("description") or "N/A"),
         ("CI Job", ci.get("job_name") or "N/A"),
-        ("BenchKit Commit", summary.get("benchkit_commit") or benchkit.get("commit_hash") or "N/A"),
+        ("Benchkit Commit", summary.get("benchkit_commit") or benchkit.get("commit_hash") or "N/A"),
     ])
     modules = toolchain.get("modules") or []
     if modules:

--- a/scripts/bk_functions.sh
+++ b/scripts/bk_functions.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # bk_functions.sh - Common functions for standardized benchmark result output.
-# Source this file from BenchKit bash run/build/estimate scripts.
+# Source this file from Benchkit bash run/build/estimate scripts.
 #
 # Bash is required for the estimation and profiler helpers below.
 
@@ -715,7 +715,7 @@ bk_section_package_requires_special_acquisition() {
 #   Execute the command as-is.
 #
 # Extension point:
-#   If bk_wrap_estimation_data_collection is defined, BenchKit calls it instead.
+#   If bk_wrap_estimation_data_collection is defined, Benchkit calls it instead.
 #   This allows package- or site-dependent wrappers such as ncu, profiler, or
 #   hardware-counter tools to be inserted without pushing that logic into app
 #   estimate.sh files.
@@ -753,7 +753,7 @@ bk_run_estimation_data_collection() {
 
 # Profiler helpers
 #
-# BenchKit keeps the common wrapper in bk_functions.sh, while each application
+# Benchkit keeps the common wrapper in bk_functions.sh, while each application
 # decides whether to use a profiler and which profiler tool / level to request.
 # A level is translated per tool: fapp levels expand to one or more counter
 # event runs, while ncu levels expand to a single Nsight Compute invocation with

--- a/scripts/estimation/packages/instrumented_app_sections_dummy.sh
+++ b/scripts/estimation/packages/instrumented_app_sections_dummy.sh
@@ -91,7 +91,7 @@ bk_estimation_package_metadata() {
       "score": 0.20
     },
     "notes": {
-      "summary": "Reference implementation for application-defined section timing based estimation in BenchKit."
+      "summary": "Reference implementation for application-defined section timing based estimation in Benchkit."
     },
     "assumptions": {
       "scaling_assumption": "weak-scaling",

--- a/scripts/estimation/packages/weakscaling.sh
+++ b/scripts/estimation/packages/weakscaling.sh
@@ -81,7 +81,7 @@ bk_estimation_package_metadata() {
       "score": 0.30
     },
     "notes": {
-      "summary": "Reference implementation for section-wise weak-scaling estimation in BenchKit."
+      "summary": "Reference implementation for section-wise weak-scaling estimation in Benchkit."
     },
     "assumptions": {
       "scaling_assumption": "weak-scaling",

--- a/scripts/estimation/prepare_gpu_lightgbm_ncu_input.py
+++ b/scripts/estimation/prepare_gpu_lightgbm_ncu_input.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Prepare a PerfTools LightGBM_model/1.0 NCU input CSV.
 
-BenchKit's NCU profiler archive stores Nsight Compute raw CSV in the wide
+Benchkit's NCU profiler archive stores Nsight Compute raw CSV in the wide
 metric layout exported by ``ncu --page raw --csv``.  PerfTools LightGBM can read
 wide CSV directly, but it expects a few compatibility columns such as
 ``Duration [ns]`` to already exist.  This bridge normalizes the archive into
@@ -26,7 +26,7 @@ from prepare_gpu_mlp_ncu_input import (
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     input_group = parser.add_mutually_exclusive_group(required=True)
-    input_group.add_argument("--padata", help="BenchKit padata*.tgz archive")
+    input_group.add_argument("--padata", help="Benchkit padata*.tgz archive")
     input_group.add_argument("--raw-csv", help="Nsight Compute raw wide CSV")
     parser.add_argument("--source-gpu", default="H100")
     parser.add_argument("--out-csv", required=True)

--- a/scripts/estimation/prepare_gpu_mlp_ncu_input.py
+++ b/scripts/estimation/prepare_gpu_mlp_ncu_input.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Prepare a PerfTools MLP_NN input CSV from an Nsight Compute archive.
 
-This is a small compatibility bridge for BenchKit.  It converts the wide
+This is a small compatibility bridge for Benchkit.  It converts the wide
 Nsight Compute raw CSV exported from ``profile.ncu-rep`` into the CSV layout
 expected by PerfTools' ``MLP_NN/examples/prepare_data.py``, then fills the
 current v1.5 spec-sheet gaps that otherwise leave required SRC/TGT columns as
@@ -62,7 +62,7 @@ ALLOWED_NAN_COLUMNS = {"Warp Cycles Per Executed Instruction [cycle/inst]"}
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     input_group = parser.add_mutually_exclusive_group(required=True)
-    input_group.add_argument("--padata", help="BenchKit padata*.tgz archive")
+    input_group.add_argument("--padata", help="Benchkit padata*.tgz archive")
     input_group.add_argument("--raw-csv", help="Nsight Compute raw wide CSV")
     parser.add_argument("--perftools-root", required=True)
     parser.add_argument("--source-gpu", default="H100")

--- a/scripts/estimation/section_packages/gpu_kernel_lightgbm_v10.sh
+++ b/scripts/estimation/section_packages/gpu_kernel_lightgbm_v10.sh
@@ -18,7 +18,7 @@ bk_section_package_metadata_gpu_kernel_lightgbm_v10() {
   "required_artifact_kinds": [
     "PerfTools LightGBM_model/1.0 compatible NCU CSV",
     "precomputed prediction CSV",
-    "or BenchKit padata archive with Nsight Compute raw CSV"
+    "or Benchkit padata archive with Nsight Compute raw CSV"
   ],
   "acquisition_mode": "external",
   "output_fields": [

--- a/scripts/estimation/section_packages/gpu_kernel_mlp_v15.sh
+++ b/scripts/estimation/section_packages/gpu_kernel_mlp_v15.sh
@@ -19,7 +19,7 @@ bk_section_package_metadata_gpu_kernel_mlp_v15() {
   "required_artifact_kinds": [
     "PerfTools MLP_NN/v1.5 prepared input CSV",
     "precomputed prediction CSV",
-    "or BenchKit padata archive with Nsight Compute raw CSV"
+    "or Benchkit padata archive with Nsight Compute raw CSV"
   ],
   "acquisition_mode": "external",
   "output_fields": [

--- a/scripts/estimation/section_packages/gpu_kernel_mlp_v21.sh
+++ b/scripts/estimation/section_packages/gpu_kernel_mlp_v21.sh
@@ -18,7 +18,7 @@ bk_section_package_metadata_gpu_kernel_mlp_v21() {
   "required_artifact_kinds": [
     "PerfTools MLP_NN/v2.1 prepared input CSV",
     "precomputed prediction CSV",
-    "or BenchKit padata archive with Nsight Compute raw CSV"
+    "or Benchkit padata archive with Nsight Compute raw CSV"
   ],
   "acquisition_mode": "external",
   "output_fields": [

--- a/scripts/estimation/section_packages/gpu_kernel_mlp_v41.sh
+++ b/scripts/estimation/section_packages/gpu_kernel_mlp_v41.sh
@@ -18,7 +18,7 @@ bk_section_package_metadata_gpu_kernel_mlp_v41() {
   "required_artifact_kinds": [
     "PerfTools MLP_NN/v4.1 prepared input CSV",
     "precomputed prediction CSV",
-    "or BenchKit padata archive with Nsight Compute raw CSV"
+    "or Benchkit padata archive with Nsight Compute raw CSV"
   ],
   "acquisition_mode": "external",
   "output_fields": [

--- a/scripts/job_functions.sh
+++ b/scripts/job_functions.sh
@@ -67,7 +67,7 @@ get_system_queue_group() {
 # Return optional site-local scheduler arguments.
 #
 # Explicit BK_SCHEDULER_EXTRA_ARGS values remain site-local overrides. When no
-# explicit override is set, BenchKit derives scheduler arguments only for
+# explicit override is set, Benchkit derives scheduler arguments only for
 # systems whose submit syntax is known to require the semantic allocation
 # project ID supplied by the Portal.
 get_scheduler_extra_args() {

--- a/scripts/profiling/render_ncu_plan_commands.py
+++ b/scripts/profiling/render_ncu_plan_commands.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Render a BenchKit NCU plan into concrete ``bk_profiler ncu`` commands.
+"""Render a Benchkit NCU plan into concrete ``bk_profiler ncu`` commands.
 
 This helper is deliberately dry-run friendly.  It does not run Nsight Compute;
 it translates ``ncu_plan.json`` profiles into the environment variables and

--- a/scripts/site/setup_trigger_runner.sh
+++ b/scripts/site/setup_trigger_runner.sh
@@ -23,7 +23,7 @@ Usage:
 
 Options:
   --site SITE              Site suffix used for the systemd unit name.
-  --repo-dir DIR           BenchKit checkout. Default: current directory.
+  --repo-dir DIR           Benchkit checkout. Default: current directory.
   --venv DIR               Python venv. Default: $HOME/fugakunext/venv.
   --db PATH                cx_portal.sqlite3 path.
                            Default: $HOME/fugakunext/$SITE/cx_portal.sqlite3.
@@ -95,7 +95,7 @@ if [[ -z "$env_file" ]]; then
   env_file="$HOME/.config/fncx/$site.env"
 fi
 
-[[ -d "$repo_dir/.git" ]] || die "--repo-dir must point at a BenchKit checkout"
+[[ -d "$repo_dir/.git" ]] || die "--repo-dir must point at a Benchkit checkout"
 [[ -x "$venv_dir/bin/python" ]] || die "Python not found: $venv_dir/bin/python"
 [[ -f "$db_path" ]] || die "DB not found: $db_path"
 [[ -f "$env_file" ]] || die "EnvironmentFile not found: $env_file"
@@ -127,7 +127,7 @@ runner_args+=(--schedule-lookback-minutes "$schedule_lookback_minutes")
 info "Writing $service_path"
 {
   printf '[Unit]\n'
-  printf 'Description=BenchKit Portal trigger runner (%s)\n' "$site"
+  printf 'Description=Benchkit Portal trigger runner (%s)\n' "$site"
   printf 'After=network-online.target\n'
   if [[ -n "$service_host" ]]; then
     printf 'ConditionHost=%s\n' "$service_host"
@@ -146,7 +146,7 @@ info "Writing $service_path"
 info "Writing $timer_path"
 {
   printf '[Unit]\n'
-  printf 'Description=Run BenchKit Portal trigger runner (%s)\n' "$site"
+  printf 'Description=Run Benchkit Portal trigger runner (%s)\n' "$site"
   printf '\n[Timer]\n'
   printf 'OnCalendar=%s\n' "$on_calendar"
   printf 'Persistent=true\n'


### PR DESCRIPTION
## Summary
- standardize public/docs spelling to Benchkit and Benchpark
- narrow the home User Guide section to add-a-new-application links
- add GitLab Manual CI allocation_project_id input and pass it as BK_ALLOCATION_PROJECT_ID

## Verification
- git diff --check
- python3 scripts/tests/check_text_integrity.py
- bash -n benchpark-bridge/scripts/ci_generator.sh benchpark-bridge/scripts/common.sh benchpark-bridge/scripts/runner.sh scripts/bk_functions.sh scripts/job_functions.sh scripts/site/setup_trigger_runner.sh
- .venv/bin/python -m pytest result_server/tests

## Audit follow-up
- Addresses the manual GitLab CI BK_ALLOCATION_PROJECT_ID documentation/workflow mismatch.
- Leaves source/container provenance, site-local config separation, and CI supply-chain pinning for separate PRs.