### PR TITLE
Disable QWS dummy estimation data

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -97,9 +97,9 @@ The workflow:
 - 実行後、一時GitLabブランチを削除します。
 - Removes the temporary GitLab branch after the run.
 
-この経路は、`qws` / `MiyabiG` の最小実行で、GitLab pipeline 起動から推定まで動作確認済みです。
+この経路は、`qws` / `MiyabiG` の最小実行で GitLab pipeline 起動まで動作確認済みです。QWS の合成推定 scaffold は本番向けに無効化されているため、現在この組み合わせは推定ジョブを生成しません。
 
-This path has been smoke-tested with a minimal `qws` / `MiyabiG` run through GitLab pipeline execution and estimation.
+This path has been smoke-tested with a minimal `qws` / `MiyabiG` run through GitLab pipeline execution. QWS synthetic estimation scaffolding is disabled for production, so this combination no longer generates estimate jobs.
 
 `target_ref`はupstreamリポジトリ内のbranch、tag、SHAを指定する想定です。forkからのpull requestをGitLab CIで試す場合は、maintainerがまずupstreamリポジトリ側に`ci/pr-123`のような信頼済み一時ブランチを作り、そのブランチに対して`GitLab Manual CI`を実行します。
 

--- a/docs/cx/BENCHKIT_GAP_ANALYSIS.md
+++ b/docs/cx/BENCHKIT_GAP_ANALYSIS.md
@@ -62,10 +62,10 @@ Benchkit already has a solid foundation for continuous benchmarking, especially 
 - portal presentation of benchmark, estimation, and usage data
 - basic source provenance tracking for the top-level application
 
-Continuous estimation has now moved beyond a mere entry point: a common estimation flow, a `weakscaling` reference path, a detailed dummy package for `qws`, and result-provenance handoff have all been implemented.
+Continuous estimation has now moved beyond a mere entry point: a common estimation flow, a `weakscaling` reference path, a detailed section-based package scaffold, and result-provenance handoff have all been implemented. The previous QWS synthetic detailed-estimation scaffold is disabled for production until QWS provides measured section timings and artifacts.
 However, estimation is still not yet broadly deployed across multiple applications, and AI-driven optimization integration remains mostly at the integration-point stage.
 
-As of the current repository survey, Benchkit has multiple benchmark applications with `build.sh`/`run.sh`; `qws` and `genesis` now provide `estimate.sh`, while the remaining applications still need estimation declarations before they can participate in the detailed estimation flow.
+As of the current repository survey, Benchkit has multiple benchmark applications with `build.sh`/`run.sh`; `genesis` provides an active `estimate.sh`, while `qws` keeps a disabled reference scaffold and the remaining applications still need estimation declarations before they can participate in the detailed estimation flow.
 The result portal also already has a meaningful pytest-based test suite under `result_server/tests`, and the repository now has a repo-local Python dependency manifest, a standard portal test entrypoint under `result_server/tests`, and a lightweight GitHub Actions verification path for portal-oriented changes.
 The main GitLab pipeline still intentionally skips heavy benchmark execution when a direct or manually triggered GitLab pipeline sees changes limited to `result_server/**/*` or portal display metadata such as `config/system_info.csv`. Protected-branch synchronization itself uses `ci.skip`, so the dedicated lightweight GitHub Actions path should continue to be kept in sync as portal-side files evolve.
 
@@ -166,7 +166,7 @@ The following are not standalone gaps unless the SPEC explicitly requires them: 
 本質的な機能 GAP は、現時点では次の領域に集約される。
 
 1. 推定 package の metadata discovery、複数 package の選択・fallback・比較導線が未固定である。
-2. `qws` / `genesis` 以外の app へ推定を横展開するための `estimate.sh` 宣言 API と共通実行契約がまだ十分に固まっていない。
+2. `genesis` 以外の app へ推定を横展開するための `estimate.sh` 宣言 API と共通実行契約がまだ十分に固まっていない。`qws` の合成 scaffold は本番向けに無効化済みである。
 3. 再推定の portal 起動、履歴比較、差分表示が end-to-end の利用導線として未完成である。
 4. Result JSON / Estimate JSON / provenance の契約は実装が進んでいるが、app 横断で何を必須・任意・非 git source として扱うかの運用契約が未固定である。
 5. site onboarding と capability summary は docs と portal visibility が中心で、execution profile / trigger runner は導入済みだが、runner / scheduler / queue 条件を自動確認して運用判断に使う導線はまだ弱い。
@@ -180,7 +180,7 @@ The essential functional gaps currently concentrate in estimation-package discov
 | ベンチマーク実行定義 | アプリごとの build/run/list を保持し、継続実行可能であること | `programs/*` に `build.sh` `run.sh` `list.csv`、一部 `estimate.sh` がある。追加や修正は既存例を見ながら行う運用が中心である | 機能 GAP として残るのは、将来の申請・承認 workflow から app / run 条件変更へ接続する導線が未実装であること。責務境界や置き場所は既存 guide / spec で定義できる | 申請・承認・AI 連携の前提になる | 高 |
 | CI ジョブ生成 | system と queue 情報を使って CI 実行を生成すること | `matrix_generate.sh` と `job_functions.sh` が実装済み。`add-site.md` に `system.csv` / `queue.csv` / `system_info.csv` の責務分担、接続確認順序、障害切り分け、onboarding checklist も整理された。portal の `/results/usage` では queue 定義抜けや `system_info.csv` 未登録を軽く確認できる。さらに公開 `system_info.csv` が `system.csv` と `queue.csv` に対応することは `result_server/tests/check_site_config.py` で CI preflight 化済み。Portal execution profile は allocation project ID を解決し、manual / scheduled / repo-ref trigger は GitLab pipeline trigger に接続済みである | site ごとの capability summary と、runner / scheduler / queue 条件を運用判断へつなぐ自動 validation が未実装。profile と使用量・実行履歴を横断する運用 view はまだ弱い。app support matrix は visibility 扱いであり、SPEC が gate を求めるまでは GAP としない | 拠点追加、予算管理、申請フォームの自動化に影響 | 高 |
 | 結果正規化 | `run.sh` 出力を Result JSON に正規化すること | `bk_emit_result`、`bk_emit_section`、`bk_emit_overlap`、`result.sh` が実装済み。portal 側では一覧の quality badge と詳細の `Quality` セクションで `source_info`、`fom_breakdown`、推定入力参照の有無を軽く確認でき、`/results/usage` では最新 result ベースの current-state も見られる | app 横断で Result JSON の必須・任意 field、provenance、estimation input 参照をどう扱うかの契約と validation 導線が未固定 | 推定、可視化、AI 診断の入力契約に直結 | 高 |
-| 性能推定 | Result JSON から Estimate JSON を生成し、可視化可能であること | `scripts/estimation/common.sh`、`scripts/estimation/run.sh`、`scripts/result_server/send_estimate.sh`、`estimated` 画面あり。`qws` と `genesis` では `weakscaling` や詳細ダミー推定、section ごとの package 指定、補助データ参照、section-level fallback、requested/applied package 識別、top-level applicability end state、推定元 result と推定結果自体の UUID / timestamp 保持まで動作する | 横展開はまだ `qws` / `genesis` 中心。複数 detailed package の本実装、再推定比較運用、他 app への適用が未完成 | AI 駆動、将来機評価、継続的フィードバックの基盤になる | 最優先 |
+| 性能推定 | Result JSON から Estimate JSON を生成し、可視化可能であること | `scripts/estimation/common.sh`、`scripts/estimation/run.sh`、`scripts/result_server/send_estimate.sh`、`estimated` 画面あり。`genesis` では `weakscaling`、section ごとの package 指定、補助データ参照、section-level fallback、requested/applied package 識別、top-level applicability end state、推定元 result と推定結果自体の UUID / timestamp 保持まで動作する。`qws` の合成詳細推定 scaffold は本番向けに無効化済みである | 横展開はまだ `genesis` 中心。QWS は実測 section timing / artifact が入るまで推定対象外。複数 detailed package の本実装、再推定比較運用、他 app への適用が未完成 | AI 駆動、将来機評価、継続的フィードバックの基盤になる | 最優先 |
 | 推定結果表示 | Estimate JSON を一覧・詳細で表示できること | `result_server/routes/estimated.py` とテンプレートが実装済み。requested/applied package、applicability、estimate UUID の基本表示に加えて、HTML detail で current / future breakdown、section / overlap 単位の fallback / package applicability まで表示できる。home からの導線も整理済みで、未認証時は login required であることも入口で分かる | compare UI、`not_applicable` の説明補助、複数 estimate 間の差分把握はまだ弱い | 推定運用を本格化すると重要度が上がる | 高 |
 | 使用量集計 | 実行使用量を集計し、運用判断に使えること | `node_hours.py` と `/results/usage` が実装済み。node-hour 集計に加えて、登録済み system と app の対応状況を `list.csv` および `build.sh` / `run.sh` の検出に基づく coverage matrix で確認できる。さらに `system.csv` / `queue.csv` / `system_info.csv` の軽い診断、partial support、最新 result ベースの quality / source tracking current-state も表示できる | profile の allocation project ID、実行要求、runner、使用量履歴の結び付きや、site capability を使用量判断へつなぐ導線が未実装 | 多拠点運用と予算管理の核になる | 高 |
 | ソース出自情報 | 最上位アプリケーションの commit hash を追跡すること | `bk_fetch_source` と `source_info` が実装済み。portal 側でも `/results/usage` に最新 result ベースの `source_status`、`source_type`、`source_reference`、不足 field が出せる | git source provenance の app 横断適用と、archive/file など非 git source の `source_reference` 契約・validation semantics が未固定 | 推定比較、AI 最適化、回帰分析の再現性に直結 | 高 |
@@ -283,15 +283,18 @@ Once the estimation specification is clarified, many other design decisions beco
 - 推定モデルの種別と識別方法
 - 再推定のトリガ、履歴、比較可能性と表示導線
 
-現状は `qws` と `genesis` が先行 app として、
+現状は `genesis` が active な先行 app として、
 
 - `weakscaling`
 - `instrumented_app_sections_dummy`
+- app log 由来の section timing
+- NCU profile archive と section artifact の紐付け
 - 推定元 result の UUID / timestamp 引き回し
 - side ごとの `model` 表現
 
 まで動作確認済みである。
-したがって、入口確認段階はすでに超えており、次はこの形をさらに他 app に横展開できるよう引き上げる必要がある。
+`qws` は合成 section timing / dummy artifact scaffold を残しているが、`estimate.disabled` により本番の推定対象から外している。
+したがって、入口確認段階はすでに超えており、次は GENESIS で進んだ責務分離と artifact 連携を他 app に横展開できるよう引き上げる必要がある。
 
 #### 5.1.1 推定機構の実装 GAP 再調査 / Re-Survey of Estimation Implementation Gaps
 
@@ -299,17 +302,17 @@ Once the estimation specification is clarified, many other design decisions beco
 
 | 項目 | 仕様上の期待 | 現状実装 | GAP | 優先度 |
 |---|---|---|---|---|
-| 共通推定エントリ | app 側 `estimate.sh` を薄くし、共通呼び出し順を持つこと | `scripts/estimation/common.sh` と package 呼び出し型の `qws/estimate.sh` / `genesis/estimate.sh` がある | 他 app への横展開が未着手。`estimate.sh` 内の宣言ブロックの共通 API も未固定 | 最優先 |
+| 共通推定エントリ | app 側 `estimate.sh` を薄くし、共通呼び出し順を持つこと | `scripts/estimation/common.sh` と package 呼び出し型の `genesis/estimate.sh` がある。`qws/estimate.sh` は合成データ scaffold として残すが `estimate.disabled` で本番無効化している | 他 app への横展開が未着手。`estimate.sh` 内の宣言ブロックの共通 API も未固定 | 最優先 |
 | `weakscaling` package | section ごとの時間を app 側が出し、`identity` と `logp` で weak scaling を構成できること | `weakscaling` を実装済み。`identity` / `logp` を current 側で適用し、unsupported な section package は fallback できる | 他 app への横展開と、より明示的な package discovery は未完 | 高 |
 | 適用可能性判定 | 不足入力を `applicable/fallback/not_applicable/needs_remeasurement` で扱うこと | `weakscaling` と `instrumented_app_sections_dummy` でこれらを扱える。Estimate JSON でも requested / applied package、fallback、`applicable` / `partially_applicable` / `fallback` / `not_applicable` を表現でき、estimated detail でも section / overlap 単位に表示できる | 複数 detailed package 間の分岐、より細かい fallback 選択、compare UI 側の見せ方は未実装 | 高 |
 | package metadata | package 名、版、required inputs、fallback policy を持つこと | `weakscaling` / 詳細ダミーとも最小 metadata を持つ。`weakscaling` の `method_class` は `minimum` に整理された | richer metadata を discovery や UI に活かす実装がまだ無い | 中 |
 | section ごとの package 指定 | 区間ごとに推定 package を割り当てられること | `bk_emit_section` / `bk_emit_overlap` から Result JSON に `estimation_package` を載せられ、`instrumented_app_sections_dummy` でも dispatch に利用している。`weakscaling` では unsupported package を fallback する | 他 app への横展開と package discovery の整理が未完 | 最優先 |
-| app 側推定宣言 | app 側が実行前に section / overlap と `estimation_package` をまとめて宣言できること | `qws/estimate.sh` と `genesis/estimate.sh` で current / future package、target system / nodes、future 側 section / overlap 宣言を持てる | 宣言 API の更なる標準化、既定値の与え方、他 app への横展開は未完 | 最優先 |
+| app 側推定宣言 | app 側が実行前に section / overlap と `estimation_package` をまとめて宣言できること | `genesis/estimate.sh` で current / future package、target system / nodes、future 側 section / overlap 宣言を持てる。`qws/estimate.sh` は無効化済み scaffold としてのみ残している | 宣言 API の更なる標準化、既定値の与え方、他 app への横展開は未完 | 最優先 |
 | 追加採取実行 | 通常実行と別に詳細推定入力の採取だけを共通入口から追加実行できること | `bk_run_estimation_data_collection` 方向は整理済み | shell API、分岐条件、保存処理との接続は未実装 | 最優先 |
-| section ごとの補助データ参照 | tgz 等の補助データを section ごとに紐付けられること | `qws` では section / overlap ごとに `artifacts` を Result JSON に保持し、詳細ダミー package でも利用している | 他 app への横展開と artifact 収集方式の一般化が未着手 | 高 |
+| section ごとの補助データ参照 | tgz 等の補助データを section ごとに紐付けられること | `genesis` では NCU profile archive を section artifact として Result JSON に保持する。`qws` の dummy artifact 生成は本番向けに無効化済み | 他 app への横展開と artifact 収集方式の一般化が未着手 | 高 |
 | overlap 推定 | overlap を独立した推定部品として扱えること | Result JSON で保持でき、詳細ダミー package でも overlap の `bench_time/time` は扱える | overlap 専用 package や複数方式切替は未実装 | 中 |
-| 詳細推定 package | `instrumented_app_sections` など取得方式別 package を持てること | `instrumented_app_sections_dummy` を `qws` 向け参照実装として実装済み | 実測区間時間や外部ツール区間時間を使う本格 package は未実装 | 最優先 |
-| 複合推定 | section ごとに異なる方式を合成できること | `qws` と `instrumented_app_sections_dummy` で section ごとの package 指定、artifact 参照、section package dispatch、section-level fallback を実装済み | 複数実アプリへの適用、本格 package 実装、より一般的な合成規則は未着手 | 高 |
+| 詳細推定 package | `instrumented_app_sections` など取得方式別 package を持てること | `instrumented_app_sections_dummy` は参照scaffoldとして実装済み。ただし QWS からの合成入力生成は本番向けに無効化済み | 実測区間時間や外部ツール区間時間を使う本格 package は未実装 | 最優先 |
+| 複合推定 | section ごとに異なる方式を合成できること | section ごとの package 指定、artifact 参照、section package dispatch、section-level fallback の基盤は実装済み。QWS dummy input は本番向けに無効化済みで、GENESISのprofile artifact連携が実運用寄りの先行例である | 複数実アプリへの適用、本格 package 実装、より一般的な合成規則は未着手 | 高 |
 | 推定 provenance | 推定元 result と推定結果自体の出自情報を保持すること | 推定元 result の UUID / timestamp、requested/applied package、推定結果自体の UUID / timestamp を Estimate JSON に保持できる。result JSON 側にも server UUID / timestamp を保持できる | compare UI や再推定導線での活用は未整理 | 中 |
 | 再推定 | `estimate_result_uuid` 起点で再推定し比較可能にすること | 再推定専用 trigger、child pipeline、result / estimate / estimation input の再取得、`reestimation` ブロック付与、CI 上での保存完了まで動作する | compare UI、portal からの起動導線、表示上の差分把握が未完 | 高 |
 | 推定結果表示 | model / assumptions / applicability を表示できること | estimated 画面で requested/applied package、applicability、estimate UUID などの基本表示に加えて、detail 画面で current / future breakdown と section / overlap 単位の fallback / applicability を表示できる | 比較表示、`not_applicable` の説明補助、再推定との横並び表示は未整備 | 中 |
@@ -318,7 +321,7 @@ Once the estimation specification is clarified, many other design decisions beco
 
 1. `scripts/estimation/common.sh` を中心とした共通呼び出しと Estimate JSON 出力
 2. `weakscaling` による `identity` / `logp` ベースの最小推定経路
-3. `instrumented_app_sections_dummy` による区間時間ベース詳細ダミー推定
+3. GENESIS による app log 由来の section timing と GPU profiler artifact を使った詳細推定経路
 4. 推定元 result UUID / timestamp の引き回し
 
 逆に、まだ核ではないが後で効くものは以下である。
@@ -333,7 +336,7 @@ Once the estimation specification is clarified, many other design decisions beco
 
 推定機構について、次の実装順を推奨する。
 
-1. `qws` / `genesis` で得た推定方式を他 app へ横展開する
+1. `genesis` で得た推定方式を他 app へ横展開する
 2. `not_applicable` と compare を含む推定差分 UI を portal で見やすくする
 3. 複数 detailed package 間の fallback と discovery を整理する
 4. その後に再推定比較 UI と portal 起動導線へ進む
@@ -375,7 +378,7 @@ CI 関連の残作業は、「仕組みを新規に置く」段階から「対�
 
 1. `result-server-tests.yml` の path filter は、`result_server/**/*`、`scripts/bk_functions.sh`、`scripts/result.sh`、`scripts/result_server/**`、profile-data shell tests、`programs/**/list.csv`、`programs/**/build.sh`、`programs/**/estimate.sh`、`programs/**/run.sh`、`config/system.csv`、`config/queue.csv`、`config/system_info.csv`、`requirements-result-server.txt` を対象にする形へ更新済みである。
 2. `.gitlab-ci.yml` の heavy benchmark skip rules と `docs/ci.md` の説明は、root Markdown、`docs/**/*`、`result_server/**/*`、`requirements-result-server.txt`、`config/system_info.csv` の skip 対象について同期済みである。一方、`scripts/bk_functions.sh`、`scripts/result.sh`、`scripts/result_server/**` は GitHub Actions の lightweight verification 対象でもあるが、直接または手動で GitLab pipeline を起動した場合は `.gitlab-ci.yml` の `scripts/**/*` rule により benchmark-affecting として実行される。
-3. 手動 GitLab CI は、`qws` / `MiyabiG` の最小実行で GitLab pipeline 起動から推定まで確認済みである。Pipeline API variables は JSON payload で渡す。
+3. 手動 GitLab CI は、`qws` / `MiyabiG` の最小実行で GitLab pipeline 起動まで確認済みである。QWS の合成推定 scaffold は本番向けに無効化されており、この組み合わせでは推定ジョブを生成しない。Pipeline API variables は JSON payload で渡す。
 4. protected branch sync は、`ci.skip` により GitLab mirror 更新時に GitLab CI が自動起動しないことを運用上確認済みである。
 
 docs-only / portal-only / benchmark-code / CI-config の代表的な変更セットは、`docs/ci.md` の examples として整理済みである。
@@ -403,7 +406,7 @@ AI 駆動最適化連携は、PoC を含む試行錯誤を前提として早め�
 
 1. `estimate.sh` の宣言ブロックと共通補助を整える
 2. `bk_run_estimation_data_collection` の共通入口を整える
-3. `qws` 以外に 1 から 2 本の app へ推定を横展開する
+3. `genesis` 以外に 1 から 2 本の app へ推定を横展開する
 4. `result_server` 用の lightweight CI、標準 test entrypoint、依存 manifest を portal 周辺の変更に追従させる
 5. ローカル再現手順と CI path filter の対象範囲を定期的に見直す
 6. Estimate JSON と portal 表示を section / overlap 詳細まで整える

--- a/docs/cx/ESTIMATE_JSON_SPEC.md
+++ b/docs/cx/ESTIMATE_JSON_SPEC.md
@@ -137,17 +137,17 @@ In addition, `target_nodes` represents the estimated node count on each system s
 
 ```json
 {
-  "code": "qws",
-  "exp": "CASE0",
+  "code": "genesis",
+  "exp": "p8",
   "current_system": {
     "system": "Fugaku",
     "fom": 123.456,
-    "target_nodes": "4",
+    "target_nodes": "1",
     "scaling_method": "measured",
     "benchmark": {
       "system": "Fugaku",
       "fom": 123.456,
-      "nodes": "4",
+      "nodes": "1",
       "numproc_node": "12",
       "timestamp": "2026-04-03 12:34:56",
       "uuid": "00000000-0000-0000-0000-000000000000"
@@ -156,12 +156,12 @@ In addition, `target_nodes` represents the estimated node count on each system s
   "future_system": {
     "system": "FugakuNEXT",
     "fom": 246.912,
-    "target_nodes": "4",
+    "target_nodes": "1",
     "scaling_method": "scale-mock",
     "benchmark": {
       "system": "MiyabiG",
       "fom": 123.456,
-      "nodes": "4",
+      "nodes": "1",
       "numproc_node": "1",
       "timestamp": "2026-04-03 12:34:56",
       "uuid": "11111111-1111-1111-1111-111111111111"
@@ -235,8 +235,8 @@ In addition, Benchkit may retain result-compatible CI provenance at the top leve
     "source_result": {
       "uuid": "00000000-0000-0000-0000-000000000000",
       "timestamp": "2026-04-03 12:34:56",
-      "code": "qws",
-      "exp": "CASE0",
+      "code": "genesis",
+      "exp": "p8",
       "system": "Fugaku",
       "node_count": "1",
       "numproc_node": "4"
@@ -244,8 +244,8 @@ In addition, Benchkit may retain result-compatible CI provenance at the top leve
     "current_source_result": {
       "uuid": "00000000-0000-0000-0000-000000000000",
       "timestamp": "2026-04-03 12:34:56",
-      "code": "qws",
-      "exp": "CASE0",
+      "code": "genesis",
+      "exp": "p8",
       "system": "Fugaku",
       "node_count": "1",
       "numproc_node": "4"
@@ -253,8 +253,8 @@ In addition, Benchkit may retain result-compatible CI provenance at the top leve
     "future_source_result": {
       "uuid": "11111111-1111-1111-1111-111111111111",
       "timestamp": "2026-04-03 12:34:56",
-      "code": "qws",
-      "exp": "CASE0",
+      "code": "genesis",
+      "exp": "p8",
       "system": "MiyabiG",
       "node_count": "1",
       "numproc_node": "1"
@@ -343,7 +343,7 @@ This field stores how the measurement inputs used for estimation were obtained.
     "type": "scaling",
     "name": "scale-mock",
     "version": "0.1",
-    "implementation": "programs/qws/estimate.sh"
+    "implementation": "programs/genesis/estimate.sh"
   }
 }
 ```

--- a/docs/guides/add-estimation-package.md
+++ b/docs/guides/add-estimation-package.md
@@ -33,7 +33,14 @@
 この配置は現時点の約束です。将来、推定 package が増えた場合にディレクトリ名や登録方法を見直す可能性があります。
 そのため、package 固有のロジック、metadata、applicability 判定はこの配下に閉じ、Benchkit 共通層へ app 固有・package 固有の処理を混ぜないようにしてください。
 
-`qws` の詳細ダミー推定では、たとえば次のような分担です。
+現時点の active な app 側参照例は `genesis` です。まず
+[GENESIS Benchkit Integration Notes](../../programs/genesis/README.md) を確認してください。
+GENESIS は app log 由来の section timing と NCU profile archive を section artifact
+として出し、共通 package に推定処理を委ねます。新しい app では、実測 section timing /
+artifact を用意してから同じ責務分担を適用してください。
+
+本番では無効化済みの旧 `qws` 詳細推定 scaffold でも、同じ package 分担を検証していました。
+現行の分担は次の形です。
 
 - top-level
   - `instrumented_app_sections_dummy.sh`

--- a/docs/guides/add-estimation-to-app.md
+++ b/docs/guides/add-estimation-to-app.md
@@ -6,6 +6,12 @@
 - app 側でまず決めるのは、FOM と section / overlap の名前、および各 section / overlap に使う `estimation_package`
 - 採取手順、保存形式、再推定時の復元方法は、共通化できるものから Benchkit 側へ寄せる
 
+詳細推定の active な参照例は GENESIS です。まず
+[GENESIS Benchkit Integration Notes](../../programs/genesis/README.md) を読み、
+`programs/genesis/sections.sh`、`programs/genesis/profile.sh`、
+`programs/genesis/parse_timing.sh`、`programs/genesis/estimate.sh` の分担を見ると、
+`run.sh` / `build.sh` から profile / estimation 固有処理を分離する方向を追いやすいです。
+
 ## 目次
 
 1. [最初に決めること](#1-最初に決めること)
@@ -119,7 +125,8 @@ bk_estimation_write_output "results/estimate_${est_code}_0.json"
 - 各 section / overlap に割り当てる `estimation_package`
 - target system や target nodes の app 既定値
 
-イメージとしては次のようになります。
+イメージとしては次のようになります。ここでは、現在の active な参照例である
+GENESIS の section 名を使っています。
 
 ```bash
 myapp_declare_estimation_layout() {
@@ -128,15 +135,22 @@ myapp_declare_estimation_layout() {
   bk_define_current_estimation_package weakscaling
   bk_define_future_estimation_package instrumented_app_sections_dummy
   bk_define_baseline_system Fugaku
-  bk_define_baseline_exp CASE0
-  bk_define_future_system FutureSystemA
-  bk_define_current_target_nodes 1024
-  bk_define_future_target_nodes 256
+  bk_define_baseline_exp p8
+  bk_define_future_system FugakuNEXT
+  bk_define_current_target_nodes 1
+  bk_define_future_target_nodes 1
 
-  bk_declare_section --side future prepare_rhs half
-  bk_declare_section --side future compute_solver half
-  bk_declare_section --side future allreduce logp
-  bk_declare_overlap --side future compute_hopping,halo_exchange half
+  bk_declare_section --side future pairlist gpu_kernel_ensemble_average
+  bk_declare_section --side future bond identity
+  bk_declare_section --side future angle identity
+  bk_declare_section --side future dihedral identity
+  bk_declare_section --side future pme_real_wait identity
+  bk_declare_section --side future pme_real_inter gpu_kernel_ensemble_average
+  bk_declare_section --side future pme_real_intra gpu_kernel_ensemble_average
+  bk_declare_section --side future pme_recip identity
+  bk_declare_section --side future integrator identity
+  bk_declare_section --side future other identity
+  bk_declare_overlap --side future pme_real_wait,pme_real_inter,pme_real_intra,pme_recip identity
 }
 ```
 
@@ -187,23 +201,24 @@ bk_emit_result \
 ```bash
 bk_emit_declared_section \
   --side future \
-  prepare_rhs 0.42 \
+  pairlist 0.42 \
   >> results/result
 
 bk_emit_declared_section \
   --side future \
-  compute_solver 1.03 \
-  results/estimation_artifacts/compute_solver_papi.tgz \
+  pme_real_inter 1.03 \
+  results/padata_inter.tgz \
   >> results/result
 
 bk_emit_declared_overlap \
   --side future \
-  compute_hopping,halo_exchange 0.23 \
-  results/estimation_artifacts/compute_halo_overlap.json \
+  pme_real_wait,pme_real_inter,pme_real_intra,pme_recip 0.23 \
   >> results/result
 ```
 
-さらに整理を進めるなら、section 時間の配分やダミー artifact 作成のような推定専用処理も `estimate.sh` 側の関数へ寄せ、`run.sh` ではその関数を 1 回呼ぶだけにしてよいです。
+さらに整理を進めるなら、GENESIS のように log から section timing を切り出す処理や
+profiler artifact と section の対応付けを app-local helper へ分離し、`run.sh` では
+その関数を 1 回呼ぶだけにしてよいです。
 
 ここで app 側の主責務は、section 名と `estimation_package` の割当てを明示することです。
 
@@ -239,18 +254,22 @@ myapp_declare_estimation_layout() {
   bk_define_current_estimation_package weakscaling
   bk_define_future_estimation_package instrumented_app_sections_dummy
   bk_define_baseline_system Fugaku
-  bk_define_baseline_exp CASE0
+  bk_define_baseline_exp p8
   bk_define_future_system FugakuNEXT
-  bk_define_current_target_nodes 1024
-  bk_define_future_target_nodes 256
+  bk_define_current_target_nodes 1
+  bk_define_future_target_nodes 1
 
-  bk_declare_section --side future prepare_rhs half
-  bk_declare_section --side future compute_hopping quarter
-  bk_declare_section --side future compute_solver half
-  bk_declare_section --side future halo_exchange quarter
-  bk_declare_section --side future allreduce logp
-  bk_declare_section --side future write_result half
-  bk_declare_overlap --side future compute_hopping,halo_exchange half
+  bk_declare_section --side future pairlist gpu_kernel_ensemble_average
+  bk_declare_section --side future bond identity
+  bk_declare_section --side future angle identity
+  bk_declare_section --side future dihedral identity
+  bk_declare_section --side future pme_real_wait identity
+  bk_declare_section --side future pme_real_inter gpu_kernel_ensemble_average
+  bk_declare_section --side future pme_real_intra gpu_kernel_ensemble_average
+  bk_declare_section --side future pme_recip identity
+  bk_declare_section --side future integrator identity
+  bk_declare_section --side future other identity
+  bk_declare_overlap --side future pme_real_wait,pme_real_inter,pme_real_intra,pme_recip identity
 }
 
 myapp_declare_estimation_layout

--- a/docs/guides/add-estimation.md
+++ b/docs/guides/add-estimation.md
@@ -86,6 +86,7 @@ Benchkit 共通層は、app や package の内部意味を解釈せず、宣言�
 既存アプリに推定を載せたい場合は、こちらから始めてください。
 
 - [add-estimation-to-app.md](./add-estimation-to-app.md)
+- [GENESIS Benchkit Integration Notes](../../programs/genesis/README.md)
 
 主に次が分かります。
 
@@ -93,6 +94,15 @@ Benchkit 共通層は、app や package の内部意味を解釈せず、宣言�
 - `estimate.sh` をどこまで薄くできるか
 - `weakscaling` から詳細推定へどう広げるか
 - 今後の改善
+
+GENESIS は、現時点で一番実運用に近い推定の参照例です。特に次の分担を見ると、
+app 側に残す責務と Benchkit 共通層へ寄せる責務を追いやすくなります。
+
+- `programs/genesis/README.md`: profile / estimation 全体の意図と運用メモ
+- `programs/genesis/sections.sh`: section / overlap 宣言と Result JSON へ渡す timing metadata
+- `programs/genesis/profile.sh`: NCU 採取、artifact 登録、section との対応付け
+- `programs/genesis/parse_timing.sh`: GENESIS log から section timing を抽出する app-local parser
+- `programs/genesis/estimate.sh`: 共通推定 flow を呼ぶ薄い entrypoint
 
 ### 推定 package 開発者
 
@@ -112,7 +122,8 @@ Benchkit 共通層は、app や package の内部意味を解釈せず、宣言�
 現時点の Benchkit では、次の整理で見ると分かりやすいです。
 
 - 最小の導入経路は `weakscaling`
-- 詳細推定は `qws` が参照実装
+- 詳細推定の参照例は `genesis` を主に見る。まず [GENESIS Benchkit Integration Notes](../../programs/genesis/README.md) を確認する
+- 古い `qws` scaffold は本番では無効化済みで、実測 section timing / artifact を入れるまでは推定対象にしない
 - app 側は「何を測って何を渡すか」を主に担当
 - package 側は「どう推定して、入力不足をどう扱うか」を主に担当
 - model 名、model type、measurement / confidence / notes / assumptions の既定値は package metadata 側へ寄せる方向で整理が進んでいる

--- a/programs/qws/README.md
+++ b/programs/qws/README.md
@@ -7,8 +7,9 @@ depend on QWS-local variables or dummy section names.
 ## Estimation Sections
 
 `programs/qws/estimate.sh` is a reference lightweight app wrapper. It declares
-the section names and the section-package mapping locally, then passes measured
-or synthetic section timings to the common Benchkit estimation layer.
+the section names and the section-package mapping locally. QWS production runs
+do not emit section timing metadata until those timings are measured by QWS
+itself.
 
 Current reference sections are:
 
@@ -27,9 +28,11 @@ The reference overlap is:
 compute_hopping,halo_exchange
 ```
 
-The current QWS section timings are synthetic fractions of the benchmark FOM.
-They are useful for exercising the common estimation framework and portal
-display, but they are not a substitute for app-side timers from QWS itself.
+Previous test scaffolding emitted synthetic section timings and dummy artifacts
+as fractions of the benchmark FOM. That path is disabled for production because
+fake section data is easy to confuse with measured application data.
+The `estimate.disabled` marker also prevents CI matrix generation from adding
+QWS estimate jobs on estimate-target systems such as MiyabiG and RC_GH200.
 
 ## Responsibility Split
 

--- a/programs/qws/estimate.disabled
+++ b/programs/qws/estimate.disabled
@@ -1,0 +1,3 @@
+QWS estimation is disabled for production until QWS emits real app-side section
+timings and measured estimation artifacts. The old synthetic section timing and
+dummy artifact scaffold remains commented out in estimate.sh for reference.

--- a/programs/qws/estimate.sh
+++ b/programs/qws/estimate.sh
@@ -22,6 +22,13 @@ qws_results_dir() {
   fi
 }
 
+qws_estimation_enabled() {
+  local root
+
+  root=$(qws_repo_root)
+  [[ ! -f "${root}/programs/qws/estimate.disabled" ]]
+}
+
 qws_declare_estimation_layout() {
   bk_clear_estimation_defaults
   bk_clear_estimation_declarations
@@ -44,38 +51,49 @@ EOF
 )"
 }
 
-qws_create_dummy_estimation_artifact() {
-  local rel_path="$1"
-  local content="$2"
-  local full_path
+# Disabled for production: these helpers created synthetic section timings and
+# dummy estimation artifacts. Keep the scaffold here as a reminder of the old
+# test fixture, but do not emit fake values into QWS results.
+# qws_create_dummy_estimation_artifact() {
+#   local rel_path="$1"
+#   local content="$2"
+#   local full_path
+#
+#   full_path="$(qws_results_dir)/${rel_path}"
+#   mkdir -p "$(dirname "$full_path")"
+#   printf '%s\n' "$content" > "$full_path"
+# }
+#
+# qws_emit_estimation_data_from_fom() {
+#   local fom="$1"
+#
+#   qws_create_dummy_estimation_artifact "estimation_artifacts/prepare_rhs_interval.json" "{\"section\":\"prepare_rhs\",\"kind\":\"interval_time\"}"
+#   qws_create_dummy_estimation_artifact "estimation_artifacts/compute_hopping_papi.tgz" "dummy papi archive for compute_hopping"
+#   qws_create_dummy_estimation_artifact "estimation_artifacts/compute_solver_papi.tgz" "dummy papi archive for compute_solver"
+#   qws_create_dummy_estimation_artifact "estimation_artifacts/halo_exchange_trace.tgz" "dummy mpi trace archive for halo_exchange"
+#   qws_create_dummy_estimation_artifact "estimation_artifacts/allreduce_trace.tgz" "dummy collective trace archive for allreduce"
+#   qws_create_dummy_estimation_artifact "estimation_artifacts/write_result_interval.json" "{\"section\":\"write_result\",\"kind\":\"interval_time\"}"
+#   qws_create_dummy_estimation_artifact "estimation_artifacts/compute_halo_overlap.json" "{\"overlap\":[\"compute_hopping\",\"halo_exchange\"],\"kind\":\"overlap_time\"}"
+#
+#   bk_emit_declared_fractional_items --side future "$fom" "$(cat <<'EOF'
+# section|prepare_rhs|0.16|results/estimation_artifacts/prepare_rhs_interval.json
+# section|compute_hopping|0.28|results/estimation_artifacts/compute_hopping_papi.tgz
+# section|compute_solver|0.18|results/estimation_artifacts/compute_solver_papi.tgz
+# section|halo_exchange|0.18|results/estimation_artifacts/halo_exchange_trace.tgz
+# section|allreduce|0.16|results/estimation_artifacts/allreduce_trace.tgz
+# section|write_result|0.08|results/estimation_artifacts/write_result_interval.json
+# overlap|compute_hopping,halo_exchange|0.04|results/estimation_artifacts/compute_halo_overlap.json
+# EOF
+# )"
+# }
 
-  full_path="$(qws_results_dir)/${rel_path}"
-  mkdir -p "$(dirname "$full_path")"
-  printf '%s\n' "$content" > "$full_path"
-}
-
-qws_emit_estimation_data_from_fom() {
-  local fom="$1"
-
-  qws_create_dummy_estimation_artifact "estimation_artifacts/prepare_rhs_interval.json" "{\"section\":\"prepare_rhs\",\"kind\":\"interval_time\"}"
-  qws_create_dummy_estimation_artifact "estimation_artifacts/compute_hopping_papi.tgz" "dummy papi archive for compute_hopping"
-  qws_create_dummy_estimation_artifact "estimation_artifacts/compute_solver_papi.tgz" "dummy papi archive for compute_solver"
-  qws_create_dummy_estimation_artifact "estimation_artifacts/halo_exchange_trace.tgz" "dummy mpi trace archive for halo_exchange"
-  qws_create_dummy_estimation_artifact "estimation_artifacts/allreduce_trace.tgz" "dummy collective trace archive for allreduce"
-  qws_create_dummy_estimation_artifact "estimation_artifacts/write_result_interval.json" "{\"section\":\"write_result\",\"kind\":\"interval_time\"}"
-  qws_create_dummy_estimation_artifact "estimation_artifacts/compute_halo_overlap.json" "{\"overlap\":[\"compute_hopping\",\"halo_exchange\"],\"kind\":\"overlap_time\"}"
-
-  bk_emit_declared_fractional_items --side future "$fom" "$(cat <<'EOF'
-section|prepare_rhs|0.16|results/estimation_artifacts/prepare_rhs_interval.json
-section|compute_hopping|0.28|results/estimation_artifacts/compute_hopping_papi.tgz
-section|compute_solver|0.18|results/estimation_artifacts/compute_solver_papi.tgz
-section|halo_exchange|0.18|results/estimation_artifacts/halo_exchange_trace.tgz
-section|allreduce|0.16|results/estimation_artifacts/allreduce_trace.tgz
-section|write_result|0.08|results/estimation_artifacts/write_result_interval.json
-overlap|compute_hopping,halo_exchange|0.04|results/estimation_artifacts/compute_halo_overlap.json
-EOF
-)"
-}
+if ! qws_estimation_enabled; then
+  echo "QWS estimation is disabled until real section timings and artifacts are available." >&2
+  if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
+    return 0 2>/dev/null || exit 0
+  fi
+  exit 0
+fi
 
 source scripts/bk_functions.sh
 source scripts/estimation/common.sh

--- a/programs/qws/run.sh
+++ b/programs/qws/run.sh
@@ -9,8 +9,10 @@ export OMP_NUM_THREADS=$nthreads
 source "${PWD}/scripts/bk_functions.sh"
 qws_profiler_tool=$(bk_resolve_profiler_tool fapp QWS_PROFILER_TOOL)
 qws_profiler_level=$(bk_resolve_profiler_level detailed QWS_PROFILER_LEVEL)
-# Load estimation helpers used when emitting section/overlap metadata.
-source "${PWD}/programs/qws/estimate.sh"
+# QWS synthetic estimation metadata is disabled for production runs. Keep
+# QWS result output limited to measured benchmark FOM until QWS emits real
+# app-side section timings and artifacts.
+# source "${PWD}/programs/qws/estimate.sh"
 
 mkdir -p results && > results/result
 
@@ -23,17 +25,21 @@ print_results() {
     local fom
     fom=$(grep etime "$outfile" | awk 'NR==2{printf("%5.3f\n",$5)}')
     bk_emit_result --fom "$fom" --fom-unit s --fom-version DDSolverJacobi --exp "$exp" --nodes "$nodes" --numproc-node "$np" --nthreads "$nthreads"
-    qws_emit_estimation_data_from_fom "$fom"
+    # Disabled: this emitted synthetic section timings and dummy estimation
+    # artifacts. Re-enable only after QWS provides real app-side timings.
+    # qws_emit_estimation_data_from_fom "$fom"
 }
 
-emit_qws_dummy_padata() {
-    mkdir -p pa
-    echo dummy > ./pa/padat.0
-    echo dummy > ./pa/padat.1
-    echo dummy > ./pa/padat.2
-    echo dummy > ./pa/padat.3
-    tar -czf "$1" ./pa
-}
+# Disabled: dummy PA archives are confusing on the production portal because
+# they look like downloadable measurement artifacts.
+# emit_qws_dummy_padata() {
+#     mkdir -p pa
+#     echo dummy > ./pa/padat.0
+#     echo dummy > ./pa/padat.1
+#     echo dummy > ./pa/padat.2
+#     echo dummy > ./pa/padat.3
+#     tar -czf "$1" ./pa
+# }
 
 [[ -d qws ]] || git clone https://github.com/RIKEN-LQCD/qws.git
 
@@ -56,8 +62,8 @@ case "$system" in
                 print_results output.${PJM_JOBID}/0/2/stdout.2.0 CASE1 2 >> ../results/result
                 if bk_profiler_enabled "$qws_profiler_tool"; then
                     bk_profiler "$qws_profiler_tool" --level "$qws_profiler_level" --archive ../results/padata0.tgz --raw-dir pa -- mpiexec -n 1 ./main 32 6 4 3 1 1 1 1 -1 -1 6 50 > CASE0.profile
-                else
-                    emit_qws_dummy_padata ../results/padata0.tgz
+                # else
+                #     emit_qws_dummy_padata ../results/padata0.tgz
                 fi
                 ;;
             2)
@@ -65,8 +71,8 @@ case "$system" in
                 print_results output.${PJM_JOBID}/0/1/stdout.1.0 CASE7 4 >> ../results/result
                 if bk_profiler_enabled "$qws_profiler_tool"; then
                     bk_profiler "$qws_profiler_tool" --level "$qws_profiler_level" --archive ../results/padata0.tgz --raw-dir pa -- mpiexec -n 8 ./main 32 6 4 3 1 2 2 2 -1 -1 6 50 > CASE7.profile
-                else
-                    emit_qws_dummy_padata ../results/padata0.tgz
+                # else
+                #     emit_qws_dummy_padata ../results/padata0.tgz
                 fi
                 ;;
             *)

--- a/result_server/tests/test_site_diagnostics.py
+++ b/result_server/tests/test_site_diagnostics.py
@@ -174,3 +174,48 @@ def test_site_config_preflight_requires_public_systems_to_be_runnable(tmp_path):
         "system_info.csv exposes PUBLIC_MISSING_SYSTEM, but config/system.csv has no matching system.",
         "system_info.csv exposes PUBLIC_BAD_QUEUE, but config/system.csv references queue MISSING_QUEUE without a matching config/queue.csv definition.",
     ]
+
+
+def test_site_diagnostics_treats_disabled_estimate_as_inactive(tmp_path):
+    config_dir = tmp_path / "config"
+    programs_dir = tmp_path / "programs"
+    config_dir.mkdir()
+    programs_dir.mkdir()
+
+    _write_csv(
+        config_dir / "system.csv",
+        ["system", "mode", "tag_build", "tag_run", "queue", "queue_group"],
+        [["Fugaku", "cross", "", "", "FJ", "small"]],
+    )
+    _write_csv(
+        config_dir / "queue.csv",
+        ["queue", "submit_cmd", "template"],
+        [["FJ", "pjsub", "template"]],
+    )
+    _write_csv(
+        config_dir / "system_info.csv",
+        ["system", "name", "cpu_name", "cpu_per_node", "cpu_cores", "gpu_name", "gpu_per_node", "memory", "display_order"],
+        [["Fugaku", "Fugaku", "A64FX", "1", "48", "-", "-", "32GB", "1"]],
+    )
+
+    qws_dir = programs_dir / "qws"
+    qws_dir.mkdir()
+    (qws_dir / "build.sh").write_text("case \"$system\" in\nFugaku)\n  echo build\n  ;;\nesac\n", encoding="utf-8")
+    (qws_dir / "run.sh").write_text("case \"$system\" in\nFugaku)\n  echo run\n  ;;\nesac\n", encoding="utf-8")
+    _write_csv(
+        qws_dir / "list.csv",
+        ["system", "enable", "nodes", "numproc_node", "nthreads", "elapse"],
+        [["Fugaku", "yes", "1", "4", "12", "0:10:00"]],
+    )
+    (qws_dir / "estimate.sh").write_text("#!/bin/bash\n", encoding="utf-8")
+    (qws_dir / "estimate.disabled").write_text("disabled\n", encoding="utf-8")
+
+    diagnostics = build_site_diagnostics(
+        system_csv_path=str(config_dir / "system.csv"),
+        queue_csv_path=str(config_dir / "queue.csv"),
+        system_info_csv_path=str(config_dir / "system_info.csv"),
+        programs_dir=str(programs_dir),
+    )
+
+    assert diagnostics["apps_with_estimate_count"] == 0
+    assert diagnostics["apps_without_estimate"] == ["qws"]

--- a/result_server/utils/site_diagnostics.py
+++ b/result_server/utils/site_diagnostics.py
@@ -72,7 +72,8 @@ def _scan_program_diagnostics(programs_root, registered_systems):
             })
 
         estimate_path = os.path.join(entry.path, "estimate.sh")
-        if os.path.exists(estimate_path):
+        estimate_disabled_path = os.path.join(entry.path, "estimate.disabled")
+        if os.path.exists(estimate_path) and not os.path.exists(estimate_disabled_path):
             apps_with_estimate_count += 1
         else:
             apps_without_estimate.append(entry.name)

--- a/scripts/job_functions.sh
+++ b/scripts/job_functions.sh
@@ -298,12 +298,15 @@ is_estimate_target() {
     return 1
 }
 
-# Check if a program directory has an estimate script
-# Returns 0 if $1/estimate.sh exists, 1 otherwise
+# Check if a program directory has an active estimate script.
+# programs/<code>/estimate.disabled keeps reference estimate.sh scaffolding in
+# the tree without generating production estimate jobs for that application.
+# Returns 0 if $1/estimate.sh exists and is not disabled, 1 otherwise.
 # Usage: has_estimate_script "programs/qws" && echo "has estimate"
 has_estimate_script() {
     local program_dir="$1"
-    [[ -f "${program_dir}/estimate.sh" ]]
+    [[ -f "${program_dir}/estimate.sh" ]] || return 1
+    [[ ! -f "${program_dir}/estimate.disabled" ]]
 }
 
 # Emit estimate job YAML block

--- a/scripts/tests/test_scheduler_extra_args.sh
+++ b/scripts/tests/test_scheduler_extra_args.sh
@@ -30,8 +30,24 @@ unset BK_SCHEDULER_EXTRA_ARGS_RIKYU
 export BK_SCHEDULER_EXTRA_ARGS="--account=global"
 test "$(get_scheduler_extra_args RIKYU)" = "--account=global"
 
+tmpdir=""
+estimate_tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir" "$estimate_tmpdir"' EXIT
+
+mkdir -p "$estimate_tmpdir/app"
+if has_estimate_script "$estimate_tmpdir/app"; then
+    echo "directory without estimate.sh must not be estimate-enabled" >&2
+    exit 1
+fi
+touch "$estimate_tmpdir/app/estimate.sh"
+has_estimate_script "$estimate_tmpdir/app"
+touch "$estimate_tmpdir/app/estimate.disabled"
+if has_estimate_script "$estimate_tmpdir/app"; then
+    echo "estimate.disabled must disable estimate.sh" >&2
+    exit 1
+fi
+
 tmpdir=$(mktemp -d)
-trap 'rm -rf "$tmpdir"' EXIT
 
 cat >"$tmpdir/sbatch" <<'SCRIPT'
 #!/bin/bash


### PR DESCRIPTION
## Summary
- disable QWS synthetic section timing and dummy PA artifact emission for production runs
- add an estimate.disabled marker so CI matrix generation and site diagnostics treat QWS estimation as inactive
- update estimation docs to use GENESIS as the active detailed-estimation reference

## Tests
- git diff --check
- bash -n programs/qws/run.sh programs/qws/estimate.sh scripts/job_functions.sh scripts/tests/test_scheduler_extra_args.sh
- shellcheck -S error programs/qws/run.sh programs/qws/estimate.sh scripts/job_functions.sh scripts/tests/test_scheduler_extra_args.sh
- bash scripts/tests/test_scheduler_extra_args.sh
- .venv/bin/python -m pytest result_server/tests/test_site_diagnostics.py
- .venv/bin/python result_server/tests/check_site_config.py
- matrix smoke: qws on RC_GH200/MiyabiG does not generate estimate/send_estimate jobs