### PR TITLE
Preserve build snapshot wrappers in Genesis RIKYU container

### DIFF
--- a/programs/genesis/build.sh
+++ b/programs/genesis/build.sh
@@ -39,9 +39,14 @@ run_genesis_rikyu_in_container() {
     echo "Running GENESIS RIKYU build in Apptainer image: $image"
     "$apptainer_bin" exec --nv --bind "$binds" --pwd "$PWD" \
         --env GENESIS_RIKYU_IN_CONTAINER=true \
+        --env "BK_BENCHKIT_ROOT=$PWD" \
+        --env "BK_SYSTEM=${BK_SYSTEM:-$system}" \
         --env "BK_SOURCE_CONTAINER_PATH=$image" \
         --env "BK_SOURCE_CONTAINER_SHA256=$image_sha256" \
-        "$image" bash "$0" "$@"
+        "$image" bash -c '
+            export PATH="${BK_BENCHKIT_ROOT}/scripts/build_tool_wrappers:${PATH}"
+            exec bash "$@"
+        ' _ "$0" "$@"
     exit $?
 }
 

--- a/result_server/tests/test_environment_snapshot_ci_scripts.py
+++ b/result_server/tests/test_environment_snapshot_ci_scripts.py
@@ -27,3 +27,17 @@ def test_send_results_process_does_not_collect_send_stage_snapshot():
     ).read_text(encoding="utf-8")
 
     assert "collect_environment_snapshot.sh" not in process_script
+
+
+def test_genesis_rikyu_container_build_preserves_wrapper_path():
+    build_script = (REPO_ROOT / "programs" / "genesis" / "build.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert '--env "BK_BENCHKIT_ROOT=$PWD"' in build_script
+    assert '--env "BK_SYSTEM=${BK_SYSTEM:-$system}"' in build_script
+    assert (
+        'export PATH="${BK_BENCHKIT_ROOT}/scripts/build_tool_wrappers:${PATH}"'
+        in build_script
+    )
+    assert 'exec bash "$@"' in build_script


### PR DESCRIPTION
## Summary
- preserve the build tool wrapper PATH when the GENESIS RIKYU build re-enters the Apptainer image
- pass BK_BENCHKIT_ROOT and BK_SYSTEM explicitly across the container boundary
- add a regression check for the GENESIS RIKYU container build wrapper path

## Verification
- .venv/bin/python -m pytest result_server/tests
- bash scripts/tests/test_build_environment_snapshot.sh
- full shell regression set from Result Server Tests workflow
- shellcheck -S error programs/genesis/build.sh scripts/build_tool_wrappers/bk_build_tool_wrapper.sh
- python scripts/tests/check_text_integrity.py
- git diff --check

## Notes
- dev2 GENESIS/RIKYU trigger result arrived successfully, but environment_snapshot.payload.stages.build_actual was empty before this fix.
- dev2 QWS/Fugaku trigger request was submitted to SWC pipeline 3829; no Portal result had arrived at the time of this PR.