### PR TITLE
Record source and build environment provenance

### DIFF
--- a/.github/workflows/result-server-tests.yml
+++ b/.github/workflows/result-server-tests.yml
@@ -70,6 +70,8 @@ jobs:
       - name: Run profiler, profile-data, and estimation shell tests
         run: |
           bash scripts/tests/test_bk_profiler.sh
+          bash scripts/tests/test_bk_fetch_source.sh
+          bash scripts/tests/test_build_environment_snapshot.sh
           bash scripts/tests/test_ncu_plan_generation.sh
           bash scripts/tests/test_result_profile_data.sh
           bash scripts/tests/test_process_and_send_results.sh

--- a/docs/guides/add-app.md
+++ b/docs/guides/add-app.md
@@ -116,9 +116,24 @@ Benchkit では、実行条件とシステム運用設定を明確に分けま�
 
 Benchkit では、まず **top-level application の source provenance** を追えることを優先します。
 具体的には、Git 管理のアプリであれば `repo_url`、`branch`、`commit_hash` を `source_info` として入れられる形が望ましいです。
+通常のアプリ build は、対象 repo の対象 branch の最新 commit を使います。
+再現実行や監査で commit を固定したい場合だけ、`bk_fetch_source` の第4引数に expected commit を渡して、意図した commit を build してください。
+tar archive を使う場合も、必要に応じて第4引数に expected SHA-256 を渡せます。
 
 一方で、ローカルファイルや依存ライブラリを含む完全な provenance を、現時点ですべての app に必須化する方針ではありません。
 portal の `/results/usage` では、この source provenance が各 app / system の最新 result に対して current-state として見えるので、まずは top-level source tracked を目標に整備すると自然です。
+
+### build environment snapshot の方針
+
+CI の共通 wrapper は、`build.sh` 実行前に runner 側の軽量 snapshot を記録します。
+一方で、多くの app は `build.sh` 内で `module load` や compiler 設定を行うため、実際の build 環境は app build の直前で記録する必要があります。
+
+`scripts/bk_functions.sh` を source した build script では、`bk_capture_build_environment_snapshot` または `bk_make` を使ってください。
+`bk_make` は `make` 実行直前に `results/environment_snapshot_build_actual.json` を更新してから `make` を呼びます。
+この snapshot には、主要 compiler / MPI / CUDA / profiler / container command の path と version、loaded modules、allowlist された build 環境変数が含まれます。
+`TOKEN`、`SECRET`、`PASSWORD`、`AUTH`、`KEY`、`CERT` などを名前に含む環境変数は値を redacted として記録します。
+
+この actual build snapshot は、将来の build cache key や、同じ source から異なる binary が生じた場合の原因確認に使う前提の記録です。
 
 ---
 
@@ -135,14 +150,15 @@ source scripts/bk_functions.sh
 
 # ソースコード取得と source_info 生成
 REPO_DIR="your-app"
-bk_fetch_source "https://github.com/your-org/your-app.git" "${REPO_DIR}" "main"
+SOURCE_COMMIT="${YOUR_APP_SOURCE_COMMIT:-}"
+bk_fetch_source "https://github.com/your-org/your-app.git" "${REPO_DIR}" "main" "${SOURCE_COMMIT}"
 cd "${REPO_DIR}"
 
 # システム別ビルド設定
 case "$system" in
     Fugaku)
         # A64FX向けクロスコンパイル
-        make -j 8 compiler=fujitsu_cross mpi=1
+        bk_make -j 8 compiler=fujitsu_cross mpi=1
         ;;
     FugakuCN)
         # A64FX向けネイティブコンパイル
@@ -150,7 +166,7 @@ case "$system" in
         ;;
     MiyabiG)
         # Neoverse-N1向けビルド
-        make -j 8 compiler=openmpi-gnu arch=skylake mpi=1
+        bk_make -j 8 compiler=openmpi-gnu arch=skylake mpi=1
         ;;
     MiyabiC)
         # Intel向けビルド
@@ -159,7 +175,7 @@ case "$system" in
     RC_GENOA)
         # AMD Genoa向けビルド
         module load system/genoa mpi/openmpi-x86_64
-        make -j 8 compiler=openmpi-gnu arch=skylake mpi=1
+        bk_make -j 8 compiler=openmpi-gnu arch=skylake mpi=1
         ;;
     RC_DGXSP)
         # DGX Spark向けビルド
@@ -545,8 +561,10 @@ git push origin add-<code>
 - ビルド・実行ファイルの衝突は基本的に発生しない
 
 ### Git リポジトリの取り扱い
-- ソース取得は原則 `scripts/bk_functions.sh` の `bk_fetch_source <source> <dest_dir> [branch]` を使う
+- ソース取得は原則 `scripts/bk_functions.sh` の `bk_fetch_source <source> <dest_dir> [branch] [expected_commit_or_sha256]` を使う
 - `bk_fetch_source` は Git URL または tar archive を取得・展開し、`results/source_info.env` に source provenance を書く
+- Git source では expected commit を指定すると、その commit に checkout して一致しなければ失敗する
+- tar archive では expected SHA-256 を指定すると、一致しなければ失敗し、`source_info` に `sha256sum` も記録する
 - `build.sh` と `run.sh` の両方で同じ checkout が必要な場合も、直接 `git clone` せず `bk_fetch_source` に寄せる
 - `run.sh` が build artifact の実行ファイルだけで完結する場合は、実行時に再 clone しない
 - 取得元 URL を site ごとに変えたい場合は、app 固有環境変数で上書きできる形にしてもよい

--- a/docs/guides/portal-execution-profiles-handoff.md
+++ b/docs/guides/portal-execution-profiles-handoff.md
@@ -55,20 +55,21 @@ Completed:
   `result_metadata_index` at ingest time. JSON/tgz artifacts remain the raw
   records and existing result pages remain file-backed.
 - Generated GitLab CI jobs collect lightweight environment snapshots in the
-  common build/run/build_run wrappers, without requiring application
-  `build.sh` or `run.sh` changes. Result submission combines those artifacts
-  into a Result JSON `environment_snapshot` reference block. The Portal indexes
-  the snapshot payload by hash in `environment_snapshots` and links received
-  results through `environment_snapshot_results`. Result detail pages show the
-  snapshot hash, allocation project ID, scheduler, runner, and Benchkit commit.
+  common build/run/build_run wrappers. Build scripts can additionally record
+  the post-module-load, pre-compile environment as
+  `results/environment_snapshot_build_actual.json`. Result submission combines
+  those artifacts into a Result JSON `environment_snapshot` reference block.
+  The Portal indexes the snapshot payload by hash in `environment_snapshots`
+  and links received results through `environment_snapshot_results`. Result
+  detail pages show the snapshot hash, allocation project ID, scheduler,
+  runner, and Benchkit commit.
 
 Remaining follow-up:
 
 1. Review which result and estimate views should move from file-backed scans to
    indexed lookup once the operational view requirements are stable.
-2. Expand environment snapshot collectors only when a specific site needs more
-   runtime detail. The v1 collector intentionally avoids full environment dumps
-   and secret-bearing CI variables.
+2. Keep environment snapshot collectors allowlist-based. They intentionally
+   avoid full environment dumps and secret-bearing CI variables.
 
 GitLab schedules should not be the primary governance point. The Portal should
 own periodic and event-triggered execution decisions, then trigger GitLab CI
@@ -96,6 +97,7 @@ describe the intended scope, allocation, approval state, and trigger bindings;
 snapshots describe what the CI job actually observed when it packaged the
 result. The v1 snapshot identity is the SHA-256 hash of the canonical snapshot
 payload assembled from `results/environment_snapshot_build.json`,
+`results/environment_snapshot_build_actual.json`,
 `results/environment_snapshot_run.json`, or
 `results/environment_snapshot_build_run.json`.
 

--- a/programs/LQCD_dw_solver/build.sh
+++ b/programs/LQCD_dw_solver/build.sh
@@ -6,6 +6,8 @@ echo "[LQCD_dw_solver] Building on system: $system"
 mkdir -p artifacts
 #git clone https://github.com/RIKEN-LQCD/qws.git
 
+source scripts/bk_functions.sh
+
 TARDIR=./
 case "$system" in
   Fugaku*)
@@ -20,10 +22,12 @@ esac
 echo "soruce location " $TARDIR
 
 TARBALL=LQCD_dw_solver_20251209_773762.tar.gz
+TARBALL_SHA256="${LQCD_DW_SOLVER_ARCHIVE_SHA256:-${BK_LQCD_DW_SOLVER_ARCHIVE_SHA256:-}}"
 SRC=`echo $TARBALL|sed -e "s/\.tar\.gz//"`
 DIR=LQCD_dw_solver
 if [ ! -d LQCD_dw_solver ]; then
-  cp $TARDIR/$TARBALL .
+  bk_record_file_source_info "$TARDIR/$TARBALL" "$TARBALL_SHA256" "LQCD_dw_solver source archive"
+  cp "$TARDIR/$TARBALL" .
   tar -zxf $TARBALL
   ln -s $SRC $DIR
 fi
@@ -41,9 +45,9 @@ case "$system" in
       if [ ! -e Makefile_target.inc.keep ]; then
         cp Makefile_target.inc Makefile_target.inc.keep
       fi
-      make -j 8 lib
+      bk_make -j 8 lib
       cd benchmark/domainwall/
-      make -j 8
+      bk_make -j 8
       cd -
       cp $BIN ../artifacts
       #fccpx --version
@@ -55,9 +59,9 @@ case "$system" in
         cp Makefile_target.inc Makefile_target.inc.keep
         sed -i "s/FCCpx/FCC/g" Makefile_target.inc
       fi
-      make -j 12 lib
+      bk_make -j 12 lib
       cd benchmark/domainwall/
-      make -j 12
+      bk_make -j 12
       cd -
       cp $BIN ../artifacts
       ;;
@@ -69,46 +73,46 @@ case "$system" in
     #   ;;
     MiyabiC|AVX512)
       cp Makefile_simd_avx512 Makefile
-      make -j 8 lib
+      bk_make -j 8 lib
       cd benchmark/domainwall/
-      make -j 8
+      bk_make -j 8
       cd -
       cp $BIN ../artifacts
       ;;
     MiyabiG)
       # OpenACC
       cp Makefile_openacc Makefile
-      make -j 8 lib
+      bk_make -j 8 lib
       cd benchmark/domainwall/
-      make -j 8
+      bk_make -j 8
       cd -
       mv $BIN $BIN_openacc
       cp $BIN_openacc ../artifacts
       # CUDA
       rm -r build
       cp Makefile_cuda Makefile
-      make clean
-      make -j 8 lib
+      bk_make clean
+      bk_make -j 8 lib
       cd benchmark/domainwall/
-      make clean
-      make -j 8
+      bk_make clean
+      bk_make -j 8
       cd -
       mv $BIN $BIN_cuda
       cp $BIN_cuda ../artifacts
       ;;
     OpenACC)
       cp Makefile_openacc Makefile
-      make -j 8 lib
+      bk_make -j 8 lib
       cd benchmark/domainwall/
-      make -j 8
+      bk_make -j 8
       cd -
       cp $BIN ../artifacts
       ;;
     CUDA)
       cp Makefile_cuda Makefile
-      make -j 8 lib
+      bk_make -j 8 lib
       cd benchmark/domainwall/
-      make -j 8
+      bk_make -j 8
       cd -
       cp $BIN ../artifacts
       ;;

--- a/programs/MHDTurbulence/build.sh
+++ b/programs/MHDTurbulence/build.sh
@@ -6,15 +6,16 @@ system="$1"
 
 code=MHDTurbulence
 REPO=https://github.com/cfcanaoj/MHDTurbulence.git
+BRANCH="${MHDTURBULENCE_BRANCH:-main}"
+SOURCE_COMMIT="${MHDTURBULENCE_SOURCE_COMMIT:-}"
 artdir=artifacts
 
 echo "[${code}] Building on system: $system"
 
 mkdir -p ${artdir}
 
-if [ ! -d "$code" ]; then
-    git clone $REPO
-fi
+source scripts/bk_functions.sh
+bk_fetch_source "$REPO" "$code" "$BRANCH" "$SOURCE_COMMIT"
 
 DIR=$code
 
@@ -24,14 +25,14 @@ case "$system" in
     MiyabiC)
 	cd src_f90_omp_host
 	echo "Compile cods in "`pwd`
-	make
+	bk_make
 	echo "Executable is "${BIN}" and copied to "${artdir}
 	cp ../exe/$BIN ../../${artdir}
 	;;
     MiyabiG)
 	cd src_f90_acc_device
 	echo "Compile cods in "`pwd`
-	make
+	bk_make
 	echo "Executable is "${BIN}" and copied to "${artdir}
 	cp ../exe/$BIN ../../${artdir}
 	;;

--- a/programs/ffb/build.sh
+++ b/programs/ffb/build.sh
@@ -7,6 +7,8 @@ CPU_ARCHIVE="/vol0003/rccs-sdt/data/a01008/apps/ffb/ffb-frt_cpu.fugaku.tar.gz"
 GPU_ARCHIVE="/lvs0/rccs-sdt/kazuto.ando/apps/ffb/ffb-acc_gpu.gh.tar.gz"
 WORK_DIR="ffb_src"
 
+source scripts/bk_functions.sh
+
 mkdir -p artifacts
 rm -rf "${WORK_DIR}"
 mkdir -p "${WORK_DIR}"
@@ -14,10 +16,12 @@ mkdir -p "${WORK_DIR}"
 case "$system" in
   FugakuCN)
     archive="${CPU_ARCHIVE}"
+    archive_sha256="${FFB_CPU_ARCHIVE_SHA256:-${BK_FFB_CPU_ARCHIVE_SHA256:-}}"
     exe_relpath="bin/les3x.mpi"
     ;;
   RC_GH200)
     archive="${GPU_ARCHIVE}"
+    archive_sha256="${FFB_GPU_ARCHIVE_SHA256:-${BK_FFB_GPU_ARCHIVE_SHA256:-}}"
     exe_relpath="bin.acc_gpu/les3x.mpi"
     ;;
   *)
@@ -31,10 +35,12 @@ if [[ ! -f "$archive" ]]; then
   exit 1
 fi
 
+bk_record_file_source_info "$archive" "$archive_sha256" "FFB source archive"
 tar -xzf "$archive" -C "${WORK_DIR}" --strip-components=1
 cd "${WORK_DIR}"
 
 chmod +x make.FP3.sh
+bk_capture_build_environment_snapshot
 bash ./make.FP3.sh
 
 if [[ ! -f "$exe_relpath" ]]; then

--- a/programs/genesis-nonbonded-kernels/build.sh
+++ b/programs/genesis-nonbonded-kernels/build.sh
@@ -4,7 +4,8 @@ system="$1"
 
 REPO_DIR="genesis-nonbonded-kernels"
 REPO_URL="https://github.com/genesis-release-r-ccs/${REPO_DIR}.git"
-BRANCH="main"
+BRANCH="${GENESIS_NONBONDED_KERNELS_BRANCH:-main}"
+SOURCE_COMMIT="${GENESIS_NONBONDED_KERNELS_SOURCE_COMMIT:-}"
 name_list=(Generic Oct Oct_mod1)
 dir_list=(Generic Intel Intel_mod1)
 
@@ -12,7 +13,7 @@ echo "[${REPO_DIR}] Building on system: $system"
 mkdir -p artifacts
 
 source scripts/bk_functions.sh
-bk_fetch_source "${REPO_URL}" "${REPO_DIR}" "${BRANCH}"
+bk_fetch_source "${REPO_URL}" "${REPO_DIR}" "${BRANCH}" "${SOURCE_COMMIT}"
 
 cd ${REPO_DIR} || {
     echo "Failed to enter ${REPO_DIR}"
@@ -43,8 +44,10 @@ case "$system" in
 	# dir="normal_${comp}_omp_dir"
 	# version="-v"
 	# archopt="MARCH=native"
-	# ;;
+    # ;;
 esac
+
+bk_capture_build_environment_snapshot
 
 for i in "${!name_list[@]}"; do
     name=${name_list[i]}
@@ -52,7 +55,7 @@ for i in "${!name_list[@]}"; do
 	index=$((i + 1))
 	echo "Looping over name='$name', dir='$dir_path'"
 	cd "$dir_path" || { echo "cd failed to '$dir_path'"; exit 1; }
-    make FC="${comp}" OMP=omp SIMD=dir KIND="${name}" ${archopt}
+    bk_make FC="${comp}" OMP=omp SIMD=dir KIND="${name}" ${archopt}
     cp "$dir/kernel" "../../artifacts/kernel_${name}"
 	cd - > /dev/null
 done

--- a/programs/genesis/build.sh
+++ b/programs/genesis/build.sh
@@ -6,11 +6,16 @@ system="$1"
 REPO_DIR="genesis"
 REPO_URL="${GENESIS_REPO_URL:-https://github.com/genesis-release-r-ccs/${REPO_DIR}.git}"
 BRANCH="${GENESIS_BRANCH:-main}"
+SOURCE_COMMIT="${GENESIS_SOURCE_COMMIT:-}"
+
+source scripts/bk_functions.sh
 
 run_genesis_rikyu_in_container() {
     local image="${GENESIS_RIKYU_SIF:-/shared/software/hpc-dev-container/hpc_dev.sif}"
     local apptainer_bin="${GENESIS_RIKYU_APPTAINER:-apptainer}"
     local binds="${PWD}:${PWD}"
+    local expected_image_sha256="${GENESIS_RIKYU_SIF_SHA256:-${BK_GENESIS_RIKYU_SIF_SHA256:-}}"
+    local image_sha256=""
 
     if [ "${GENESIS_RIKYU_IN_CONTAINER:-false}" = "true" ]; then
         return 0
@@ -23,6 +28,9 @@ run_genesis_rikyu_in_container() {
         echo "Apptainer command not found for GENESIS RIKYU container: $apptainer_bin" >&2
         exit 1
     fi
+    if ! image_sha256=$(bk_verify_file_sha256 "$image" "$expected_image_sha256" "GENESIS RIKYU container image"); then
+        exit 1
+    fi
 
     if [ -n "${GENESIS_RIKYU_APPTAINER_BINDS:-}" ]; then
         binds="${binds},${GENESIS_RIKYU_APPTAINER_BINDS}"
@@ -31,6 +39,8 @@ run_genesis_rikyu_in_container() {
     echo "Running GENESIS RIKYU build in Apptainer image: $image"
     "$apptainer_bin" exec --nv --bind "$binds" --pwd "$PWD" \
         --env GENESIS_RIKYU_IN_CONTAINER=true \
+        --env "BK_SOURCE_CONTAINER_PATH=$image" \
+        --env "BK_SOURCE_CONTAINER_SHA256=$image_sha256" \
         "$image" bash "$0" "$@"
     exit $?
 }
@@ -42,8 +52,7 @@ fi
 echo "[${REPO_DIR}] Building on system: $system"
 mkdir -p artifacts
 
-source scripts/bk_functions.sh
-bk_fetch_source "${REPO_URL}" "${REPO_DIR}" "${BRANCH}"
+bk_fetch_source "${REPO_URL}" "${REPO_DIR}" "${BRANCH}" "${SOURCE_COMMIT}"
 
 cd ${REPO_DIR} || {
     echo "Failed to enter ${REPO_DIR}"
@@ -341,6 +350,7 @@ echo "CXX=${CXX:-}"
 echo "F77=${F77:-}"
 echo "configure args: ${CONFIG_ARGS[*]}"
 
+bk_capture_build_environment_snapshot
 bootstrap_genesis
 configure_env=(CC="$CC" FC="$FC")
 if [ -n "${CXX:-}" ]; then

--- a/programs/qws/build.sh
+++ b/programs/qws/build.sh
@@ -3,11 +3,16 @@ set -e
 system="$1"
 mkdir -p artifacts
 
+REPO_URL="https://github.com/RIKEN-LQCD/qws.git"
+REPO_DIR="qws"
+BRANCH="${QWS_BRANCH:-master}"
+SOURCE_COMMIT="${QWS_SOURCE_COMMIT:-}"
+
 # bk_fetch_source でソースコード取得とメタデータ収集
 source scripts/bk_functions.sh
-bk_fetch_source https://github.com/RIKEN-LQCD/qws.git qws
+bk_fetch_source "${REPO_URL}" "${REPO_DIR}" "${BRANCH}" "${SOURCE_COMMIT}"
 
-cd qws
+cd "${REPO_DIR}"
 
 qws_profiler_tool=$(bk_resolve_profiler_tool fapp QWS_PROFILER_TOOL)
 qws_make_profiler_args=()
@@ -18,10 +23,10 @@ fi
 # システムに合わせてbuild方法を書く。systemの選択肢はlist.csvに合わせる。
 case "$system" in
     Fugaku)
-	make -j 8 fugaku_benchmark= omp=1  compiler=fujitsu_cross rdma= mpi=1 powerapi= "${qws_make_profiler_args[@]}"
+	bk_make -j 8 fugaku_benchmark= omp=1  compiler=fujitsu_cross rdma= mpi=1 powerapi= "${qws_make_profiler_args[@]}"
 	;;
     FugakuCN)
-	make -j 8 fugaku_benchmark= omp=1  compiler=fujitsu_native rdma= mpi=1 powerapi= "${qws_make_profiler_args[@]}"
+	bk_make -j 8 fugaku_benchmark= omp=1  compiler=fujitsu_native rdma= mpi=1 powerapi= "${qws_make_profiler_args[@]}"
 	;;
     # FugakuLN retired; previous LN smoke build kept for reference.
     # FugakuLN)
@@ -38,87 +43,87 @@ case "$system" in
 	# ;;
     RIKYU)
 	module load nvhpc-hpcx/26.3
-	make -j 8 omp=1 compiler=nvhpc-hpcx arch=grace rdma= mpi=1
+	bk_make -j 8 omp=1 compiler=nvhpc-hpcx arch=grace rdma= mpi=1
 	;;
     RC_GH200)
 	module load system/qc-gh200 nvhpc-hpcx/25.9
 	### QWSはNeoverse版やGPU版はないので汎用版としてとりあえずarch=skylakeを指定している
- 	make -j 8 fugaku_benchmark= omp=1  compiler=openmpi-gnu arch=skylake rdma= mpi=1 powerapi=
+	bk_make -j 8 fugaku_benchmark= omp=1  compiler=openmpi-gnu arch=skylake rdma= mpi=1 powerapi=
 	;;
     RC_GENOA)
 	module load system/genoa  mpi/openmpi-x86_64
- 	make -j 8 fugaku_benchmark= omp=1  compiler=openmpi-gnu arch=skylake rdma= mpi=1 powerapi=
+	bk_make -j 8 fugaku_benchmark= omp=1  compiler=openmpi-gnu arch=skylake rdma= mpi=1 powerapi=
     ;;
 	RC_DGXSP)
 	source /etc/profile.d/modules.sh
 	module load system/ng-dgx nvhpc-hpcx/26.3
-	make -j 8 fugaku_benchmark= omp=1  compiler=openmpi-gnu arch=skylake rdma= mpi=1 powerapi=
+	bk_make -j 8 fugaku_benchmark= omp=1  compiler=openmpi-gnu arch=skylake rdma= mpi=1 powerapi=
 	;;
 	RC_FX700)
 	module load system/fx700 FJSVstclanga
-	make -j 8 fugaku_benchmark= omp=1  compiler=fujitsu_native rdma= mpi=1 powerapi= SYSLIBS=
+	bk_make -j 8 fugaku_benchmark= omp=1  compiler=fujitsu_native rdma= mpi=1 powerapi= SYSLIBS=
 	;;
     MiyabiG)
 	### QWSはNeoverse版やGPU版はないので汎用版としてとりあえずarch=skylakeを指定している
- 	make -j 8 fugaku_benchmark= omp=1  compiler=openmpi-gnu arch=skylake rdma= mpi=1 powerapi=
+	bk_make -j 8 fugaku_benchmark= omp=1  compiler=openmpi-gnu arch=skylake rdma= mpi=1 powerapi=
         ;;
     MiyabiC)
- 	make -j 8 fugaku_benchmark= omp=1  compiler=intel arch=skylake rdma= mpi=1 powerapi=
+	bk_make -j 8 fugaku_benchmark= omp=1  compiler=intel arch=skylake rdma= mpi=1 powerapi=
         ;;
     GenkaiA|GenkaiB|GenkaiC)
 	module load intel/2023.2 mvapich/3.0-intel2023.2
-	make -j 8 fugaku_benchmark= omp=1 compiler=intel arch=skylake rdma= mpi=1 powerapi= CC=mpicc CXX=mpicxx
+	bk_make -j 8 fugaku_benchmark= omp=1 compiler=intel arch=skylake rdma= mpi=1 powerapi= CC=mpicc CXX=mpicxx
 	;;
     Grand_C|Grand_G)
 	module load intel impi
-	make -j 8 fugaku_benchmark= omp=1 compiler=intel arch=skylake rdma= mpi=1 powerapi=
+	bk_make -j 8 fugaku_benchmark= omp=1 compiler=intel arch=skylake rdma= mpi=1 powerapi=
 	;;
     AOBA_A|AOBA_S)
-	make -j 8 fugaku_benchmark= omp=1 compiler=nec arch=sx rdma= mpi=1 powerapi=
+	bk_make -j 8 fugaku_benchmark= omp=1 compiler=nec arch=sx rdma= mpi=1 powerapi=
 	;;
     AOBA_B)
-	make -j 8 fugaku_benchmark= omp=1 compiler=openmpi-gnu arch=skylake rdma= mpi=1 powerapi= CC=mpicc CXX=mpic++
+	bk_make -j 8 fugaku_benchmark= omp=1 compiler=openmpi-gnu arch=skylake rdma= mpi=1 powerapi= CC=mpicc CXX=mpic++
 	;;
     SQUID_CPU)
 	module load BaseCPU
-	make compiler=intel arch=skylake mpi=1 rdma= omp=1 -j8
+	bk_make compiler=intel arch=skylake mpi=1 rdma= omp=1 -j8
 	;;
     SQUID_GPU)
 	module load BaseGPU
-	make compiler=nvhpc-hpcx arch=skylake mpi=1 rdma= omp=1 -j8
+	bk_make compiler=nvhpc-hpcx arch=skylake mpi=1 rdma= omp=1 -j8
 	;;
     SQUID_VECTOR)
 	module load BaseVEC
-	make compiler=nec arch=sx mpi=1 rdma= omp=1 -j8
+	bk_make compiler=nec arch=sx mpi=1 rdma= omp=1 -j8
 	;;
     Odyssey)
 	module load odyssey
-	make compiler=fujitsu_cross arch=postk -j 8
+	bk_make compiler=fujitsu_cross arch=postk -j 8
 	;;
     Aquarius)
 	module purge
 	module load intel
 	source /work/opt/local/x86_64/cores/intel/2023.0.0/mpi/latest/env/vars.sh
-	make compiler=intel arch=skylake rdma= -j8
+	bk_make compiler=intel arch=skylake rdma= -j8
 	;;
     Pegasus)
 	module load intel/2025.3.1 intmpi/2025.3.1
-	make compiler=intel arch=skylake mpi=1 omp=1 rdma=
+	bk_make compiler=intel arch=skylake mpi=1 omp=1 rdma=
 	;;
     Sirius)
 	module load aocc/5.0.0 openmpi/5.0.10/aocc5.0.0
-	make -j4 compiler=aocc arch=zen4 rdma= mpi=1 omp=1 profiler=timing \
+	bk_make -j4 compiler=aocc arch=zen4 rdma= mpi=1 omp=1 profiler=timing \
 	    AMD_MARCH=-march=znver4 cppflags="-DARCH_AVX512" main
 	;;
     TSUBAME4)
 	module load openmpi/5.0.10-gcc aocc/4.1.0
 	export OMPI_CC=clang OMPI_CXX=clang++ OMPI_FC=flang
-	make -j4 compiler=aocc arch=zen4 rdma= mpi=1 omp=1 profiler=timing \
+	bk_make -j4 compiler=aocc arch=zen4 rdma= mpi=1 omp=1 profiler=timing \
 	    AMD_MARCH=-march=znver4 cppflags="-DARCH_AVX512" main
 	;;
     OCTOPUS)
 	module load BaseCPU inteloneAPI
-	make -j8 compiler=intel arch=skylake mpi=1 omp=1 rdma=
+	bk_make -j8 compiler=intel arch=skylake mpi=1 omp=1 rdma=
 	;;
     Camphor3)
 	camphor3_modulepath="${MODULEPATH:-}"
@@ -137,7 +142,7 @@ case "$system" in
 	    export MODULEPATH="${camphor3_modulepath}"
 	fi
 	module load slurm/2022 SysA/2022 intel/2023.2 intelmpi/2023.2 PrgEnvIntel/2023
-	make -j 8 fugaku_benchmark= omp=1 compiler=intel arch=skylake rdma= mpi=1 powerapi=
+	bk_make -j 8 fugaku_benchmark= omp=1 compiler=intel arch=skylake rdma= mpi=1 powerapi=
 	;;
     *)
 	echo "Unknown system: $system"

--- a/programs/salmon/build.sh
+++ b/programs/salmon/build.sh
@@ -173,6 +173,7 @@ case "${system}" in
     ;;
 esac
 
+bk_capture_build_environment_snapshot
 run_logged "Configuring SALMON" "${BUILD_LOG_DIR}/${system}_configure.log" \
   cmake -Wno-dev -S . -B "${BUILD_DIR}" "${cmake_args[@]}"
 run_logged "Building SALMON" "${BUILD_LOG_DIR}/${system}_build.log" \

--- a/programs/scale-letkf/build.sh
+++ b/programs/scale-letkf/build.sh
@@ -4,25 +4,32 @@ system="$1"
 TOPDIR=`pwd`
 mkdir -p artifacts
 
+REPO_URL="https://github.com/SCALE-LETKF-RIKEN/scale-letkf-FugakuNEXT"
+REPO_DIR="scale-letkf-FugakuNEXT"
+BRANCH="${SCALE_LETKF_BRANCH:-master}"
+SOURCE_COMMIT="${SCALE_LETKF_SOURCE_COMMIT:-}"
+
 source scripts/bk_functions.sh
-bk_fetch_source https://github.com/SCALE-LETKF-RIKEN/scale-letkf-FugakuNEXT scale-letkf-FugakuNEXT
-cd scale-letkf-FugakuNEXT
+bk_fetch_source "${REPO_URL}" "${REPO_DIR}" "${BRANCH}" "${SOURCE_COMMIT}"
+cd "${REPO_DIR}"
 
 case "$system" in
   Fugaku)
     source setup-env.Fugaku.sh
+    bk_capture_build_environment_snapshot
     cd scale/scale-rm/src
-    make -j
+    bk_make -j
     cd ../../scale-letkf/scale
-    make
+    bk_make
     cd $TOPDIR
   ;;
   RC_GH200)
     source setup-env.RC_GH200.sh
+    bk_capture_build_environment_snapshot
     cd scale/scale-rm/src
-    make -j
+    bk_make -j
     cd ../../scale-letkf/scale
-    make
+    bk_make
     cd $TOPDIR
   ;;
   *)

--- a/result_server/tests/test_result_detail_template.py
+++ b/result_server/tests/test_result_detail_template.py
@@ -76,7 +76,16 @@ FULL_RESULT = {
         "payload": {
             "schema_version": 1,
             "ci": {"job_name": "qws_RC_GH200_run"},
-            "toolchain": {"modules": ["gcc/11.5.0", "openmpi/4.1.7"]},
+            "toolchain": {
+                "modules": ["gcc/11.5.0", "openmpi/4.1.7"],
+                "commands": {
+                    "gcc": {
+                        "path": "/usr/bin/gcc",
+                        "real_path": "/usr/bin/gcc",
+                        "version": "gcc (GCC) 11.5.0",
+                    }
+                },
+            },
         },
     },
 }
@@ -131,6 +140,8 @@ class TestResultDetailTemplate:
         assert "sha256:abcdef" in html
         assert "rccs-cloud" in html
         assert "slurm" in html
+        assert "Build Tools" in html
+        assert "gcc (GCC) 11.5.0" in html
         assert "Back to Results" in html
         assert "Results" in html
 

--- a/result_server/tests/test_results_loader.py
+++ b/result_server/tests/test_results_loader.py
@@ -270,7 +270,7 @@ class TestLoadResultsTableExtension:
         expected_columns = [
             {"label": "Timestamp", "key": "timestamp", "tooltip": "Date and time when benchmark execution completed and results were automatically submitted to server", "tooltip_class": "tooltip-left"},
             {"label": "CODE", "key": "code"},
-            {"label": "Branch/Hash", "key": "source_hash", "tooltip": "Source code branch name and short commit hash (git) or short md5sum (file archive)"},
+            {"label": "Branch/Hash", "key": "source_hash", "tooltip": "Source code branch name and short commit hash (git) or short sha256/md5 hash (file archive)"},
             {"label": "Exp", "key": "exp", "tooltip": "Experimental conditions (filtered by CODE)"},
             {"label": "FOM", "key": "fom", "tooltip": "Figure of Merit - Benchmark performance metric value with its unit when available"},
             {"label": "FOM version", "key": "fom_version", "tooltip": "Version identifier for the FOM measurement section - helps identify which code region was measured when users modify the timing boundaries"},

--- a/result_server/tests/test_script_source_info_security.py
+++ b/result_server/tests/test_script_source_info_security.py
@@ -29,5 +29,7 @@ def test_bk_fetch_source_writes_encoded_source_info_values():
     assert "BK_SOURCE_INFO_FORMAT=base64-v1" in bk_functions
     assert "BK_REPO_URL_B64" in bk_functions
     assert "BK_FILE_PATH_B64" in bk_functions
+    assert "BK_SHA256SUM_B64" in bk_functions
+    assert "BK_CONTAINER_IMAGE_SHA256SUM_B64" in bk_functions
     assert 'export BK_REPO_URL="$BK_REPO_URL"' not in bk_functions
     assert 'export BK_FILE_PATH="$BK_FILE_PATH"' not in bk_functions

--- a/result_server/tests/test_source_info_properties.py
+++ b/result_server/tests/test_source_info_properties.py
@@ -26,8 +26,14 @@ md5sum_strategy = st.text(
     alphabet="0123456789abcdef", min_size=32, max_size=32
 )
 
+# Strategy for valid 64-digit hexadecimal SHA-256 hashes.
+sha256sum_strategy = st.text(
+    alphabet="0123456789abcdef", min_size=64, max_size=64
+)
+
 COMMIT_HASH_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 MD5SUM_PATTERN = re.compile(r"^[0-9a-f]{32}$")
+SHA256SUM_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 
 
 class TestHashValueFormatProperty:
@@ -47,6 +53,13 @@ class TestHashValueFormatProperty:
         assert len(md5sum) == 32
         assert MD5SUM_PATTERN.match(md5sum) is not None
 
+    @given(sha256sum=sha256sum_strategy)
+    @settings(max_examples=100)
+    def test_sha256sum_is_exactly_64_hex_digits(self, sha256sum):
+        """Validate that SHA-256 hashes stay at 64 hexadecimal characters."""
+        assert len(sha256sum) == 64
+        assert SHA256SUM_PATTERN.match(sha256sum) is not None
+
     @given(commit_hash=commit_hash_strategy)
     @settings(max_examples=100)
     def test_git_source_info_structure_valid_with_commit_hash(self, commit_hash):
@@ -64,20 +77,23 @@ class TestHashValueFormatProperty:
         assert "commit_hash" in source_info
         assert COMMIT_HASH_PATTERN.match(source_info["commit_hash"]) is not None
 
-    @given(md5sum=md5sum_strategy)
+    @given(md5sum=md5sum_strategy, sha256sum=sha256sum_strategy)
     @settings(max_examples=100)
-    def test_file_source_info_structure_valid_with_md5sum(self, md5sum):
-        """Validate a file source_info payload with a formatted MD5 hash."""
+    def test_file_source_info_structure_valid_with_file_hashes(self, md5sum, sha256sum):
+        """Validate a file source_info payload with formatted file hashes."""
         source_info = {
             "source_type": "file",
             "file_path": "/path/to/archive.tar.gz",
             "md5sum": md5sum,
+            "sha256sum": sha256sum,
         }
 
         assert source_info["source_type"] == "file"
         assert "file_path" in source_info
         assert "md5sum" in source_info
+        assert "sha256sum" in source_info
         assert MD5SUM_PATTERN.match(source_info["md5sum"]) is not None
+        assert SHA256SUM_PATTERN.match(source_info["sha256sum"]) is not None
 
 
 def test_git_source_link_allows_http_urls_only():

--- a/result_server/utils/result_detail_view.py
+++ b/result_server/utils/result_detail_view.py
@@ -213,6 +213,7 @@ def _build_environment_rows(environment_snapshot):
     ci = payload.get("ci") if isinstance(payload.get("ci"), dict) else {}
     benchkit = payload.get("benchkit") if isinstance(payload.get("benchkit"), dict) else {}
     toolchain = payload.get("toolchain") if isinstance(payload.get("toolchain"), dict) else {}
+    display_toolchain = _display_toolchain(toolchain)
 
     rows = build_labeled_value_rows([
         ("Snapshot Hash", environment_snapshot.get("hash", "N/A")),
@@ -228,10 +229,55 @@ def _build_environment_rows(environment_snapshot):
         ("CI Job", ci.get("job_name") or "N/A"),
         ("Benchkit Commit", summary.get("benchkit_commit") or benchkit.get("commit_hash") or "N/A"),
     ])
-    modules = toolchain.get("modules") or []
+    modules = display_toolchain.get("modules") or []
     if modules:
         rows.append({"label": "Modules", "list": modules[:20]})
+    commands = _build_toolchain_command_summary(display_toolchain.get("commands"))
+    if commands:
+        rows.append({"label": "Build Tools", "list": commands})
     return rows
+
+
+def _display_toolchain(toolchain):
+    if not isinstance(toolchain, dict):
+        return {}
+    if isinstance(toolchain.get("commands"), dict) or isinstance(toolchain.get("modules"), list):
+        return toolchain
+    for stage in ("build_actual", "build_run", "build", "run"):
+        stage_toolchain = toolchain.get(stage)
+        if isinstance(stage_toolchain, dict) and stage_toolchain:
+            return stage_toolchain
+    return {}
+
+
+def _build_toolchain_command_summary(commands):
+    if not isinstance(commands, dict):
+        return []
+
+    rows = []
+    for name in (
+        "cc",
+        "gcc",
+        "mpicc",
+        "mpicxx",
+        "mpif90",
+        "mpifort",
+        "nvcc",
+        "nvc",
+        "nvfortran",
+        "cmake",
+        "make",
+        "apptainer",
+    ):
+        command = commands.get(name)
+        if not isinstance(command, dict):
+            continue
+        version = str(command.get("version") or "").strip()
+        path = str(command.get("path") or "").strip()
+        value = version if version else path
+        if value:
+            rows.append(f"{name}: {value}")
+    return rows[:12]
 
 
 def _environment_snapshot_hash(environment_snapshot):

--- a/result_server/utils/result_metadata_index.py
+++ b/result_server/utils/result_metadata_index.py
@@ -35,7 +35,7 @@ def _nested_text(data: dict[str, Any], *keys: str) -> str:
 def _source_ref(source_info: dict[str, Any]) -> str:
     if not isinstance(source_info, dict):
         return ""
-    for key in ("commit_hash", "md5sum", "branch", "file_path", "repo_url"):
+    for key in ("commit_hash", "sha256sum", "md5sum", "branch", "file_path", "repo_url"):
         value = _as_text(source_info.get(key))
         if value:
             return value
@@ -54,7 +54,15 @@ def _metadata_for_result(payload: dict[str, Any]) -> dict[str, Any]:
         "nthreads": payload.get("nthreads"),
         "source_info": {
             key: source_info.get(key)
-            for key in ("source_type", "repo_url", "branch", "commit_hash", "file_path", "md5sum")
+            for key in (
+                "source_type",
+                "repo_url",
+                "branch",
+                "commit_hash",
+                "file_path",
+                "md5sum",
+                "sha256sum",
+            )
             if source_info.get(key)
         },
     }

--- a/result_server/utils/result_quality_rollup.py
+++ b/result_server/utils/result_quality_rollup.py
@@ -41,21 +41,26 @@ def _summarize_source_info(data: Dict[str, Any]) -> Dict[str, Any]:
             else branch or short_hash or "git metadata incomplete"
         )
     elif source_type == "file":
-        required_fields = ("file_path", "md5sum")
+        required_fields = ("file_path",)
         file_path = source_info.get("file_path") or ""
+        sha256sum = source_info.get("sha256sum") or ""
         md5sum = source_info.get("md5sum") or ""
+        short_sha256 = sha256sum[:12] if sha256sum else ""
         short_md5 = md5sum[:8] if md5sum else ""
         basename = os.path.basename(file_path) if file_path else ""
+        source_hash = short_sha256 or short_md5
         reference = (
-            f"{basename}@{short_md5}"
-            if basename and short_md5
-            else basename or short_md5 or "file metadata incomplete"
+            f"{basename}@{source_hash}"
+            if basename and source_hash
+            else basename or source_hash or "file metadata incomplete"
         )
     else:
         required_fields = ()
         reference = "unknown source type"
 
     missing_fields = [field for field in required_fields if not source_info.get(field)]
+    if source_type == "file" and not source_info.get("sha256sum") and not source_info.get("md5sum"):
+        missing_fields.append("sha256sum")
     if source_type == "unknown":
         missing_fields = ["source_type"]
 

--- a/result_server/utils/result_records.py
+++ b/result_server/utils/result_records.py
@@ -82,7 +82,9 @@ def summarize_result_quality(data):
             source_missing_fields = [key for key in ("repo_url", "branch", "commit_hash") if not source_info.get(key)]
             source_info_complete = not source_missing_fields
         elif source_type == "file":
-            source_missing_fields = [key for key in ("file_path", "md5sum") if not source_info.get(key)]
+            source_missing_fields = [key for key in ("file_path",) if not source_info.get(key)]
+            if not source_info.get("sha256sum") and not source_info.get("md5sum"):
+                source_missing_fields.append("sha256sum")
             source_info_complete = not source_missing_fields
         else:
             warnings.append("source_info has unknown source_type")

--- a/result_server/utils/result_table_rows.py
+++ b/result_server/utils/result_table_rows.py
@@ -129,6 +129,9 @@ def _format_source_hash(source_info):
         return f"{branch}@{short_hash}" if branch and short_hash else short_hash or branch or "-"
 
     if source_type == "file":
+        sha256sum = source_info.get("sha256sum", "")
+        if sha256sum:
+            return sha256sum[:12]
         md5sum = source_info.get("md5sum", "")
         return md5sum[:8] if md5sum else "-"
 

--- a/result_server/utils/results_loader.py
+++ b/result_server/utils/results_loader.py
@@ -19,7 +19,7 @@ ESTIMATED_FIELD_MAP = {"system": "current_system.system", "code": "code", "exp":
 RESULT_TABLE_COLUMNS = [
     {"label": "Timestamp", "key": "timestamp", "tooltip": "Date and time when benchmark execution completed and results were automatically submitted to server", "tooltip_class": "tooltip-left"},
     {"label": "CODE", "key": "code"},
-    {"label": "Branch/Hash", "key": "source_hash", "tooltip": "Source code branch name and short commit hash (git) or short md5sum (file archive)"},
+    {"label": "Branch/Hash", "key": "source_hash", "tooltip": "Source code branch name and short commit hash (git) or short sha256/md5 hash (file archive)"},
     {"label": "Exp", "key": "exp", "tooltip": "Experimental conditions (filtered by CODE)"},
     {"label": "FOM", "key": "fom", "tooltip": "Figure of Merit - Benchmark performance metric value with its unit when available"},
     {"label": "FOM version", "key": "fom_version", "tooltip": "Version identifier for the FOM measurement section - helps identify which code region was measured when users modify the timing boundaries"},

--- a/scripts/bk_functions.sh
+++ b/scripts/bk_functions.sh
@@ -4,6 +4,11 @@
 #
 # Bash is required for the estimation and profiler helpers below.
 
+if [ -z "${BK_BENCHKIT_ROOT:-}" ]; then
+  BK_BENCHKIT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+  export BK_BENCHKIT_ROOT
+fi
+
 # bk_emit_result - Output a standardized FOM result line.
 #
 # Named arguments:
@@ -1763,6 +1768,87 @@ bk_base64_encode_value() {
   return 1
 }
 
+bk_md5_file() {
+  _bk_hash_file="$1"
+  if command -v md5sum >/dev/null 2>&1; then
+    md5sum "$_bk_hash_file" | awk '{print $1}'
+    return ${PIPESTATUS[0]}
+  fi
+  if command -v md5 >/dev/null 2>&1; then
+    md5 -r "$_bk_hash_file" | awk '{print $1}'
+    return ${PIPESTATUS[0]}
+  fi
+  return 1
+}
+
+bk_sha256_file() {
+  _bk_hash_file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$_bk_hash_file" | awk '{print $1}'
+    return ${PIPESTATUS[0]}
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$_bk_hash_file" | awk '{print $1}'
+    return ${PIPESTATUS[0]}
+  fi
+  if command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 -r "$_bk_hash_file" | awk '{print $1}'
+    return ${PIPESTATUS[0]}
+  fi
+  return 1
+}
+
+bk_lower_hex() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+bk_validate_hex_length() {
+  _bk_hash_value="$1"
+  _bk_hash_len="$2"
+  _bk_hash_label="$3"
+  if [ "${#_bk_hash_value}" -ne "$_bk_hash_len" ]; then
+    echo "${_bk_hash_label}: expected ${_bk_hash_len} hex characters, got ${#_bk_hash_value}" >&2
+    return 1
+  fi
+  case "$_bk_hash_value" in
+    *[!0-9a-f]*)
+      echo "${_bk_hash_label}: expected lowercase hex characters" >&2
+      return 1
+      ;;
+  esac
+  return 0
+}
+
+bk_verify_file_sha256() {
+  _bk_file_path="$1"
+  _bk_expected_sha256="$(bk_lower_hex "${2:-}")"
+  _bk_label="${3:-source archive}"
+  _bk_actual_sha256=""
+
+  if [ -z "$_bk_expected_sha256" ] && [ "${BK_REQUIRE_SOURCE_SHA256:-false}" = "true" ]; then
+    echo "${_bk_label}: expected sha256 is required when BK_REQUIRE_SOURCE_SHA256=true" >&2
+    return 1
+  fi
+
+  if ! _bk_actual_sha256=$(bk_sha256_file "$_bk_file_path"); then
+    echo "${_bk_label}: unable to compute sha256 for $_bk_file_path" >&2
+    return 1
+  fi
+  _bk_actual_sha256="$(bk_lower_hex "$_bk_actual_sha256")"
+
+  if [ -n "$_bk_expected_sha256" ]; then
+    bk_validate_hex_length "$_bk_expected_sha256" 64 "${_bk_label} sha256" || return 1
+    if [ "$_bk_actual_sha256" != "$_bk_expected_sha256" ]; then
+      echo "${_bk_label}: sha256 mismatch for $_bk_file_path" >&2
+      echo "  expected: $_bk_expected_sha256" >&2
+      echo "  actual:   $_bk_actual_sha256" >&2
+      return 1
+    fi
+  fi
+
+  printf '%s\n' "$_bk_actual_sha256"
+}
+
 bk_write_source_info_env() {
   _bk_source_type="$1"
   _bk_repo_url="${2:-}"
@@ -1770,6 +1856,9 @@ bk_write_source_info_env() {
   _bk_commit_hash="${4:-}"
   _bk_file_path="${5:-}"
   _bk_md5sum="${6:-}"
+  _bk_sha256sum="${7:-}"
+  _bk_container_path="${8:-${BK_SOURCE_CONTAINER_PATH:-}}"
+  _bk_container_sha256sum="${9:-${BK_SOURCE_CONTAINER_SHA256:-}}"
 
   if ! command -v base64 >/dev/null 2>&1 && ! command -v openssl >/dev/null 2>&1; then
     echo "bk_write_source_info_env: neither base64 nor openssl found" >&2
@@ -1784,18 +1873,107 @@ bk_write_source_info_env() {
     printf 'BK_COMMIT_HASH_B64=%s\n' "$(bk_base64_encode_value "$_bk_commit_hash")"
     printf 'BK_FILE_PATH_B64=%s\n' "$(bk_base64_encode_value "$_bk_file_path")"
     printf 'BK_MD5SUM_B64=%s\n' "$(bk_base64_encode_value "$_bk_md5sum")"
+    printf 'BK_SHA256SUM_B64=%s\n' "$(bk_base64_encode_value "$_bk_sha256sum")"
+    printf 'BK_CONTAINER_IMAGE_PATH_B64=%s\n' "$(bk_base64_encode_value "$_bk_container_path")"
+    printf 'BK_CONTAINER_IMAGE_SHA256SUM_B64=%s\n' "$(bk_base64_encode_value "$_bk_container_sha256sum")"
   } > results/source_info.env
+}
+
+bk_record_file_source_info() {
+  _bk_file_src="$1"
+  _bk_expected_sha256="${2:-}"
+  _bk_file_label="${3:-source archive}"
+  _bk_abs_file_path=""
+  _bk_md5sum=""
+  _bk_sha256sum=""
+
+  if [ ! -f "$_bk_file_src" ]; then
+    echo "${_bk_file_label}: file not found: $_bk_file_src" >&2
+    return 1
+  fi
+
+  case "$_bk_file_src" in
+    /*) _bk_abs_file_path="$_bk_file_src" ;;
+    *) _bk_abs_file_path="$(pwd)/$_bk_file_src" ;;
+  esac
+
+  if ! _bk_sha256sum=$(bk_verify_file_sha256 "$_bk_file_src" "$_bk_expected_sha256" "$_bk_file_label"); then
+    return 1
+  fi
+
+  if _bk_md5sum=$(bk_md5_file "$_bk_file_src"); then
+    _bk_md5sum="$(bk_lower_hex "$_bk_md5sum")"
+  else
+    echo "${_bk_file_label}: warning: neither md5sum nor md5 found" >&2
+    _bk_md5sum=""
+  fi
+
+  BK_SOURCE_TYPE="file"
+  BK_FILE_PATH="$_bk_abs_file_path"
+  BK_MD5SUM="$_bk_md5sum"
+  BK_SHA256SUM="$_bk_sha256sum"
+  export BK_SOURCE_TYPE BK_FILE_PATH BK_MD5SUM BK_SHA256SUM
+
+  mkdir -p results
+  bk_write_source_info_env "file" "" "" "" "$BK_FILE_PATH" "$BK_MD5SUM" "$BK_SHA256SUM"
+}
+
+bk_capture_build_environment_snapshot() {
+  local snapshot_file="${1:-results/environment_snapshot_build_actual.json}"
+  local snapshot_stage="${2:-build_actual}"
+  local strict="${BK_STRICT_BUILD_ENVIRONMENT_SNAPSHOT:-false}"
+  local system_value="${BK_SYSTEM:-${system:-}}"
+  local repo_root="${BK_BENCHKIT_ROOT:-$PWD}"
+  local collector="${repo_root}/scripts/collect_environment_snapshot.sh"
+
+  if [ "${BK_CAPTURE_BUILD_ENVIRONMENT_SNAPSHOT:-true}" = "false" ]; then
+    return 0
+  fi
+  if [ ! -f "$collector" ]; then
+    echo "bk_capture_build_environment_snapshot: ${collector} not found; skipping" >&2
+    return 0
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "bk_capture_build_environment_snapshot: jq not found; skipping" >&2
+    return 0
+  fi
+
+  case "$snapshot_file" in
+    /*) ;;
+    *) snapshot_file="${repo_root}/${snapshot_file}" ;;
+  esac
+
+  mkdir -p "$(dirname "$snapshot_file")"
+  if (
+    cd "$repo_root" &&
+    BK_SYSTEM="$system_value" BK_SNAPSHOT_STAGE="$snapshot_stage" \
+      bash "$collector" "$snapshot_file"
+  ); then
+    return 0
+  fi
+
+  echo "bk_capture_build_environment_snapshot: failed to write ${snapshot_file}" >&2
+  if [ "$strict" = "true" ]; then
+    return 1
+  fi
+  return 0
+}
+
+bk_make() {
+  bk_capture_build_environment_snapshot
+  make "$@"
 }
 
 # bk_fetch_source - Fetch source code and collect metadata.
 #
 # Usage:
-#   bk_fetch_source <source> <dest_dir> [branch]
+#   bk_fetch_source <source> <dest_dir> [branch] [expected_commit_or_sha256]
 #
 # Arguments:
 #   $1 - source: Repository URL or archive file path
 #   $2 - dest_dir: Destination directory name
 #   $3 - branch: (optional) Git branch to clone
+#   $4 - expected commit for git, expected sha256 for archive (optional)
 #
 # Auto-detection:
 #   http:// / https:// prefix or .git suffix → git clone
@@ -1808,6 +1986,7 @@ bk_write_source_info_env() {
 #   BK_COMMIT_HASH  - (git) Full 40-char commit hash
 #   BK_FILE_PATH    - (file) Absolute path to archive
 #   BK_MD5SUM       - (file) Full 32-char md5sum
+#   BK_SHA256SUM    - (file) Full 64-char sha256sum
 #
 # Side effects:
 #   Writes results/source_info.env as data, not executable shell
@@ -1824,6 +2003,7 @@ bk_fetch_source() {
   _bk_src="$1"
   _bk_dest="$2"
   _bk_branch="${3:-}"
+  _bk_expected="${4:-}"
 
   # Auto-detect source type
   _bk_is_git=0
@@ -1843,6 +2023,10 @@ bk_fetch_source() {
     BK_SOURCE_TYPE="git"
     BK_REPO_URL="$_bk_src"
     export BK_SOURCE_TYPE BK_REPO_URL
+    _bk_expected_commit="$(bk_lower_hex "${BK_FETCH_EXPECTED_COMMIT:-$_bk_expected}")"
+    if [ -n "$_bk_expected_commit" ]; then
+      bk_validate_hex_length "$_bk_expected_commit" 40 "bk_fetch_source expected commit" || return 1
+    fi
 
     if [ -d "$_bk_dest" ]; then
       # Directory exists: skip clone, collect metadata from existing dir
@@ -1866,14 +2050,33 @@ bk_fetch_source() {
       BK_COMMIT_HASH=$(git -C "$_bk_dest" rev-parse HEAD 2>/dev/null || echo "")
     fi
 
+    if [ -n "$_bk_expected_commit" ]; then
+      if ! git -C "$_bk_dest" cat-file -e "${_bk_expected_commit}^{commit}" 2>/dev/null; then
+        git -C "$_bk_dest" fetch origin "$_bk_expected_commit" 2>/dev/null || true
+      fi
+      if ! git -C "$_bk_dest" checkout --detach "$_bk_expected_commit" 2>&1; then
+        echo "bk_fetch_source: expected commit not available: $_bk_expected_commit" >&2
+        return 1
+      fi
+      BK_COMMIT_HASH=$(git -C "$_bk_dest" rev-parse HEAD 2>/dev/null || echo "")
+      if [ "$BK_COMMIT_HASH" != "$_bk_expected_commit" ]; then
+        echo "bk_fetch_source: commit mismatch for '$_bk_src'" >&2
+        echo "  expected: $_bk_expected_commit" >&2
+        echo "  actual:   $BK_COMMIT_HASH" >&2
+        return 1
+      fi
+      if [ -z "$BK_BRANCH" ] || [ "$BK_BRANCH" = "HEAD" ]; then
+        BK_BRANCH="${_bk_branch:-detached}"
+      fi
+    fi
+
     export BK_BRANCH BK_COMMIT_HASH
 
     bk_write_source_info_env "git" "$BK_REPO_URL" "$BK_BRANCH" "$BK_COMMIT_HASH"
 
   else
     # --- File archive path ---
-    BK_SOURCE_TYPE="file"
-    export BK_SOURCE_TYPE
+    _bk_expected_sha256="${BK_FETCH_EXPECTED_SHA256:-$_bk_expected}"
 
     # Check archive exists
     if [ ! -f "$_bk_src" ]; then
@@ -1881,27 +2084,7 @@ bk_fetch_source() {
       return 1
     fi
 
-    # Compute absolute path
-    case "$_bk_src" in
-      /*)
-        BK_FILE_PATH="$_bk_src"
-        ;;
-      *)
-        BK_FILE_PATH="$(pwd)/$_bk_src"
-        ;;
-    esac
-    export BK_FILE_PATH
-
-    # Cross-platform md5sum
-    if command -v md5sum >/dev/null 2>&1; then
-      BK_MD5SUM=$(md5sum "$_bk_src" | awk '{print $1}')
-    elif command -v md5 >/dev/null 2>&1; then
-      BK_MD5SUM=$(md5 -r "$_bk_src" | awk '{print $1}')
-    else
-      echo "bk_fetch_source: warning: neither md5sum nor md5 found" >&2
-      BK_MD5SUM=""
-    fi
-    export BK_MD5SUM
+    bk_record_file_source_info "$_bk_src" "$_bk_expected_sha256" "bk_fetch_source archive" || return 1
 
     # Extract archive if dest_dir doesn't exist
     if [ ! -d "$_bk_dest" ]; then
@@ -1910,8 +2093,6 @@ bk_fetch_source() {
         return 1
       fi
     fi
-
-    bk_write_source_info_env "file" "" "" "" "$BK_FILE_PATH" "$BK_MD5SUM"
 
   fi
 

--- a/scripts/collect_environment_snapshot.sh
+++ b/scripts/collect_environment_snapshot.sh
@@ -9,8 +9,29 @@ json_string_array() {
   jq -R -s -c 'split("\n") | map(select(length > 0))'
 }
 
+json_empty_object_if_blank() {
+  if [ -n "$1" ]; then
+    printf '%s' "$1"
+  else
+    printf '{}'
+  fi
+}
+
 command_path() {
   command -v "$1" 2>/dev/null || true
+}
+
+resolved_command_path() {
+  local path="$1"
+  if [ -z "$path" ]; then
+    printf '%s' ""
+    return 0
+  fi
+  if command -v readlink >/dev/null 2>&1; then
+    readlink -f "$path" 2>/dev/null || printf '%s' "$path"
+    return 0
+  fi
+  printf '%s' "$path"
 }
 
 command_version() {
@@ -21,12 +42,94 @@ command_version() {
   fi
 }
 
+snapshot_command_version() {
+  local cmd="$1"
+  case "$cmd" in
+    python|python3|python3.*)
+      command_version "$cmd" --version
+      ;;
+    *)
+      command_version "$cmd" --version
+      ;;
+  esac
+}
+
+snapshot_tool_commands_json() {
+  local default_commands
+  default_commands="bash sh cc c++ gcc g++ clang clang++ fcc fccpx frt frtpx "
+  default_commands+="mpicc mpicxx mpifcc mpifccpx mpifrt mpifrtpx mpif90 mpifort "
+  default_commands+="mpiicc mpiicpc mpiifort gfortran nvcc nvc nvc++ nvfortran "
+  default_commands+="cmake make ninja ld ar pkg-config python3 apptainer singularity ncu nsys"
+
+  local commands="${BK_SNAPSHOT_TOOL_COMMANDS:-$default_commands}"
+  local cmd path real_path version
+
+  for cmd in $commands; do
+    path=$(command_path "$cmd")
+    if [ -z "$path" ]; then
+      continue
+    fi
+    real_path=$(resolved_command_path "$path")
+    version=$(snapshot_command_version "$cmd")
+    jq -n -c \
+      --arg name "$cmd" \
+      --arg path "$path" \
+      --arg real_path "$real_path" \
+      --arg version "$version" \
+      '{key: $name, value: {path: $path, real_path: $real_path, version: $version}}'
+  done | jq -s -c 'from_entries'
+}
+
+snapshot_env_is_sensitive() {
+  case "$1" in
+    *TOKEN*|*SECRET*|*PASSWORD*|*PASSWD*|*PRIVATE*|*CREDENTIAL*|*AUTH*|*KEY*|*CERT*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+snapshot_environment_json() {
+  local default_vars
+  default_vars="CC CXX FC F77 F90 CPP CPPFLAGS CFLAGS CXXFLAGS FCFLAGS FFLAGS "
+  default_vars+="LDFLAGS LIBS PATH LD_LIBRARY_PATH LIBRARY_PATH CPATH PKG_CONFIG_PATH "
+  default_vars+="MODULEPATH LOADEDMODULES CUDA_HOME CUDA_PATH NVHPC_ROOT OMP_NUM_THREADS "
+  default_vars+="OMPI_CC OMPI_CXX OMPI_FC MPICH_CC MPICH_CXX MPICH_FC"
+
+  local vars="${BK_SNAPSHOT_ENV_VARS:-$default_vars}"
+  local name value
+
+  for name in $vars; do
+    case "$name" in
+      [A-Za-z_][A-Za-z0-9_]*)
+        ;;
+      *)
+        continue
+        ;;
+    esac
+    if [ -z "${!name+x}" ]; then
+      continue
+    fi
+    if snapshot_env_is_sensitive "$name"; then
+      value="[redacted]"
+    else
+      value="${!name}"
+    fi
+    jq -n -c --arg key "$name" --arg value "$value" '{key: $key, value: $value}'
+  done | jq -s -c 'from_entries'
+}
+
 module_list_json="[]"
 if command -v module >/dev/null 2>&1; then
   module_list_json=$(module -t list 2>&1 | sed '/^No Modulefiles Currently Loaded/d' | json_string_array)
 elif [ -n "${LOADEDMODULES:-}" ]; then
   module_list_json=$(printf '%s' "$LOADEDMODULES" | tr ':' '\n' | json_string_array)
 fi
+
+tool_commands_json=$(snapshot_tool_commands_json)
+tool_environment_json=$(snapshot_environment_json)
 
 git_commit=""
 git_branch=""
@@ -85,7 +188,11 @@ jq -n \
   --arg mpicc_version "$(command_version mpicc --version)" \
   --arg nvcc_version "$(command_version nvcc --version)" \
   --arg python_version "$(command_version python3 --version)" \
+  --arg container_image_path "${BK_SOURCE_CONTAINER_PATH:-}" \
+  --arg container_image_sha256sum "${BK_SOURCE_CONTAINER_SHA256:-}" \
   --argjson modules "$module_list_json" \
+  --argjson commands "$(json_empty_object_if_blank "$tool_commands_json")" \
+  --argjson environment "$(json_empty_object_if_blank "$tool_environment_json")" \
   '{
     schema_version: ($schema_version | tonumber),
     stage: $stage,
@@ -130,7 +237,13 @@ jq -n \
       mpicc: $mpicc_version,
       nvcc: $nvcc_version,
       python3: $python_version,
-      modules: $modules
+      modules: $modules,
+      commands: $commands,
+      environment: $environment,
+      container: {
+        image_path: $container_image_path,
+        image_sha256sum: $container_image_sha256sum
+      }
     }
   }' > "$out_file"
 

--- a/scripts/result.sh
+++ b/scripts/result.sh
@@ -132,7 +132,17 @@ build_source_info_block() {
       --arg repo_url "$(source_info_env_value BK_REPO_URL)" \
       --arg branch "$(source_info_env_value BK_BRANCH)" \
       --arg commit_hash "$(source_info_env_value BK_COMMIT_HASH)" \
-      '{source_type: $source_type, repo_url: $repo_url, branch: $branch, commit_hash: $commit_hash}'
+      --arg container_path "$(source_info_env_value BK_CONTAINER_IMAGE_PATH)" \
+      --arg container_sha256sum "$(source_info_env_value BK_CONTAINER_IMAGE_SHA256SUM)" \
+      '
+      {source_type: $source_type, repo_url: $repo_url, branch: $branch, commit_hash: $commit_hash}
+      + (if $container_path != "" or $container_sha256sum != "" then {
+          container_image: {
+            file_path: $container_path,
+            sha256sum: $container_sha256sum
+          }
+        } else {} end)
+      '
     return 0
   fi
 
@@ -141,7 +151,11 @@ build_source_info_block() {
       --arg source_type "file" \
       --arg file_path "$(source_info_env_value BK_FILE_PATH)" \
       --arg md5sum "$(source_info_env_value BK_MD5SUM)" \
-      '{source_type: $source_type, file_path: $file_path, md5sum: $md5sum}'
+      --arg sha256sum "$(source_info_env_value BK_SHA256SUM)" \
+      '
+      {source_type: $source_type, file_path: $file_path, md5sum: $md5sum}
+      + (if $sha256sum != "" then {sha256sum: $sha256sum} else {} end)
+      '
     return 0
   fi
 
@@ -167,18 +181,23 @@ sha256_text() {
 build_environment_snapshot_block() {
   local snapshot_file="results/environment_snapshot.json"
   local build_snapshot_file="results/environment_snapshot_build.json"
+  local build_actual_snapshot_file="results/environment_snapshot_build_actual.json"
   local run_snapshot_file="results/environment_snapshot_run.json"
   local native_snapshot_file="results/environment_snapshot_build_run.json"
   local snapshot_source
 
   if [ -f "$snapshot_file" ]; then
     snapshot_source=$(jq -cS . "$snapshot_file" 2>/dev/null || true)
-  elif [ -f "$build_snapshot_file" ] || [ -f "$run_snapshot_file" ] || [ -f "$native_snapshot_file" ]; then
+  elif [ -f "$build_snapshot_file" ] || [ -f "$build_actual_snapshot_file" ] || [ -f "$run_snapshot_file" ] || [ -f "$native_snapshot_file" ]; then
     local build_snapshot="{}"
+    local build_actual_snapshot="{}"
     local run_snapshot="{}"
     local build_run_snapshot="{}"
     if [ -f "$build_snapshot_file" ]; then
       build_snapshot=$(jq -cS . "$build_snapshot_file" 2>/dev/null || printf '{}')
+    fi
+    if [ -f "$build_actual_snapshot_file" ]; then
+      build_actual_snapshot=$(jq -cS . "$build_actual_snapshot_file" 2>/dev/null || printf '{}')
     fi
     if [ -f "$run_snapshot_file" ]; then
       run_snapshot=$(jq -cS . "$run_snapshot_file" 2>/dev/null || printf '{}')
@@ -188,10 +207,11 @@ build_environment_snapshot_block() {
     fi
     snapshot_source=$(jq -cS -n \
       --argjson build "$build_snapshot" \
+      --argjson build_actual "$build_actual_snapshot" \
       --argjson run "$run_snapshot" \
       --argjson build_run "$build_run_snapshot" \
       '
-      ($run | if . == {} then ($build_run | if . == {} then $build else . end) else . end) as $primary |
+      ($run | if . == {} then ($build_run | if . == {} then ($build_actual | if . == {} then $build else . end) else . end) else . end) as $primary |
       {
         schema_version: 1,
         collected_at: ($primary.collected_at // ""),
@@ -207,11 +227,13 @@ build_environment_snapshot_block() {
         ),
         toolchain: {
           build: ($build.toolchain // {}),
+          build_actual: ($build_actual.toolchain // {}),
           run: ($run.toolchain // {}),
           build_run: ($build_run.toolchain // {})
         },
         stages: {
           build: $build,
+          build_actual: $build_actual,
           run: $run,
           build_run: $build_run
         }

--- a/scripts/tests/test_bk_fetch_source.sh
+++ b/scripts/tests/test_bk_fetch_source.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_DIR=$(cd "${SCRIPT_DIR}/../.." && pwd)
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq not found; skipping bk_fetch_source test"
+  exit 0
+fi
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+source "${REPO_DIR}/scripts/bk_functions.sh"
+
+write_minimal_result() {
+  mkdir -p results
+  cat > results/result <<'EOF'
+FOM:1.0 FOM_unit:s FOM_version:test Exp:CASE0 node_count:1 numproc_node:1 nthreads:1
+EOF
+}
+
+make_zero_sha1() {
+  printf '0%.0s' {1..40}
+}
+
+make_zero_sha256() {
+  printf '0%.0s' {1..64}
+}
+
+mkdir -p "${TMP_DIR}/src"
+git -C "${TMP_DIR}/src" init -q
+git -C "${TMP_DIR}/src" config user.email "benchkit-test@example.invalid"
+git -C "${TMP_DIR}/src" config user.name "Benchkit Test"
+git -C "${TMP_DIR}/src" checkout -q -b main
+printf 'first\n' > "${TMP_DIR}/src/value.txt"
+git -C "${TMP_DIR}/src" add value.txt
+git -C "${TMP_DIR}/src" commit -q -m "first"
+commit_one=$(git -C "${TMP_DIR}/src" rev-parse HEAD)
+printf 'second\n' > "${TMP_DIR}/src/value.txt"
+git -C "${TMP_DIR}/src" commit -q -am "second"
+git -C "${TMP_DIR}/src" clone -q --bare "${TMP_DIR}/src" "${TMP_DIR}/origin.git"
+
+mkdir -p "${TMP_DIR}/git-work"
+pushd "${TMP_DIR}/git-work" >/dev/null
+write_minimal_result
+bk_fetch_source "${TMP_DIR}/origin.git" checkout main "$commit_one"
+test "$(git -C checkout rev-parse HEAD)" = "$commit_one"
+bash "${REPO_DIR}/scripts/result.sh" app TestSystem native build run 123 >/dev/null
+jq -e --arg commit "$commit_one" '
+  .source_info.source_type == "git" and
+  .source_info.branch == "main" and
+  .source_info.commit_hash == $commit
+' results/result0.json >/dev/null
+popd >/dev/null
+
+mkdir -p "${TMP_DIR}/git-mismatch"
+pushd "${TMP_DIR}/git-mismatch" >/dev/null
+write_minimal_result
+if bk_fetch_source "${TMP_DIR}/origin.git" checkout main "$(make_zero_sha1)" >/dev/null 2>&1; then
+  echo "bk_fetch_source accepted a mismatched git commit" >&2
+  exit 1
+fi
+popd >/dev/null
+
+mkdir -p "${TMP_DIR}/archive-src/payload"
+printf 'archive payload\n' > "${TMP_DIR}/archive-src/payload/value.txt"
+tar -czf "${TMP_DIR}/source.tar.gz" -C "${TMP_DIR}/archive-src" payload
+archive_sha256=$(bk_sha256_file "${TMP_DIR}/source.tar.gz")
+
+mkdir -p "${TMP_DIR}/archive-work"
+pushd "${TMP_DIR}/archive-work" >/dev/null
+write_minimal_result
+bk_fetch_source "${TMP_DIR}/source.tar.gz" payload "" "$archive_sha256"
+test -f payload/value.txt
+bash "${REPO_DIR}/scripts/result.sh" app TestSystem native build run 123 >/dev/null
+jq -e --arg sha256 "$archive_sha256" '
+  .source_info.source_type == "file" and
+  .source_info.sha256sum == $sha256 and
+  (.source_info.md5sum | length) == 32
+' results/result0.json >/dev/null
+popd >/dev/null
+
+mkdir -p "${TMP_DIR}/archive-mismatch"
+pushd "${TMP_DIR}/archive-mismatch" >/dev/null
+write_minimal_result
+if bk_fetch_source "${TMP_DIR}/source.tar.gz" payload "" "$(make_zero_sha256)" >/dev/null 2>&1; then
+  echo "bk_fetch_source accepted a mismatched archive sha256" >&2
+  exit 1
+fi
+popd >/dev/null
+
+mkdir -p "${TMP_DIR}/archive-require"
+pushd "${TMP_DIR}/archive-require" >/dev/null
+write_minimal_result
+if BK_REQUIRE_SOURCE_SHA256=true bk_fetch_source "${TMP_DIR}/source.tar.gz" payload >/dev/null 2>&1; then
+  echo "bk_fetch_source accepted an unpinned archive with BK_REQUIRE_SOURCE_SHA256=true" >&2
+  exit 1
+fi
+popd >/dev/null
+
+echo "bk_fetch_source provenance verification test passed"

--- a/scripts/tests/test_build_environment_snapshot.sh
+++ b/scripts/tests/test_build_environment_snapshot.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_DIR=$(cd "${SCRIPT_DIR}/../.." && pwd)
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq not found; skipping build environment snapshot test"
+  exit 0
+fi
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+mkdir -p "${TMP_DIR}/project/scripts" "${TMP_DIR}/project/results" "${TMP_DIR}/project/src"
+cp "${REPO_DIR}/scripts/bk_functions.sh" "${TMP_DIR}/project/scripts/bk_functions.sh"
+cp "${REPO_DIR}/scripts/collect_environment_snapshot.sh" "${TMP_DIR}/project/scripts/collect_environment_snapshot.sh"
+cp "${REPO_DIR}/scripts/result.sh" "${TMP_DIR}/project/scripts/result.sh"
+
+cat > "${TMP_DIR}/project/results/result" <<'EOF'
+FOM:1.0 FOM_unit:s FOM_version:test Exp:CASE0 node_count:1 numproc_node:1 nthreads:1
+EOF
+
+cat > "${TMP_DIR}/project/results/environment_snapshot_build.json" <<'EOF'
+{
+  "schema_version": 1,
+  "stage": "build",
+  "collected_at": "2026-08-24T00:00:00Z",
+  "system": {
+    "name": "TestSystem",
+    "allocation_project_id": ""
+  },
+  "scheduler": {
+    "kind": "unknown"
+  },
+  "runner": {
+    "description": "test-runner"
+  },
+  "ci": {},
+  "benchkit": {},
+  "toolchain": {
+    "modules": []
+  }
+}
+EOF
+
+pushd "${TMP_DIR}/project" >/dev/null
+source scripts/bk_functions.sh
+popd >/dev/null
+
+pushd "${TMP_DIR}/project/src" >/dev/null
+export BK_SYSTEM=TestSystem
+export BK_SNAPSHOT_TOOL_COMMANDS="bash"
+export BK_SNAPSHOT_ENV_VARS="CC SECRET_TOKEN"
+export CC=mpicc
+export SECRET_TOKEN=should_not_be_recorded
+bk_capture_build_environment_snapshot
+popd >/dev/null
+
+SNAPSHOT="${TMP_DIR}/project/results/environment_snapshot_build_actual.json"
+test -f "$SNAPSHOT"
+jq -e '
+  .stage == "build_actual" and
+  .system.name == "TestSystem" and
+  (.toolchain.commands.bash.path | length) > 0 and
+  .toolchain.environment.CC == "mpicc" and
+  .toolchain.environment.SECRET_TOKEN == "[redacted]"
+' "$SNAPSHOT" >/dev/null
+
+pushd "${TMP_DIR}/project" >/dev/null
+bash scripts/result.sh app TestSystem native build run 123 >/dev/null
+popd >/dev/null
+
+jq -e '
+  .environment_snapshot.payload.stages.build.stage == "build" and
+  .environment_snapshot.payload.stages.build_actual.stage == "build_actual" and
+  .environment_snapshot.payload.toolchain.build_actual.environment.CC == "mpicc" and
+  (.environment_snapshot.hash | startswith("sha256:"))
+' "${TMP_DIR}/project/results/result0.json" >/dev/null
+
+echo "build environment snapshot test passed"


### PR DESCRIPTION
## Summary
- add optional expected commit / SHA-256 verification to bk_fetch_source and archive-based source records
- record post-module-load actual build environment snapshots from build scripts
- include source/archive SHA-256 and actual build tool metadata in result metadata and detail views

## Tests
- shellcheck -S error scripts/collect_environment_snapshot.sh scripts/bk_functions.sh scripts/result.sh scripts/tests/test_bk_fetch_source.sh scripts/tests/test_build_environment_snapshot.sh programs/qws/build.sh programs/scale-letkf/build.sh programs/genesis/build.sh programs/genesis-nonbonded-kernels/build.sh programs/MHDTurbulence/build.sh programs/ffb/build.sh programs/LQCD_dw_solver/build.sh programs/salmon/build.sh
- bash scripts/tests/test_bk_profiler.sh && bash scripts/tests/test_bk_fetch_source.sh && bash scripts/tests/test_build_environment_snapshot.sh && bash scripts/tests/test_ncu_plan_generation.sh && bash scripts/tests/test_result_profile_data.sh && bash scripts/tests/test_process_and_send_results.sh && bash scripts/tests/test_scheduler_extra_args.sh && bash scripts/tests/test_send_results_profile_data.sh && bash scripts/tests/test_send_estimate_artifacts.sh && bash scripts/tests/test_estimation_gpu_kernel_ensemble_average.sh && bash scripts/tests/test_estimation_gpu_kernel_lightgbm_v10.sh && bash scripts/tests/test_estimation_gpu_kernel_mlp_v15.sh && bash scripts/tests/test_genesis_gpu_mlp_estimation.sh
- .venv/bin/python -m pytest result_server/tests
- .venv/bin/python scripts/tests/check_text_integrity.py
- git diff --check