### PR TITLE
Restrict public portal result detail access

### DIFF
--- a/result_server/routes/results_detail_routes.py
+++ b/result_server/routes/results_detail_routes.py
@@ -11,6 +11,7 @@ from utils.node_hours import compute_node_hours
 from utils.result_compare_view import load_result_compare_context
 from utils.result_detail_view import build_result_detail_context
 from utils.result_file import (
+    load_public_result_json,
     load_permitted_result_json,
     serve_permitted_result_file,
     serve_public_padata_file,
@@ -45,11 +46,18 @@ def register_results_detail_routes(results_bp):
     @results_bp.route("/detail/<filename>")
     def result_detail(filename):
         is_public_surface = public_surface()
-        result = load_permitted_result_json(
-            filename,
-            current_app.config["RECEIVED_DIR"],
-            not_found_message="Result file not found",
-        )
+        if is_public_surface:
+            result = load_public_result_json(
+                filename,
+                current_app.config["RECEIVED_DIR"],
+                not_found_message="Result file not found",
+            )
+        else:
+            result = load_permitted_result_json(
+                filename,
+                current_app.config["RECEIVED_DIR"],
+                not_found_message="Result file not found",
+            )
         quality = summarize_result_quality(result)
         padata_dir = current_app.config.get("RECEIVED_PADATA_DIR", current_app.config["RECEIVED_DIR"])
         padata_filenames = [name for name in os.listdir(padata_dir) if name.endswith(".tgz")]

--- a/result_server/tests/test_public_result_routes.py
+++ b/result_server/tests/test_public_result_routes.py
@@ -1,0 +1,99 @@
+"""Public portal route tests for result detail and compare views."""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from test_support import (  # noqa: E402
+    StaticAffiliationUserStore,
+    build_results_route_app,
+    install_portal_test_stubs,
+)
+
+install_portal_test_stubs()
+
+
+def _add_navigation_routes(app):
+    app.add_url_rule("/", "home", lambda: "home")
+    app.add_url_rule("/systems", "systemlist", lambda: "systems")
+    app.add_url_rule("/login", "auth.login", lambda: "login")
+    app.add_url_rule("/logout", "auth.logout", lambda: "logout")
+
+
+def _write_result(received_dir, filename, payload):
+    with open(received_dir / filename, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle)
+
+
+def _build_public_app(tmp_path):
+    received_dir = tmp_path / "received"
+    received_dir.mkdir()
+    app = build_results_route_app(received_dir=str(received_dir))
+    _add_navigation_routes(app)
+    app.config["PUBLIC_PORTAL_MODE"] = True
+    app.config["USER_STORE"] = StaticAffiliationUserStore({"dev@example.test": ["dev"]})
+    return app, received_dir
+
+
+def _authenticate_dev(client):
+    with client.session_transaction() as sess:
+        sess["authenticated"] = True
+        sess["user_email"] = "dev@example.test"
+
+
+def test_public_portal_detail_hides_confidential_result_for_authorized_session(tmp_path):
+    app, received_dir = _build_public_app(tmp_path)
+    filename = "result_20260824_090000_11111111-2222-3333-4444-555555555555.json"
+    _write_result(
+        received_dir,
+        filename,
+        {
+            "code": "qws",
+            "system": "Fugaku",
+            "Exp": "CASE1",
+            "FOM": 1.0,
+            "confidential": ["dev"],
+        },
+    )
+
+    with app.test_client() as client:
+        _authenticate_dev(client)
+        response = client.get(f"/results/detail/{filename}")
+
+    assert response.status_code == 404
+
+
+def test_public_portal_compare_hides_confidential_result_for_authorized_session(tmp_path):
+    app, received_dir = _build_public_app(tmp_path)
+    public_filename = "result_20260824_090000_11111111-2222-3333-4444-555555555555.json"
+    confidential_filename = "result_20260824_091000_aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.json"
+    _write_result(
+        received_dir,
+        public_filename,
+        {
+            "code": "qws",
+            "system": "Fugaku",
+            "Exp": "CASE1",
+            "FOM": 1.0,
+        },
+    )
+    _write_result(
+        received_dir,
+        confidential_filename,
+        {
+            "code": "qws",
+            "system": "Fugaku",
+            "Exp": "CASE2",
+            "FOM": 1.1,
+            "confidential": ["dev"],
+        },
+    )
+
+    with app.test_client() as client:
+        _authenticate_dev(client)
+        response = client.get(
+            f"/results/compare?files={public_filename},{confidential_filename}"
+        )
+
+    assert response.status_code == 404

--- a/result_server/utils/result_compare_view.py
+++ b/result_server/utils/result_compare_view.py
@@ -1,7 +1,12 @@
 from flask import abort
 
-from utils.result_file import check_file_permission
-from utils.result_records import build_axis_label, build_compare_headline, load_result_json_batch
+from utils.result_file import check_file_permission, load_public_result_json
+from utils.result_records import (
+    build_axis_label,
+    build_compare_headline,
+    format_result_timestamp,
+    load_result_json_batch,
+)
 
 
 def build_result_compare_context(results):
@@ -42,14 +47,31 @@ def build_result_compare_context(results):
 
 
 def load_result_compare_context(filenames, directory, *, public_surface=False):
+    if public_surface:
+        results = _load_public_result_json_batch(filenames, directory)
+        return build_result_compare_context([
+            _project_public_compare_result(row) for row in results
+        ])
+
     for filename in filenames:
         check_file_permission(filename, directory)
     results = load_result_json_batch(filenames, directory)
     if len(results) != len(filenames):
         abort(404, "Result file not found")
-    if public_surface:
-        results = [_project_public_compare_result(row) for row in results]
     return build_result_compare_context(results)
+
+
+def _load_public_result_json_batch(filenames, directory):
+    results = []
+    for filename in filenames:
+        results.append({
+            "filename": filename,
+            "timestamp": format_result_timestamp(filename),
+            "data": load_public_result_json(filename, directory),
+        })
+
+    results.sort(key=lambda item: item["timestamp"])
+    return results
 
 
 def _project_public_compare_result(row):

--- a/result_server/utils/result_file.py
+++ b/result_server/utils/result_file.py
@@ -144,6 +144,23 @@ def load_permitted_result_json(
     return result
 
 
+def load_public_result_json(
+    filename: str,
+    result_dir: str,
+    *,
+    not_found_message: str = "Result file not found",
+):
+    """Load JSON content only when it has no confidential tags."""
+    from utils.result_records import load_result_json
+
+    result = load_result_json(filename, result_dir)
+    if result is None:
+        abort(404, not_found_message)
+    if _extract_confidential_tags(result):
+        abort(404, not_found_message)
+    return result
+
+
 def load_authenticated_result_json(
     filename: str,
     data_dir: str,


### PR DESCRIPTION
## Summary
- require public-only result JSONs for public portal detail pages
- require every public portal compare result to be public-only
- add route regression tests for authenticated sessions that otherwise match confidential affiliations

## Tests
- .venv/bin/python -m pytest result_server/tests
- .venv/bin/python scripts/tests/check_text_integrity.py