### PR TITLE
Fix NVIDIA compiler version snapshots

### DIFF
--- a/scripts/build_tool_wrappers/bk_build_tool_wrapper.sh
+++ b/scripts/build_tool_wrappers/bk_build_tool_wrapper.sh
@@ -74,12 +74,43 @@ fallback_resolved_path() {
 
 fallback_command_version() {
   local cmd="$1"
+  local version_args=("--version")
 
   if ! PATH="$path_without_wrapper" command -v "$cmd" >/dev/null 2>&1; then
     printf '%s' ""
     return 0
   fi
-  PATH="$path_without_wrapper" "$cmd" --version 2>/dev/null | sed -n '1p' || true
+  case "$cmd" in
+    nvcc|nvc|nvc++|nvfortran)
+      version_args=("-V")
+      ;;
+  esac
+  PATH="$path_without_wrapper" "$cmd" "${version_args[@]}" 2>&1 | extract_command_version_line "$cmd" || true
+}
+
+extract_command_version_line() {
+  local cmd="$1"
+
+  case "$cmd" in
+    nvcc)
+      awk '
+        /Cuda compilation tools/ {print; found=1; exit}
+        /release [0-9][0-9.]*/ {print; found=1; exit}
+        NF && first == "" {first=$0}
+        END {if (!found && first != "") print first}
+      '
+      ;;
+    nvc|nvc++|nvfortran)
+      awk '
+        /^[[:space:]]*(nvc|nvc\+\+|nvfortran)[[:space:]]+[0-9]/ {print; found=1; exit}
+        NF && first == "" {first=$0}
+        END {if (!found && first != "") print first}
+      '
+      ;;
+    *)
+      sed -n '/[^[:space:]]/ { p; q; }'
+      ;;
+  esac
 }
 
 fallback_commands_json() {

--- a/scripts/collect_environment_snapshot.sh
+++ b/scripts/collect_environment_snapshot.sh
@@ -38,13 +38,41 @@ command_version() {
   local cmd="$1"
   shift
   if command -v "$cmd" >/dev/null 2>&1; then
-    "$cmd" "$@" 2>/dev/null | head -n 1 || true
+    "$cmd" "$@" 2>&1 | extract_command_version_line "$cmd" || true
   fi
+}
+
+extract_command_version_line() {
+  local cmd="$1"
+
+  case "$cmd" in
+    nvcc)
+      awk '
+        /Cuda compilation tools/ {print; found=1; exit}
+        /release [0-9][0-9.]*/ {print; found=1; exit}
+        NF && first == "" {first=$0}
+        END {if (!found && first != "") print first}
+      '
+      ;;
+    nvc|nvc++|nvfortran)
+      awk '
+        /^[[:space:]]*(nvc|nvc\+\+|nvfortran)[[:space:]]+[0-9]/ {print; found=1; exit}
+        NF && first == "" {first=$0}
+        END {if (!found && first != "") print first}
+      '
+      ;;
+    *)
+      sed -n '/[^[:space:]]/ { p; q; }'
+      ;;
+  esac
 }
 
 snapshot_command_version() {
   local cmd="$1"
   case "$cmd" in
+    nvcc|nvc|nvc++|nvfortran)
+      command_version "$cmd" -V
+      ;;
     python|python3|python3.*)
       command_version "$cmd" --version
       ;;
@@ -184,10 +212,10 @@ jq -n \
   --arg benchkit_commit "$git_commit" \
   --arg benchkit_branch "$git_branch" \
   --arg benchkit_dirty "$git_dirty" \
-  --arg gcc_version "$(command_version gcc --version)" \
-  --arg mpicc_version "$(command_version mpicc --version)" \
-  --arg nvcc_version "$(command_version nvcc --version)" \
-  --arg python_version "$(command_version python3 --version)" \
+  --arg gcc_version "$(snapshot_command_version gcc)" \
+  --arg mpicc_version "$(snapshot_command_version mpicc)" \
+  --arg nvcc_version "$(snapshot_command_version nvcc)" \
+  --arg python_version "$(snapshot_command_version python3)" \
   --arg container_image_path "${BK_SOURCE_CONTAINER_PATH:-}" \
   --arg container_image_sha256sum "${BK_SOURCE_CONTAINER_SHA256:-}" \
   --argjson modules "$module_list_json" \

--- a/scripts/tests/test_build_environment_snapshot.sh
+++ b/scripts/tests/test_build_environment_snapshot.sh
@@ -52,10 +52,43 @@ printf '%s\n' "$*" > "${BK_TEST_FAKE_MAKE_ARGS}"
 EOF
 chmod +x "${TMP_DIR}/bin/make"
 
+cat > "${TMP_DIR}/bin/nvcc" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+if [ "${1:-}" != "-V" ]; then
+  echo "unexpected nvcc version argument: ${1:-}" >&2
+  exit 2
+fi
+cat <<'OUT'
+nvcc: NVIDIA (R) Cuda compiler driver
+Copyright (c) 2005-2025 NVIDIA Corporation
+Built on Tue_Dec_16_07:27:17_PM_PST_2025
+Cuda compilation tools, release 13.1, V13.1.115
+Build cuda_13.1.r13.1/compiler.37061995_0
+OUT
+EOF
+chmod +x "${TMP_DIR}/bin/nvcc"
+
+cat > "${TMP_DIR}/bin/nvc" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+if [ "${1:-}" != "-V" ]; then
+  echo "unexpected nvc version argument: ${1:-}" >&2
+  exit 2
+fi
+cat <<'OUT'
+
+nvc 26.3-0 linuxarm64 target on aarch64 Linux -tp neoverse-v2
+NVIDIA Compilers and Tools
+Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+OUT
+EOF
+chmod +x "${TMP_DIR}/bin/nvc"
+
 pushd "${TMP_DIR}/project/src" >/dev/null
 export BK_SYSTEM=TestSystem
 export BK_BENCHKIT_ROOT="${TMP_DIR}/project"
-export BK_SNAPSHOT_TOOL_COMMANDS="make bash"
+export BK_SNAPSHOT_TOOL_COMMANDS="make bash nvcc nvc"
 export BK_SNAPSHOT_ENV_VARS="CC SECRET_TOKEN"
 export PATH="${TMP_DIR}/project/scripts/build_tool_wrappers:${TMP_DIR}/bin:${PATH}"
 export CC=mpicc
@@ -67,11 +100,20 @@ popd >/dev/null
 SNAPSHOT="${TMP_DIR}/project/results/environment_snapshot_build_actual.json"
 test -f "$SNAPSHOT"
 test "$(cat "${TMP_DIR}/make_args")" = "-j2 target"
-jq -e --arg make_path "${TMP_DIR}/bin/make" '
+jq -e \
+  --arg make_path "${TMP_DIR}/bin/make" \
+  --arg nvcc_path "${TMP_DIR}/bin/nvcc" \
+  --arg nvc_path "${TMP_DIR}/bin/nvc" \
+  '
   .stage == "build_actual" and
   .system.name == "TestSystem" and
   .toolchain.commands.make.path == $make_path and
   (.toolchain.commands.bash.path | length) > 0 and
+  .toolchain.nvcc == "Cuda compilation tools, release 13.1, V13.1.115" and
+  .toolchain.commands.nvcc.path == $nvcc_path and
+  .toolchain.commands.nvcc.version == "Cuda compilation tools, release 13.1, V13.1.115" and
+  .toolchain.commands.nvc.path == $nvc_path and
+  .toolchain.commands.nvc.version == "nvc 26.3-0 linuxarm64 target on aarch64 Linux -tp neoverse-v2" and
   .toolchain.environment.CC == "mpicc" and
   .toolchain.environment.SECRET_TOKEN == "[redacted]"
 ' "$SNAPSHOT" >/dev/null
@@ -97,10 +139,19 @@ popd >/dev/null
 
 test -f "$SNAPSHOT"
 test "$(cat "${TMP_DIR}/make_args_fallback")" = "fallback"
-jq -e --arg make_path "${TMP_DIR}/bin/make" '
+jq -e \
+  --arg make_path "${TMP_DIR}/bin/make" \
+  --arg nvcc_path "${TMP_DIR}/bin/nvcc" \
+  --arg nvc_path "${TMP_DIR}/bin/nvc" \
+  '
   .stage == "build_actual" and
   .system.name == "TestSystem" and
   .toolchain.commands.make.path == $make_path and
+  .toolchain.nvcc == "Cuda compilation tools, release 13.1, V13.1.115" and
+  .toolchain.commands.nvcc.path == $nvcc_path and
+  .toolchain.commands.nvcc.version == "Cuda compilation tools, release 13.1, V13.1.115" and
+  .toolchain.commands.nvc.path == $nvc_path and
+  .toolchain.commands.nvc.version == "nvc 26.3-0 linuxarm64 target on aarch64 Linux -tp neoverse-v2" and
   .toolchain.environment.CC == "mpicc" and
   .toolchain.environment.SECRET_TOKEN == "[redacted]"
 ' "$SNAPSHOT" >/dev/null


### PR DESCRIPTION
## Summary
- use -V for nvcc/nvc/nvc++/nvfortran version capture
- extract the CUDA release line from nvcc multi-line output
- keep command path/real_path capture through the commands map and test nvcc/nvc paths

## Tests
- bash -n scripts/collect_environment_snapshot.sh scripts/build_tool_wrappers/bk_build_tool_wrapper.sh scripts/tests/test_build_environment_snapshot.sh
- shellcheck -S error scripts/collect_environment_snapshot.sh scripts/build_tool_wrappers/bk_build_tool_wrapper.sh scripts/tests/test_build_environment_snapshot.sh
- bash scripts/tests/test_build_environment_snapshot.sh
- .venv/bin/python -m pytest result_server/tests/test_environment_snapshot_ci_scripts.py result_server/tests/test_environment_snapshots.py result_server/tests/test_environment_snapshot_results_route.py
- .venv/bin/python -m pytest result_server/tests
- .venv/bin/python scripts/tests/check_text_integrity.py
- git diff --check