### PR TITLE
Remove build snapshot helper API

### DIFF
--- a/docs/guides/add-app.md
+++ b/docs/guides/add-app.md
@@ -130,7 +130,7 @@ CI の共通 wrapper は、`build.sh` 実行前に runner 側の軽量 snapshot 
 
 CI の build job では `scripts/build_tool_wrappers/` を `PATH` の先頭に入れ、`make` / `cmake` / `ninja` の同名 wrapper が `results/environment_snapshot_build_actual.json` を更新してから本物の command に委譲します。
 そのため、app の `build.sh` では通常どおり `make` / `cmake` / `ninja` を呼べば十分です。
-特殊な独自ビルド command でこれらを経由しない場合だけ、必要に応じて `bk_capture_build_environment_snapshot` を個別に使えます。
+特殊な独自ビルド command でこれらを経由しない場合は、その command 用の wrapper を共通層に追加してから使ってください。
 この snapshot には、主要 compiler / MPI / CUDA / profiler / container command の path と version、loaded modules、allowlist された build 環境変数が含まれます。
 `TOKEN`、`SECRET`、`PASSWORD`、`AUTH`、`KEY`、`CERT` などを名前に含む環境変数は値を redacted として記録します。
 

--- a/scripts/bk_functions.sh
+++ b/scripts/bk_functions.sh
@@ -1918,47 +1918,6 @@ bk_record_file_source_info() {
   bk_write_source_info_env "file" "" "" "" "$BK_FILE_PATH" "$BK_MD5SUM" "$BK_SHA256SUM"
 }
 
-bk_capture_build_environment_snapshot() {
-  local snapshot_file="${1:-results/environment_snapshot_build_actual.json}"
-  local snapshot_stage="${2:-build_actual}"
-  local strict="${BK_STRICT_BUILD_ENVIRONMENT_SNAPSHOT:-false}"
-  local system_value="${BK_SYSTEM:-${system:-}}"
-  local repo_root="${BK_BENCHKIT_ROOT:-$PWD}"
-  local collector="${repo_root}/scripts/collect_environment_snapshot.sh"
-
-  if [ "${BK_CAPTURE_BUILD_ENVIRONMENT_SNAPSHOT:-true}" = "false" ]; then
-    return 0
-  fi
-  if [ ! -f "$collector" ]; then
-    echo "bk_capture_build_environment_snapshot: ${collector} not found; skipping" >&2
-    return 0
-  fi
-  if ! command -v jq >/dev/null 2>&1; then
-    echo "bk_capture_build_environment_snapshot: jq not found; skipping" >&2
-    return 0
-  fi
-
-  case "$snapshot_file" in
-    /*) ;;
-    *) snapshot_file="${repo_root}/${snapshot_file}" ;;
-  esac
-
-  mkdir -p "$(dirname "$snapshot_file")"
-  if (
-    cd "$repo_root" &&
-    BK_SYSTEM="$system_value" BK_SNAPSHOT_STAGE="$snapshot_stage" \
-      bash "$collector" "$snapshot_file"
-  ); then
-    return 0
-  fi
-
-  echo "bk_capture_build_environment_snapshot: failed to write ${snapshot_file}" >&2
-  if [ "$strict" = "true" ]; then
-    return 1
-  fi
-  return 0
-}
-
 # bk_fetch_source - Fetch source code and collect metadata.
 #
 # Usage:

--- a/scripts/build_tool_wrappers/bk_build_tool_wrapper.sh
+++ b/scripts/build_tool_wrappers/bk_build_tool_wrapper.sh
@@ -44,13 +44,31 @@ if [ -z "$real_tool" ]; then
 fi
 
 if [ "${BK_BUILD_TOOL_WRAPPER_SNAPSHOT:-true}" != "false" ]; then
-  (
-    export PATH="$path_without_wrapper"
-    export BK_BENCHKIT_ROOT="$repo_root"
-    # shellcheck source=/dev/null
-    source "${repo_root}/scripts/bk_functions.sh"
-    bk_capture_build_environment_snapshot
-  )
+  snapshot_file="${BK_BUILD_ENVIRONMENT_SNAPSHOT_FILE:-${repo_root}/results/environment_snapshot_build_actual.json}"
+  case "$snapshot_file" in
+    /*) ;;
+    *) snapshot_file="${repo_root}/${snapshot_file}" ;;
+  esac
+
+  collector="${repo_root}/scripts/collect_environment_snapshot.sh"
+  if [ -f "$collector" ] && PATH="$path_without_wrapper" command -v jq >/dev/null 2>&1; then
+    mkdir -p "$(dirname "$snapshot_file")"
+    if ! (
+      cd "$repo_root" &&
+      PATH="$path_without_wrapper" \
+        BK_SYSTEM="${BK_SYSTEM:-}" \
+        BK_SNAPSHOT_STAGE="${BK_SNAPSHOT_STAGE:-build_actual}" \
+        bash "$collector" "$snapshot_file"
+    ); then
+      echo "bk_build_tool_wrapper: failed to write ${snapshot_file}" >&2
+      if [ "${BK_STRICT_BUILD_ENVIRONMENT_SNAPSHOT:-false}" = "true" ]; then
+        exit 1
+      fi
+    fi
+  elif [ "${BK_STRICT_BUILD_ENVIRONMENT_SNAPSHOT:-false}" = "true" ]; then
+    echo "bk_build_tool_wrapper: cannot collect build environment snapshot" >&2
+    exit 1
+  fi
 fi
 
 exec "$real_tool" "$@"


### PR DESCRIPTION
## Summary
- remove the remaining bk_capture_build_environment_snapshot helper from bk_functions.sh
- have build tool wrappers call collect_environment_snapshot.sh directly
- update app guide so unusual build commands should get common wrappers instead of app-local helper calls

## Tests
- shellcheck -S error scripts/build_tool_wrappers/bk_build_tool_wrapper.sh scripts/build_tool_wrappers/make scripts/build_tool_wrappers/cmake scripts/build_tool_wrappers/ninja scripts/bk_functions.sh scripts/tests/test_build_environment_snapshot.sh
- bash scripts/tests/test_bk_profiler.sh && bash scripts/tests/test_bk_fetch_source.sh && bash scripts/tests/test_build_environment_snapshot.sh && bash scripts/tests/test_ncu_plan_generation.sh && bash scripts/tests/test_result_profile_data.sh && bash scripts/tests/test_process_and_send_results.sh && bash scripts/tests/test_scheduler_extra_args.sh && bash scripts/tests/test_send_results_profile_data.sh && bash scripts/tests/test_send_estimate_artifacts.sh && bash scripts/tests/test_estimation_gpu_kernel_ensemble_average.sh && bash scripts/tests/test_estimation_gpu_kernel_lightgbm_v10.sh && bash scripts/tests/test_estimation_gpu_kernel_mlp_v15.sh && bash scripts/tests/test_genesis_gpu_mlp_estimation.sh
- .venv/bin/python -m pytest result_server/tests
- .venv/bin/python scripts/tests/check_text_integrity.py
- git diff --check