### PR TITLE
Write fallback build snapshots without jq

### DIFF
--- a/scripts/build_tool_wrappers/bk_build_tool_wrapper.sh
+++ b/scripts/build_tool_wrappers/bk_build_tool_wrapper.sh
@@ -43,6 +43,231 @@ if [ -z "$real_tool" ]; then
   exit 127
 fi
 
+json_string() {
+  local value="$1"
+
+  if PATH="$path_without_wrapper" command -v python3 >/dev/null 2>&1; then
+    JSON_VALUE="$value" PATH="$path_without_wrapper" python3 -c \
+      'import json, os; print(json.dumps(os.environ.get("JSON_VALUE", "")))'
+    return 0
+  fi
+
+  printf '"%s"' "$(printf '%s' "$value" | sed \
+    -e 's/\\/\\\\/g' \
+    -e 's/"/\\"/g' \
+    -e 's/[[:cntrl:]]//g')"
+}
+
+fallback_resolved_path() {
+  local path="$1"
+
+  if [ -z "$path" ]; then
+    printf '%s' ""
+    return 0
+  fi
+  if PATH="$path_without_wrapper" command -v readlink >/dev/null 2>&1; then
+    PATH="$path_without_wrapper" readlink -f "$path" 2>/dev/null || printf '%s' "$path"
+    return 0
+  fi
+  printf '%s' "$path"
+}
+
+fallback_command_version() {
+  local cmd="$1"
+
+  if ! PATH="$path_without_wrapper" command -v "$cmd" >/dev/null 2>&1; then
+    printf '%s' ""
+    return 0
+  fi
+  PATH="$path_without_wrapper" "$cmd" --version 2>/dev/null | sed -n '1p' || true
+}
+
+fallback_commands_json() {
+  local default_commands
+  default_commands="bash sh cc c++ gcc g++ clang clang++ fcc fccpx frt frtpx "
+  default_commands+="mpicc mpicxx mpifcc mpifccpx mpifrt mpifrtpx mpif90 mpifort "
+  default_commands+="mpiicc mpiicpc mpiifort gfortran nvcc nvc nvc++ nvfortran "
+  default_commands+="cmake make ninja ld ar pkg-config python3 apptainer singularity ncu nsys"
+
+  local commands="${BK_SNAPSHOT_TOOL_COMMANDS:-$default_commands}"
+  local first=true
+  local cmd path real_path version
+
+  printf '{'
+  for cmd in $commands; do
+    path=$(PATH="$path_without_wrapper" command -v "$cmd" 2>/dev/null || true)
+    if [ -z "$path" ]; then
+      continue
+    fi
+    real_path=$(fallback_resolved_path "$path")
+    version=$(fallback_command_version "$cmd")
+    if [ "$first" = true ]; then
+      first=false
+    else
+      printf ','
+    fi
+    printf '%s:{"path":%s,"real_path":%s,"version":%s}' \
+      "$(json_string "$cmd")" \
+      "$(json_string "$path")" \
+      "$(json_string "$real_path")" \
+      "$(json_string "$version")"
+  done
+  printf '}'
+}
+
+snapshot_env_is_sensitive() {
+  case "$1" in
+    *TOKEN*|*SECRET*|*PASSWORD*|*PASSWD*|*PRIVATE*|*CREDENTIAL*|*AUTH*|*KEY*|*CERT*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+fallback_environment_json() {
+  local default_vars
+  default_vars="CC CXX FC F77 F90 CPP CPPFLAGS CFLAGS CXXFLAGS FCFLAGS FFLAGS "
+  default_vars+="LDFLAGS LIBS PATH LD_LIBRARY_PATH LIBRARY_PATH CPATH PKG_CONFIG_PATH "
+  default_vars+="MODULEPATH LOADEDMODULES CUDA_HOME CUDA_PATH NVHPC_ROOT OMP_NUM_THREADS "
+  default_vars+="OMPI_CC OMPI_CXX OMPI_FC MPICH_CC MPICH_CXX MPICH_FC"
+
+  local vars="${BK_SNAPSHOT_ENV_VARS:-$default_vars}"
+  local first=true
+  local name value
+
+  printf '{'
+  for name in $vars; do
+    case "$name" in
+      [A-Za-z_][A-Za-z0-9_]*)
+        ;;
+      *)
+        continue
+        ;;
+    esac
+    if [ "$name" = "PATH" ]; then
+      value="$path_without_wrapper"
+    elif [ -z "${!name+x}" ]; then
+      continue
+    elif snapshot_env_is_sensitive "$name"; then
+      value="[redacted]"
+    else
+      value="${!name}"
+    fi
+    if [ "$first" = true ]; then
+      first=false
+    else
+      printf ','
+    fi
+    printf '%s:%s' "$(json_string "$name")" "$(json_string "$value")"
+  done
+  printf '}'
+}
+
+write_fallback_snapshot() {
+  local snapshot_file="$1"
+  local stage="${BK_SNAPSHOT_STAGE:-build_actual}"
+  local collected_at=""
+  local hostname_value=""
+  local uname_value=""
+  local cpu_model=""
+  local git_commit=""
+  local git_branch=""
+  local git_dirty=""
+  local commands_json
+  local environment_json
+  local scheduler_kind="unknown"
+
+  if PATH="$path_without_wrapper" command -v date >/dev/null 2>&1; then
+    collected_at=$(PATH="$path_without_wrapper" date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)
+  fi
+  if PATH="$path_without_wrapper" command -v hostname >/dev/null 2>&1; then
+    hostname_value=$(PATH="$path_without_wrapper" hostname 2>/dev/null || true)
+  fi
+  if PATH="$path_without_wrapper" command -v uname >/dev/null 2>&1; then
+    uname_value=$(PATH="$path_without_wrapper" uname -srmo 2>/dev/null || PATH="$path_without_wrapper" uname -a 2>/dev/null || true)
+  fi
+  if [ -r /proc/cpuinfo ]; then
+    cpu_model=$(awk -F: '/model name|Hardware|Processor/ {gsub(/^ +/, "", $2); print $2; exit}' /proc/cpuinfo 2>/dev/null || true)
+  fi
+  if PATH="$path_without_wrapper" command -v git >/dev/null 2>&1 && PATH="$path_without_wrapper" git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git_commit=$(PATH="$path_without_wrapper" git -C "$repo_root" rev-parse HEAD 2>/dev/null || true)
+    git_branch=$(PATH="$path_without_wrapper" git -C "$repo_root" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+    if [ -n "$(PATH="$path_without_wrapper" git -C "$repo_root" status --porcelain 2>/dev/null || true)" ]; then
+      git_dirty="true"
+    else
+      git_dirty="false"
+    fi
+  fi
+  if [ -n "${SLURM_JOB_ID:-}" ] || [ -n "${SLURM_JOBID:-}" ]; then
+    scheduler_kind="slurm"
+  elif [ -n "${PBS_JOBID:-}" ]; then
+    scheduler_kind="pbs"
+  elif [ -n "${JACAMAR_CI:-}" ] || [ -n "${JACAMAR_SCHEDULER_ACTION:-}" ]; then
+    scheduler_kind="jacamar"
+  fi
+
+  commands_json=$(fallback_commands_json)
+  environment_json=$(fallback_environment_json)
+
+  cat > "$snapshot_file" <<EOF
+{
+  "schema_version": 1,
+  "stage": $(json_string "$stage"),
+  "collected_at": $(json_string "$collected_at"),
+  "system": {
+    "name": $(json_string "${BK_SYSTEM:-}"),
+    "allocation_project_id": $(json_string "${BK_ALLOCATION_PROJECT_ID:-}"),
+    "host": {
+      "hostname": $(json_string "$hostname_value"),
+      "uname": $(json_string "$uname_value"),
+      "cpu_model": $(json_string "$cpu_model")
+    }
+  },
+  "scheduler": {
+    "kind": $(json_string "$scheduler_kind"),
+    "slurm_job_id": $(json_string "${SLURM_JOB_ID:-${SLURM_JOBID:-}}"),
+    "slurm_partition": $(json_string "${SLURM_JOB_PARTITION:-}"),
+    "pbs_jobid": $(json_string "${PBS_JOBID:-}"),
+    "jacamar_scheduler_action": $(json_string "${JACAMAR_SCHEDULER_ACTION:-}")
+  },
+  "runner": {
+    "description": $(json_string "${CI_RUNNER_DESCRIPTION:-}"),
+    "id": $(json_string "${CI_RUNNER_ID:-}"),
+    "tags": $(json_string "${CI_RUNNER_TAGS:-}")
+  },
+  "ci": {
+    "server_url": $(json_string "${CI_SERVER_URL:-}"),
+    "project_path": $(json_string "${CI_PROJECT_PATH:-}"),
+    "pipeline_id": $(json_string "${CI_PIPELINE_ID:-}"),
+    "job_id": $(json_string "${CI_JOB_ID:-}"),
+    "job_name": $(json_string "${CI_JOB_NAME:-}"),
+    "commit_ref_name": $(json_string "${CI_COMMIT_REF_NAME:-}"),
+    "commit_sha": $(json_string "${CI_COMMIT_SHA:-}")
+  },
+  "benchkit": {
+    "branch": $(json_string "$git_branch"),
+    "commit_hash": $(json_string "$git_commit"),
+    "dirty": $(json_string "$git_dirty")
+  },
+  "toolchain": {
+    "gcc": $(json_string "$(fallback_command_version gcc)"),
+    "mpicc": $(json_string "$(fallback_command_version mpicc)"),
+    "nvcc": $(json_string "$(fallback_command_version nvcc)"),
+    "python3": $(json_string "$(fallback_command_version python3)"),
+    "modules": [],
+    "commands": $commands_json,
+    "environment": $environment_json,
+    "container": {
+      "image_path": $(json_string "${BK_SOURCE_CONTAINER_PATH:-}"),
+      "image_sha256sum": $(json_string "${BK_SOURCE_CONTAINER_SHA256:-}")
+    }
+  }
+}
+EOF
+}
+
 if [ "${BK_BUILD_TOOL_WRAPPER_SNAPSHOT:-true}" != "false" ]; then
   snapshot_file="${BK_BUILD_ENVIRONMENT_SNAPSHOT_FILE:-${repo_root}/results/environment_snapshot_build_actual.json}"
   case "$snapshot_file" in
@@ -51,8 +276,11 @@ if [ "${BK_BUILD_TOOL_WRAPPER_SNAPSHOT:-true}" != "false" ]; then
   esac
 
   collector="${repo_root}/scripts/collect_environment_snapshot.sh"
-  if [ -f "$collector" ] && PATH="$path_without_wrapper" command -v jq >/dev/null 2>&1; then
-    mkdir -p "$(dirname "$snapshot_file")"
+  mkdir -p "$(dirname "$snapshot_file")"
+  snapshot_written=false
+  if [ "${BK_BUILD_TOOL_WRAPPER_FORCE_FALLBACK:-false}" != "true" ] \
+    && [ -f "$collector" ] \
+    && PATH="$path_without_wrapper" command -v jq >/dev/null 2>&1; then
     if ! (
       cd "$repo_root" &&
       PATH="$path_without_wrapper" \
@@ -61,11 +289,18 @@ if [ "${BK_BUILD_TOOL_WRAPPER_SNAPSHOT:-true}" != "false" ]; then
         bash "$collector" "$snapshot_file"
     ); then
       echo "bk_build_tool_wrapper: failed to write ${snapshot_file}" >&2
-      if [ "${BK_STRICT_BUILD_ENVIRONMENT_SNAPSHOT:-false}" = "true" ]; then
-        exit 1
-      fi
+    else
+      snapshot_written=true
     fi
-  elif [ "${BK_STRICT_BUILD_ENVIRONMENT_SNAPSHOT:-false}" = "true" ]; then
+  fi
+  if [ "$snapshot_written" != true ]; then
+    if write_fallback_snapshot "$snapshot_file"; then
+      snapshot_written=true
+    else
+      echo "bk_build_tool_wrapper: failed to write fallback ${snapshot_file}" >&2
+    fi
+  fi
+  if [ "$snapshot_written" != true ] && [ "${BK_STRICT_BUILD_ENVIRONMENT_SNAPSHOT:-false}" = "true" ]; then
     echo "bk_build_tool_wrapper: cannot collect build environment snapshot" >&2
     exit 1
   fi

--- a/scripts/tests/test_build_environment_snapshot.sh
+++ b/scripts/tests/test_build_environment_snapshot.sh
@@ -87,4 +87,32 @@ jq -e '
   (.environment_snapshot.hash | startswith("sha256:"))
 ' "${TMP_DIR}/project/results/result0.json" >/dev/null
 
+rm -f "${TMP_DIR}/project/results/environment_snapshot_build_actual.json" "${TMP_DIR}/project/results/result0.json"
+pushd "${TMP_DIR}/project/src" >/dev/null
+export BK_BUILD_TOOL_WRAPPER_FORCE_FALLBACK=true
+export BK_TEST_FAKE_MAKE_ARGS="${TMP_DIR}/make_args_fallback"
+make fallback
+unset BK_BUILD_TOOL_WRAPPER_FORCE_FALLBACK
+popd >/dev/null
+
+test -f "$SNAPSHOT"
+test "$(cat "${TMP_DIR}/make_args_fallback")" = "fallback"
+jq -e --arg make_path "${TMP_DIR}/bin/make" '
+  .stage == "build_actual" and
+  .system.name == "TestSystem" and
+  .toolchain.commands.make.path == $make_path and
+  .toolchain.environment.CC == "mpicc" and
+  .toolchain.environment.SECRET_TOKEN == "[redacted]"
+' "$SNAPSHOT" >/dev/null
+
+pushd "${TMP_DIR}/project" >/dev/null
+bash scripts/result.sh app TestSystem native build run 123 >/dev/null
+popd >/dev/null
+
+jq -e '
+  .environment_snapshot.payload.stages.build_actual.stage == "build_actual" and
+  .environment_snapshot.payload.toolchain.build_actual.environment.CC == "mpicc" and
+  (.environment_snapshot.hash | startswith("sha256:"))
+' "${TMP_DIR}/project/results/result0.json" >/dev/null
+
 echo "build environment snapshot test passed"


### PR DESCRIPTION
## Summary
- add a schema-compatible fallback build snapshot path when jq is unavailable
- keep using the full snapshot collector when jq is present
- cover fallback snapshots and result ingestion in shell tests

## Tests
- bash -n scripts/build_tool_wrappers/bk_build_tool_wrapper.sh scripts/tests/test_build_environment_snapshot.sh
- shellcheck -S error scripts/build_tool_wrappers/bk_build_tool_wrapper.sh scripts/tests/test_build_environment_snapshot.sh
- bash scripts/tests/test_build_environment_snapshot.sh
- .venv/bin/python -m pytest result_server/tests/test_environment_snapshot_ci_scripts.py result_server/tests/test_environment_snapshots.py result_server/tests/test_environment_snapshot_results_route.py
- .venv/bin/python scripts/tests/check_text_integrity.py
- git diff --check
- .venv/bin/python -m pytest result_server/tests
- full shell regression from Result Server Tests workflow