### PR TITLE
Use build tool wrappers for environment snapshots

### DIFF
--- a/docs/guides/add-app.md
+++ b/docs/guides/add-app.md
@@ -128,8 +128,9 @@ portal の `/results/usage` では、この source provenance が各 app / syste
 CI の共通 wrapper は、`build.sh` 実行前に runner 側の軽量 snapshot を記録します。
 一方で、多くの app は `build.sh` 内で `module load` や compiler 設定を行うため、実際の build 環境は app build の直前で記録する必要があります。
 
-`scripts/bk_functions.sh` を source した build script では、`bk_capture_build_environment_snapshot` または `bk_make` を使ってください。
-`bk_make` は `make` 実行直前に `results/environment_snapshot_build_actual.json` を更新してから `make` を呼びます。
+CI の build job では `scripts/build_tool_wrappers/` を `PATH` の先頭に入れ、`make` / `cmake` / `ninja` の同名 wrapper が `results/environment_snapshot_build_actual.json` を更新してから本物の command に委譲します。
+そのため、app の `build.sh` では通常どおり `make` / `cmake` / `ninja` を呼べば十分です。
+特殊な独自ビルド command でこれらを経由しない場合だけ、必要に応じて `bk_capture_build_environment_snapshot` を個別に使えます。
 この snapshot には、主要 compiler / MPI / CUDA / profiler / container command の path と version、loaded modules、allowlist された build 環境変数が含まれます。
 `TOKEN`、`SECRET`、`PASSWORD`、`AUTH`、`KEY`、`CERT` などを名前に含む環境変数は値を redacted として記録します。
 
@@ -158,7 +159,7 @@ cd "${REPO_DIR}"
 case "$system" in
     Fugaku)
         # A64FX向けクロスコンパイル
-        bk_make -j 8 compiler=fujitsu_cross mpi=1
+        make -j 8 compiler=fujitsu_cross mpi=1
         ;;
     FugakuCN)
         # A64FX向けネイティブコンパイル
@@ -166,7 +167,7 @@ case "$system" in
         ;;
     MiyabiG)
         # Neoverse-N1向けビルド
-        bk_make -j 8 compiler=openmpi-gnu arch=skylake mpi=1
+        make -j 8 compiler=openmpi-gnu arch=skylake mpi=1
         ;;
     MiyabiC)
         # Intel向けビルド
@@ -175,7 +176,7 @@ case "$system" in
     RC_GENOA)
         # AMD Genoa向けビルド
         module load system/genoa mpi/openmpi-x86_64
-        bk_make -j 8 compiler=openmpi-gnu arch=skylake mpi=1
+        make -j 8 compiler=openmpi-gnu arch=skylake mpi=1
         ;;
     RC_DGXSP)
         # DGX Spark向けビルド

--- a/docs/guides/portal-execution-profiles-handoff.md
+++ b/docs/guides/portal-execution-profiles-handoff.md
@@ -55,14 +55,15 @@ Completed:
   `result_metadata_index` at ingest time. JSON/tgz artifacts remain the raw
   records and existing result pages remain file-backed.
 - Generated GitLab CI jobs collect lightweight environment snapshots in the
-  common build/run/build_run wrappers. Build scripts can additionally record
-  the post-module-load, pre-compile environment as
-  `results/environment_snapshot_build_actual.json`. Result submission combines
-  those artifacts into a Result JSON `environment_snapshot` reference block.
-  The Portal indexes the snapshot payload by hash in `environment_snapshots`
-  and links received results through `environment_snapshot_results`. Result
-  detail pages show the snapshot hash, allocation project ID, scheduler,
-  runner, and Benchkit commit.
+  common build/run/build_run wrappers. Build jobs put
+  `scripts/build_tool_wrappers/` at the front of `PATH`, so `make` / `cmake` /
+  `ninja` record the post-module-load, pre-compile environment as
+  `results/environment_snapshot_build_actual.json` before delegating to the real
+  command. Result submission combines those artifacts into a Result JSON
+  `environment_snapshot` reference block. The Portal indexes the snapshot
+  payload by hash in `environment_snapshots` and links received results through
+  `environment_snapshot_results`. Result detail pages show the snapshot hash,
+  allocation project ID, scheduler, runner, and Benchkit commit.
 
 Remaining follow-up:
 

--- a/programs/LQCD_dw_solver/build.sh
+++ b/programs/LQCD_dw_solver/build.sh
@@ -45,9 +45,9 @@ case "$system" in
       if [ ! -e Makefile_target.inc.keep ]; then
         cp Makefile_target.inc Makefile_target.inc.keep
       fi
-      bk_make -j 8 lib
+      make -j 8 lib
       cd benchmark/domainwall/
-      bk_make -j 8
+      make -j 8
       cd -
       cp $BIN ../artifacts
       #fccpx --version
@@ -59,9 +59,9 @@ case "$system" in
         cp Makefile_target.inc Makefile_target.inc.keep
         sed -i "s/FCCpx/FCC/g" Makefile_target.inc
       fi
-      bk_make -j 12 lib
+      make -j 12 lib
       cd benchmark/domainwall/
-      bk_make -j 12
+      make -j 12
       cd -
       cp $BIN ../artifacts
       ;;
@@ -73,46 +73,46 @@ case "$system" in
     #   ;;
     MiyabiC|AVX512)
       cp Makefile_simd_avx512 Makefile
-      bk_make -j 8 lib
+      make -j 8 lib
       cd benchmark/domainwall/
-      bk_make -j 8
+      make -j 8
       cd -
       cp $BIN ../artifacts
       ;;
     MiyabiG)
       # OpenACC
       cp Makefile_openacc Makefile
-      bk_make -j 8 lib
+      make -j 8 lib
       cd benchmark/domainwall/
-      bk_make -j 8
+      make -j 8
       cd -
       mv $BIN $BIN_openacc
       cp $BIN_openacc ../artifacts
       # CUDA
       rm -r build
       cp Makefile_cuda Makefile
-      bk_make clean
-      bk_make -j 8 lib
+      make clean
+      make -j 8 lib
       cd benchmark/domainwall/
-      bk_make clean
-      bk_make -j 8
+      make clean
+      make -j 8
       cd -
       mv $BIN $BIN_cuda
       cp $BIN_cuda ../artifacts
       ;;
     OpenACC)
       cp Makefile_openacc Makefile
-      bk_make -j 8 lib
+      make -j 8 lib
       cd benchmark/domainwall/
-      bk_make -j 8
+      make -j 8
       cd -
       cp $BIN ../artifacts
       ;;
     CUDA)
       cp Makefile_cuda Makefile
-      bk_make -j 8 lib
+      make -j 8 lib
       cd benchmark/domainwall/
-      bk_make -j 8
+      make -j 8
       cd -
       cp $BIN ../artifacts
       ;;

--- a/programs/MHDTurbulence/build.sh
+++ b/programs/MHDTurbulence/build.sh
@@ -25,14 +25,14 @@ case "$system" in
     MiyabiC)
 	cd src_f90_omp_host
 	echo "Compile cods in "`pwd`
-	bk_make
+	make
 	echo "Executable is "${BIN}" and copied to "${artdir}
 	cp ../exe/$BIN ../../${artdir}
 	;;
     MiyabiG)
 	cd src_f90_acc_device
 	echo "Compile cods in "`pwd`
-	bk_make
+	make
 	echo "Executable is "${BIN}" and copied to "${artdir}
 	cp ../exe/$BIN ../../${artdir}
 	;;

--- a/programs/ffb/build.sh
+++ b/programs/ffb/build.sh
@@ -40,7 +40,6 @@ tar -xzf "$archive" -C "${WORK_DIR}" --strip-components=1
 cd "${WORK_DIR}"
 
 chmod +x make.FP3.sh
-bk_capture_build_environment_snapshot
 bash ./make.FP3.sh
 
 if [[ ! -f "$exe_relpath" ]]; then

--- a/programs/genesis-nonbonded-kernels/build.sh
+++ b/programs/genesis-nonbonded-kernels/build.sh
@@ -47,15 +47,13 @@ case "$system" in
     # ;;
 esac
 
-bk_capture_build_environment_snapshot
-
 for i in "${!name_list[@]}"; do
     name=${name_list[i]}
 	dir_path=${dir_list[i]}
 	index=$((i + 1))
 	echo "Looping over name='$name', dir='$dir_path'"
 	cd "$dir_path" || { echo "cd failed to '$dir_path'"; exit 1; }
-    bk_make FC="${comp}" OMP=omp SIMD=dir KIND="${name}" ${archopt}
+    make FC="${comp}" OMP=omp SIMD=dir KIND="${name}" ${archopt}
     cp "$dir/kernel" "../../artifacts/kernel_${name}"
 	cd - > /dev/null
 done

--- a/programs/genesis/build.sh
+++ b/programs/genesis/build.sh
@@ -350,7 +350,6 @@ echo "CXX=${CXX:-}"
 echo "F77=${F77:-}"
 echo "configure args: ${CONFIG_ARGS[*]}"
 
-bk_capture_build_environment_snapshot
 bootstrap_genesis
 configure_env=(CC="$CC" FC="$FC")
 if [ -n "${CXX:-}" ]; then

--- a/programs/qws/build.sh
+++ b/programs/qws/build.sh
@@ -23,10 +23,10 @@ fi
 # システムに合わせてbuild方法を書く。systemの選択肢はlist.csvに合わせる。
 case "$system" in
     Fugaku)
-	bk_make -j 8 fugaku_benchmark= omp=1  compiler=fujitsu_cross rdma= mpi=1 powerapi= "${qws_make_profiler_args[@]}"
+	make -j 8 fugaku_benchmark= omp=1  compiler=fujitsu_cross rdma= mpi=1 powerapi= "${qws_make_profiler_args[@]}"
 	;;
     FugakuCN)
-	bk_make -j 8 fugaku_benchmark= omp=1  compiler=fujitsu_native rdma= mpi=1 powerapi= "${qws_make_profiler_args[@]}"
+	make -j 8 fugaku_benchmark= omp=1  compiler=fujitsu_native rdma= mpi=1 powerapi= "${qws_make_profiler_args[@]}"
 	;;
     # FugakuLN retired; previous LN smoke build kept for reference.
     # FugakuLN)
@@ -43,87 +43,87 @@ case "$system" in
 	# ;;
     RIKYU)
 	module load nvhpc-hpcx/26.3
-	bk_make -j 8 omp=1 compiler=nvhpc-hpcx arch=grace rdma= mpi=1
+	make -j 8 omp=1 compiler=nvhpc-hpcx arch=grace rdma= mpi=1
 	;;
     RC_GH200)
 	module load system/qc-gh200 nvhpc-hpcx/25.9
 	### QWSはNeoverse版やGPU版はないので汎用版としてとりあえずarch=skylakeを指定している
-	bk_make -j 8 fugaku_benchmark= omp=1  compiler=openmpi-gnu arch=skylake rdma= mpi=1 powerapi=
+	make -j 8 fugaku_benchmark= omp=1  compiler=openmpi-gnu arch=skylake rdma= mpi=1 powerapi=
 	;;
     RC_GENOA)
 	module load system/genoa  mpi/openmpi-x86_64
-	bk_make -j 8 fugaku_benchmark= omp=1  compiler=openmpi-gnu arch=skylake rdma= mpi=1 powerapi=
+	make -j 8 fugaku_benchmark= omp=1  compiler=openmpi-gnu arch=skylake rdma= mpi=1 powerapi=
     ;;
 	RC_DGXSP)
 	source /etc/profile.d/modules.sh
 	module load system/ng-dgx nvhpc-hpcx/26.3
-	bk_make -j 8 fugaku_benchmark= omp=1  compiler=openmpi-gnu arch=skylake rdma= mpi=1 powerapi=
+	make -j 8 fugaku_benchmark= omp=1  compiler=openmpi-gnu arch=skylake rdma= mpi=1 powerapi=
 	;;
 	RC_FX700)
 	module load system/fx700 FJSVstclanga
-	bk_make -j 8 fugaku_benchmark= omp=1  compiler=fujitsu_native rdma= mpi=1 powerapi= SYSLIBS=
+	make -j 8 fugaku_benchmark= omp=1  compiler=fujitsu_native rdma= mpi=1 powerapi= SYSLIBS=
 	;;
     MiyabiG)
 	### QWSはNeoverse版やGPU版はないので汎用版としてとりあえずarch=skylakeを指定している
-	bk_make -j 8 fugaku_benchmark= omp=1  compiler=openmpi-gnu arch=skylake rdma= mpi=1 powerapi=
+	make -j 8 fugaku_benchmark= omp=1  compiler=openmpi-gnu arch=skylake rdma= mpi=1 powerapi=
         ;;
     MiyabiC)
-	bk_make -j 8 fugaku_benchmark= omp=1  compiler=intel arch=skylake rdma= mpi=1 powerapi=
+	make -j 8 fugaku_benchmark= omp=1  compiler=intel arch=skylake rdma= mpi=1 powerapi=
         ;;
     GenkaiA|GenkaiB|GenkaiC)
 	module load intel/2023.2 mvapich/3.0-intel2023.2
-	bk_make -j 8 fugaku_benchmark= omp=1 compiler=intel arch=skylake rdma= mpi=1 powerapi= CC=mpicc CXX=mpicxx
+	make -j 8 fugaku_benchmark= omp=1 compiler=intel arch=skylake rdma= mpi=1 powerapi= CC=mpicc CXX=mpicxx
 	;;
     Grand_C|Grand_G)
 	module load intel impi
-	bk_make -j 8 fugaku_benchmark= omp=1 compiler=intel arch=skylake rdma= mpi=1 powerapi=
+	make -j 8 fugaku_benchmark= omp=1 compiler=intel arch=skylake rdma= mpi=1 powerapi=
 	;;
     AOBA_A|AOBA_S)
-	bk_make -j 8 fugaku_benchmark= omp=1 compiler=nec arch=sx rdma= mpi=1 powerapi=
+	make -j 8 fugaku_benchmark= omp=1 compiler=nec arch=sx rdma= mpi=1 powerapi=
 	;;
     AOBA_B)
-	bk_make -j 8 fugaku_benchmark= omp=1 compiler=openmpi-gnu arch=skylake rdma= mpi=1 powerapi= CC=mpicc CXX=mpic++
+	make -j 8 fugaku_benchmark= omp=1 compiler=openmpi-gnu arch=skylake rdma= mpi=1 powerapi= CC=mpicc CXX=mpic++
 	;;
     SQUID_CPU)
 	module load BaseCPU
-	bk_make compiler=intel arch=skylake mpi=1 rdma= omp=1 -j8
+	make compiler=intel arch=skylake mpi=1 rdma= omp=1 -j8
 	;;
     SQUID_GPU)
 	module load BaseGPU
-	bk_make compiler=nvhpc-hpcx arch=skylake mpi=1 rdma= omp=1 -j8
+	make compiler=nvhpc-hpcx arch=skylake mpi=1 rdma= omp=1 -j8
 	;;
     SQUID_VECTOR)
 	module load BaseVEC
-	bk_make compiler=nec arch=sx mpi=1 rdma= omp=1 -j8
+	make compiler=nec arch=sx mpi=1 rdma= omp=1 -j8
 	;;
     Odyssey)
 	module load odyssey
-	bk_make compiler=fujitsu_cross arch=postk -j 8
+	make compiler=fujitsu_cross arch=postk -j 8
 	;;
     Aquarius)
 	module purge
 	module load intel
 	source /work/opt/local/x86_64/cores/intel/2023.0.0/mpi/latest/env/vars.sh
-	bk_make compiler=intel arch=skylake rdma= -j8
+	make compiler=intel arch=skylake rdma= -j8
 	;;
     Pegasus)
 	module load intel/2025.3.1 intmpi/2025.3.1
-	bk_make compiler=intel arch=skylake mpi=1 omp=1 rdma=
+	make compiler=intel arch=skylake mpi=1 omp=1 rdma=
 	;;
     Sirius)
 	module load aocc/5.0.0 openmpi/5.0.10/aocc5.0.0
-	bk_make -j4 compiler=aocc arch=zen4 rdma= mpi=1 omp=1 profiler=timing \
+	make -j4 compiler=aocc arch=zen4 rdma= mpi=1 omp=1 profiler=timing \
 	    AMD_MARCH=-march=znver4 cppflags="-DARCH_AVX512" main
 	;;
     TSUBAME4)
 	module load openmpi/5.0.10-gcc aocc/4.1.0
 	export OMPI_CC=clang OMPI_CXX=clang++ OMPI_FC=flang
-	bk_make -j4 compiler=aocc arch=zen4 rdma= mpi=1 omp=1 profiler=timing \
+	make -j4 compiler=aocc arch=zen4 rdma= mpi=1 omp=1 profiler=timing \
 	    AMD_MARCH=-march=znver4 cppflags="-DARCH_AVX512" main
 	;;
     OCTOPUS)
 	module load BaseCPU inteloneAPI
-	bk_make -j8 compiler=intel arch=skylake mpi=1 omp=1 rdma=
+	make -j8 compiler=intel arch=skylake mpi=1 omp=1 rdma=
 	;;
     Camphor3)
 	camphor3_modulepath="${MODULEPATH:-}"
@@ -142,7 +142,7 @@ case "$system" in
 	    export MODULEPATH="${camphor3_modulepath}"
 	fi
 	module load slurm/2022 SysA/2022 intel/2023.2 intelmpi/2023.2 PrgEnvIntel/2023
-	bk_make -j 8 fugaku_benchmark= omp=1 compiler=intel arch=skylake rdma= mpi=1 powerapi=
+	make -j 8 fugaku_benchmark= omp=1 compiler=intel arch=skylake rdma= mpi=1 powerapi=
 	;;
     *)
 	echo "Unknown system: $system"

--- a/programs/salmon/build.sh
+++ b/programs/salmon/build.sh
@@ -173,7 +173,6 @@ case "${system}" in
     ;;
 esac
 
-bk_capture_build_environment_snapshot
 run_logged "Configuring SALMON" "${BUILD_LOG_DIR}/${system}_configure.log" \
   cmake -Wno-dev -S . -B "${BUILD_DIR}" "${cmake_args[@]}"
 run_logged "Building SALMON" "${BUILD_LOG_DIR}/${system}_build.log" \

--- a/programs/scale-letkf/build.sh
+++ b/programs/scale-letkf/build.sh
@@ -16,20 +16,18 @@ cd "${REPO_DIR}"
 case "$system" in
   Fugaku)
     source setup-env.Fugaku.sh
-    bk_capture_build_environment_snapshot
     cd scale/scale-rm/src
-    bk_make -j
+    make -j
     cd ../../scale-letkf/scale
-    bk_make
+    make
     cd $TOPDIR
   ;;
   RC_GH200)
     source setup-env.RC_GH200.sh
-    bk_capture_build_environment_snapshot
     cd scale/scale-rm/src
-    bk_make -j
+    make -j
     cd ../../scale-letkf/scale
-    bk_make
+    make
     cd $TOPDIR
   ;;
   *)

--- a/result_server/tests/test_environment_snapshot_ci_scripts.py
+++ b/result_server/tests/test_environment_snapshot_ci_scripts.py
@@ -17,6 +17,8 @@ def test_matrix_generator_collects_snapshots_in_common_wrappers():
         "BK_SNAPSHOT_STAGE=build_run bash scripts/collect_environment_snapshot.sh"
         in matrix_generate
     )
+    assert "export BK_BENCHKIT_ROOT=" in matrix_generate
+    assert "scripts/build_tool_wrappers" in matrix_generate
 
 
 def test_send_results_process_does_not_collect_send_stage_snapshot():

--- a/scripts/bk_functions.sh
+++ b/scripts/bk_functions.sh
@@ -1959,11 +1959,6 @@ bk_capture_build_environment_snapshot() {
   return 0
 }
 
-bk_make() {
-  bk_capture_build_environment_snapshot
-  make "$@"
-}
-
 # bk_fetch_source - Fetch source code and collect metadata.
 #
 # Usage:

--- a/scripts/build_tool_wrappers/bk_build_tool_wrapper.sh
+++ b/scripts/build_tool_wrappers/bk_build_tool_wrapper.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "bk_build_tool_wrapper: missing tool name" >&2
+  exit 127
+fi
+
+tool_name="$1"
+shift
+
+wrapper_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+repo_root="${BK_BENCHKIT_ROOT:-$(cd "${wrapper_dir}/../.." && pwd -P)}"
+original_path="${PATH:-}"
+path_without_wrapper=""
+
+IFS=':' read -r -a path_entries <<< "$original_path"
+for path_entry in "${path_entries[@]}"; do
+  display_entry="$path_entry"
+  if [ -z "$display_entry" ]; then
+    display_entry="."
+  fi
+
+  entry_abs="$display_entry"
+  if [ -d "$display_entry" ]; then
+    entry_abs=$(cd "$display_entry" && pwd -P)
+  fi
+
+  if [ "$entry_abs" = "$wrapper_dir" ]; then
+    continue
+  fi
+
+  if [ -z "$path_without_wrapper" ]; then
+    path_without_wrapper="$path_entry"
+  else
+    path_without_wrapper="${path_without_wrapper}:$path_entry"
+  fi
+done
+
+real_tool=$(PATH="$path_without_wrapper" command -v "$tool_name" 2>/dev/null || true)
+if [ -z "$real_tool" ]; then
+  echo "bk_build_tool_wrapper: ${tool_name} not found after removing ${wrapper_dir} from PATH" >&2
+  exit 127
+fi
+
+if [ "${BK_BUILD_TOOL_WRAPPER_SNAPSHOT:-true}" != "false" ]; then
+  (
+    export PATH="$path_without_wrapper"
+    export BK_BENCHKIT_ROOT="$repo_root"
+    # shellcheck source=/dev/null
+    source "${repo_root}/scripts/bk_functions.sh"
+    bk_capture_build_environment_snapshot
+  )
+fi
+
+exec "$real_tool" "$@"

--- a/scripts/build_tool_wrappers/cmake
+++ b/scripts/build_tool_wrappers/cmake
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+exec "${script_dir}/bk_build_tool_wrapper.sh" cmake "$@"

--- a/scripts/build_tool_wrappers/make
+++ b/scripts/build_tool_wrappers/make
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+exec "${script_dir}/bk_build_tool_wrapper.sh" make "$@"

--- a/scripts/build_tool_wrappers/ninja
+++ b/scripts/build_tool_wrappers/ninja
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+exec "${script_dir}/bk_build_tool_wrapper.sh" ninja "$@"

--- a/scripts/matrix_generate.sh
+++ b/scripts/matrix_generate.sh
@@ -124,6 +124,9 @@ ${build_key}_build:
   script:
     - mkdir -p results
     - BK_SYSTEM=\"$system\" BK_SNAPSHOT_STAGE=build bash scripts/collect_environment_snapshot.sh results/environment_snapshot_build.json
+    - export BK_SYSTEM=\"$system\"
+    - export BK_BENCHKIT_ROOT=\"\$PWD\"
+    - export PATH=\"\$PWD/scripts/build_tool_wrappers:\$PATH\"
     - bash scripts/record_timestamp.sh results/build_start
     - echo \"[BUILD] $program for $system\"
     - bash $program_path/build.sh $system
@@ -202,6 +205,9 @@ ${job_prefix}_build_run:
   script:
     - echo \"Starting build and run\"
     - BK_SYSTEM=\"$system\" BK_SNAPSHOT_STAGE=build_run bash scripts/collect_environment_snapshot.sh results/environment_snapshot_build_run.json
+    - export BK_SYSTEM=\"$system\"
+    - export BK_BENCHKIT_ROOT=\"\$PWD\"
+    - export PATH=\"\$PWD/scripts/build_tool_wrappers:\$PATH\"
     - bash scripts/record_timestamp.sh results/build_start
     - bash $program_path/build.sh $system
     - bash scripts/record_timestamp.sh results/build_end

--- a/scripts/tests/test_build_environment_snapshot.sh
+++ b/scripts/tests/test_build_environment_snapshot.sh
@@ -12,10 +12,11 @@ fi
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "${TMP_DIR}"' EXIT
 
-mkdir -p "${TMP_DIR}/project/scripts" "${TMP_DIR}/project/results" "${TMP_DIR}/project/src"
+mkdir -p "${TMP_DIR}/project/scripts" "${TMP_DIR}/project/results" "${TMP_DIR}/project/src" "${TMP_DIR}/bin"
 cp "${REPO_DIR}/scripts/bk_functions.sh" "${TMP_DIR}/project/scripts/bk_functions.sh"
 cp "${REPO_DIR}/scripts/collect_environment_snapshot.sh" "${TMP_DIR}/project/scripts/collect_environment_snapshot.sh"
 cp "${REPO_DIR}/scripts/result.sh" "${TMP_DIR}/project/scripts/result.sh"
+cp -R "${REPO_DIR}/scripts/build_tool_wrappers" "${TMP_DIR}/project/scripts/build_tool_wrappers"
 
 cat > "${TMP_DIR}/project/results/result" <<'EOF'
 FOM:1.0 FOM_unit:s FOM_version:test Exp:CASE0 node_count:1 numproc_node:1 nthreads:1
@@ -44,24 +45,32 @@ cat > "${TMP_DIR}/project/results/environment_snapshot_build.json" <<'EOF'
 }
 EOF
 
-pushd "${TMP_DIR}/project" >/dev/null
-source scripts/bk_functions.sh
-popd >/dev/null
+cat > "${TMP_DIR}/bin/make" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+printf '%s\n' "$*" > "${BK_TEST_FAKE_MAKE_ARGS}"
+EOF
+chmod +x "${TMP_DIR}/bin/make"
 
 pushd "${TMP_DIR}/project/src" >/dev/null
 export BK_SYSTEM=TestSystem
-export BK_SNAPSHOT_TOOL_COMMANDS="bash"
+export BK_BENCHKIT_ROOT="${TMP_DIR}/project"
+export BK_SNAPSHOT_TOOL_COMMANDS="make bash"
 export BK_SNAPSHOT_ENV_VARS="CC SECRET_TOKEN"
+export PATH="${TMP_DIR}/project/scripts/build_tool_wrappers:${TMP_DIR}/bin:${PATH}"
 export CC=mpicc
 export SECRET_TOKEN=should_not_be_recorded
-bk_capture_build_environment_snapshot
+export BK_TEST_FAKE_MAKE_ARGS="${TMP_DIR}/make_args"
+make -j2 target
 popd >/dev/null
 
 SNAPSHOT="${TMP_DIR}/project/results/environment_snapshot_build_actual.json"
 test -f "$SNAPSHOT"
-jq -e '
+test "$(cat "${TMP_DIR}/make_args")" = "-j2 target"
+jq -e --arg make_path "${TMP_DIR}/bin/make" '
   .stage == "build_actual" and
   .system.name == "TestSystem" and
+  .toolchain.commands.make.path == $make_path and
   (.toolchain.commands.bash.path | length) > 0 and
   .toolchain.environment.CC == "mpicc" and
   .toolchain.environment.SECRET_TOKEN == "[redacted]"


### PR DESCRIPTION
## Summary
- remove the temporary bk_make helper and restore application build scripts to ordinary make calls
- add PATH-based wrappers for make/cmake/ninja so CI build jobs capture actual build environment snapshots automatically
- enable the wrappers from generated GitLab build jobs and update docs/tests around the new boundary

## Tests
- shellcheck -S error scripts/build_tool_wrappers/bk_build_tool_wrapper.sh scripts/build_tool_wrappers/make scripts/build_tool_wrappers/cmake scripts/build_tool_wrappers/ninja scripts/bk_functions.sh scripts/matrix_generate.sh scripts/tests/test_build_environment_snapshot.sh programs/qws/build.sh programs/LQCD_dw_solver/build.sh programs/MHDTurbulence/build.sh programs/genesis-nonbonded-kernels/build.sh programs/genesis/build.sh programs/salmon/build.sh programs/scale-letkf/build.sh programs/ffb/build.sh
- bash scripts/tests/test_bk_profiler.sh && bash scripts/tests/test_bk_fetch_source.sh && bash scripts/tests/test_build_environment_snapshot.sh && bash scripts/tests/test_ncu_plan_generation.sh && bash scripts/tests/test_result_profile_data.sh && bash scripts/tests/test_process_and_send_results.sh && bash scripts/tests/test_scheduler_extra_args.sh && bash scripts/tests/test_send_results_profile_data.sh && bash scripts/tests/test_send_estimate_artifacts.sh && bash scripts/tests/test_estimation_gpu_kernel_ensemble_average.sh && bash scripts/tests/test_estimation_gpu_kernel_lightgbm_v10.sh && bash scripts/tests/test_estimation_gpu_kernel_mlp_v15.sh && bash scripts/tests/test_genesis_gpu_mlp_estimation.sh
- .venv/bin/python -m pytest result_server/tests
- .venv/bin/python scripts/tests/check_text_integrity.py
- git diff --check