### PR TITLE
Add guarded build artifact cache wrapper

### DIFF
--- a/.github/workflows/result-server-tests.yml
+++ b/.github/workflows/result-server-tests.yml
@@ -71,6 +71,7 @@ jobs:
         run: |
           bash scripts/tests/test_bk_profiler.sh
           bash scripts/tests/test_bk_fetch_source.sh
+          bash scripts/tests/test_build_cache.sh
           bash scripts/tests/test_build_environment_snapshot.sh
           bash scripts/tests/test_ncu_plan_generation.sh
           bash scripts/tests/test_result_profile_data.sh

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -250,6 +250,30 @@ The app support matrix, partial support, missing app entrypoints, and unknown sy
 
 app support matrix、partial support、app entrypoint不足、`list.csv` 内の未知systemは、運用 visibility のため `/results/usage` に表示します。ただしアプリごとの準備状況や導入段階がばらばらなため、現時点では CI failure にはしません。
 
+## GitLab Build Cache / GitLab build cache
+
+Generated GitLab CI uses `scripts/build_with_cache.sh` for `cross` build jobs.
+The cache key is broad (`code` + `system`), and the script decides whether the
+restored cache is safe to use by comparing the current build input hash and
+the cached `results/source_info.env`.
+
+生成された GitLab CI の `cross` build job は `scripts/build_with_cache.sh` を使います。
+cache key は広めの `code` + `system` で、復元してよいかは script 側が現在の build input hash と cache 内の `results/source_info.env` を比較して判断します。
+
+Git sources are rechecked with `git ls-remote`; file/archive sources are
+rechecked by SHA-256. If a container image hash is recorded, that image hash is
+also verified. Host-build cache restore is conservative: it requires
+`BK_BUILD_CACHE_ALLOW_HOST_ENV_CACHE=true` and a non-empty
+`BK_BUILD_CACHE_ENV_KEY` so site operators can invalidate cache entries when
+compiler/module stacks change. Cache misses fall back to the normal
+`programs/<code>/build.sh` path and store a fresh cache after a successful
+build.
+
+Git source は `git ls-remote` で再確認し、file/archive source は SHA-256 を再計算します。
+container image hash が記録されている場合は image hash も確認します。
+host build の cache restore は保守的に扱い、compiler/module stack 変更時に site 運用側が cache を無効化できるよう、`BK_BUILD_CACHE_ALLOW_HOST_ENV_CACHE=true` と非空の `BK_BUILD_CACHE_ENV_KEY` を要求します。
+cache miss の場合は通常の `programs/<code>/build.sh` 経路に戻り、成功後に新しい cache を保存します。
+
 ## Lightweight Repository Policy / 軽量repository policy
 
 `Repository Policy` runs on every pull request and on pushes to `develop` or `main`. It runs `scripts/tests/check_text_integrity.py` to ensure tracked text-like files decode as UTF-8 and do not contain the U+FFFD replacement character.

--- a/docs/guides/add-app.md
+++ b/docs/guides/add-app.md
@@ -136,6 +136,19 @@ CI の build job では `scripts/build_tool_wrappers/` を `PATH` の先頭に�
 
 この actual build snapshot は、将来の build cache key や、同じ source から異なる binary が生じた場合の原因確認に使う前提の記録です。
 
+### build cache の方針
+
+cross build job では、共通 wrapper `scripts/build_with_cache.sh` が `build.sh` の前後で build artifact cache を扱います。
+app の `build.sh` から cache 用の関数を呼ぶ必要はありません。
+cache miss の場合は通常どおり `build.sh` が実行され、`artifacts/`、`results/source_info.env`、`results/environment_snapshot_build_actual.json` が cache に保存されます。
+cache hit の場合は保存済みの `artifacts/` と build provenance が復元され、`build.sh` は実行されません。
+
+cache hit は、少なくとも現在の app build input hash と source provenance が一致するときだけ許可されます。
+Git source では cache 内の `repo_url` / `branch` / `commit_hash` に対し、現在の branch commit を `git ls-remote` で再解決します。
+file/archive source では SHA-256 を再計算します。
+container image SHA-256 が source_info に入っている場合は container image も再検証します。
+container ではない host build は toolchain 更新で stale になり得るため、restore には site 側で `BK_BUILD_CACHE_ALLOW_HOST_ENV_CACHE=true` と非空の `BK_BUILD_CACHE_ENV_KEY` を明示する必要があります。
+
 ---
 
 ## 4. ビルドスクリプトの作成

--- a/result_server/tests/test_environment_snapshot_ci_scripts.py
+++ b/result_server/tests/test_environment_snapshot_ci_scripts.py
@@ -19,6 +19,9 @@ def test_matrix_generator_collects_snapshots_in_common_wrappers():
     )
     assert "export BK_BENCHKIT_ROOT=" in matrix_generate
     assert "scripts/build_tool_wrappers" in matrix_generate
+    assert "bash scripts/build_with_cache.sh $program $system $program_path" in matrix_generate
+    assert ".benchkit_build_cache/${program}/${system}/" in matrix_generate
+    assert "policy: pull-push" in matrix_generate
 
 
 def test_send_results_process_does_not_collect_send_stage_snapshot():

--- a/scripts/build_with_cache.sh
+++ b/scripts/build_with_cache.sh
@@ -1,0 +1,353 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "Usage: $0 <code> <system> <program_path>" >&2
+  exit 2
+fi
+
+code="$1"
+system="$2"
+program_path="$3"
+
+repo_root="${BK_BENCHKIT_ROOT:-$(pwd)}"
+cache_root="${BK_BUILD_CACHE_DIR:-${repo_root}/.benchkit_build_cache}"
+cache_dir="${cache_root}/${code}/${system}"
+cache_manifest="${cache_dir}/manifest.env"
+status_file="${repo_root}/results/build_cache.env"
+
+source "${repo_root}/scripts/bk_functions.sh"
+
+validate_path_component() {
+  local value="$1"
+  local label="$2"
+
+  case "$value" in
+    ""|.|..|*/*|*../*|*..*)
+      echo "build cache: invalid ${label}: ${value}" >&2
+      return 1
+      ;;
+  esac
+}
+
+decode_base64_value() {
+  if base64 --decode >/dev/null 2>&1 </dev/null; then
+    base64 --decode
+    return 0
+  fi
+  if base64 -d >/dev/null 2>&1 </dev/null; then
+    base64 -d
+    return 0
+  fi
+  if base64 -D >/dev/null 2>&1 </dev/null; then
+    base64 -D
+    return 0
+  fi
+  if command -v openssl >/dev/null 2>&1; then
+    openssl base64 -d -A
+    return 0
+  fi
+  return 1
+}
+
+env_file_value() {
+  local file="$1"
+  local key="$2"
+  local line=""
+
+  line=$(awk -F= -v k="${key}_B64" '$1 == k {print substr($0, length(k) + 2); exit}' "$file")
+  if [ -n "$line" ]; then
+    printf '%s' "$line" | decode_base64_value 2>/dev/null || true
+    return 0
+  fi
+
+  awk -F= -v k="$key" '
+    $1 == k {
+      value = substr($0, length(k) + 2)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+      gsub(/^"|"$/, "", value)
+      print value
+      exit
+    }
+  ' "$file"
+}
+
+manifest_value() {
+  local key="$1"
+
+  awk -F= -v k="$key" '$1 == k {print substr($0, length(k) + 2); exit}' "$cache_manifest"
+}
+
+write_status() {
+  local status="$1"
+  local reason="${2:-}"
+  local stored="${3:-false}"
+
+  mkdir -p "${repo_root}/results"
+  {
+    printf 'BK_BUILD_CACHE_STATUS=%s\n' "$status"
+    printf 'BK_BUILD_CACHE_REASON_B64=%s\n' "$(bk_base64_encode_value "$reason")"
+    printf 'BK_BUILD_CACHE_DIR_B64=%s\n' "$(bk_base64_encode_value "$cache_dir")"
+    printf 'BK_BUILD_CACHE_STORED=%s\n' "$stored"
+  } > "$status_file"
+}
+
+build_inputs_hash() {
+  local file_list
+  local hash_list
+  local file
+
+  file_list=$(mktemp)
+  hash_list=$(mktemp)
+  if git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git -C "$repo_root" ls-files \
+      "programs/${code}" \
+      "scripts/bk_functions.sh" \
+      "scripts/build_tool_wrappers" \
+      "scripts/build_with_cache.sh" \
+      "scripts/collect_environment_snapshot.sh" \
+      "scripts/matrix_generate.sh" \
+      > "$file_list"
+  else
+    find "${repo_root}/programs/${code}" "${repo_root}/scripts/build_tool_wrappers" \
+      -type f -print > "$file_list" 2>/dev/null || true
+    printf '%s\n' \
+      "scripts/bk_functions.sh" \
+      "scripts/build_with_cache.sh" \
+      "scripts/collect_environment_snapshot.sh" \
+      "scripts/matrix_generate.sh" \
+      >> "$file_list"
+  fi
+
+  for file in ${BK_BUILD_CACHE_EXTRA_INPUTS:-}; do
+    printf '%s\n' "$file" >> "$file_list"
+  done
+
+  LC_ALL=C sort -u "$file_list" | while IFS= read -r file; do
+    label="$file"
+    [ -n "$file" ] || continue
+    case "$file" in
+      /*)
+        case "$file" in
+          "${repo_root}/"*) label="${file#"${repo_root}/"}" ;;
+        esac
+        ;;
+      *) file="${repo_root}/${file}" ;;
+    esac
+    if [ -f "$file" ]; then
+      printf '%s  %s\n' "$(bk_sha256_file "$file")" "$label" >> "$hash_list"
+    fi
+  done
+
+  bk_sha256_file "$hash_list"
+  rm -f "$file_list" "$hash_list"
+}
+
+resolve_git_branch_commit() {
+  local repo_url="$1"
+  local branch="$2"
+  local commit=""
+
+  if [ -z "$repo_url" ] || [ -z "$branch" ] || [ "$branch" = "HEAD" ] || [ "$branch" = "detached" ]; then
+    return 1
+  fi
+
+  commit=$(git ls-remote "$repo_url" "refs/heads/${branch}" 2>/dev/null | awk 'NR == 1 {print $1}')
+  if [ -z "$commit" ]; then
+    commit=$(git ls-remote "$repo_url" "$branch" 2>/dev/null | awk 'NR == 1 {print $1}')
+  fi
+  [ -n "$commit" ] || return 1
+  printf '%s\n' "$commit"
+}
+
+validate_cached_source() {
+  local source_info_file="$1"
+  local source_type
+  local repo_url
+  local branch
+  local cached_commit
+  local current_commit
+  local file_path
+  local cached_sha256
+  local current_sha256
+  local container_path
+  local cached_container_sha256
+  local current_container_sha256
+
+  source_type=$(env_file_value "$source_info_file" BK_SOURCE_TYPE)
+  case "$source_type" in
+    git)
+      repo_url=$(env_file_value "$source_info_file" BK_REPO_URL)
+      branch=$(env_file_value "$source_info_file" BK_BRANCH)
+      cached_commit=$(env_file_value "$source_info_file" BK_COMMIT_HASH)
+      if ! current_commit=$(resolve_git_branch_commit "$repo_url" "$branch"); then
+        echo "cannot verify current git ref for ${repo_url} ${branch}"
+        return 1
+      fi
+      if [ "$current_commit" != "$cached_commit" ]; then
+        echo "source commit changed: cached ${cached_commit}, current ${current_commit}"
+        return 1
+      fi
+      ;;
+    file)
+      file_path=$(env_file_value "$source_info_file" BK_FILE_PATH)
+      cached_sha256=$(env_file_value "$source_info_file" BK_SHA256SUM)
+      if [ -z "$file_path" ] || [ -z "$cached_sha256" ] || [ ! -f "$file_path" ]; then
+        echo "cannot verify cached source archive"
+        return 1
+      fi
+      current_sha256=$(bk_sha256_file "$file_path")
+      if [ "$current_sha256" != "$cached_sha256" ]; then
+        echo "source archive sha256 changed"
+        return 1
+      fi
+      ;;
+    *)
+      echo "unsupported cached source type: ${source_type:-empty}"
+      return 1
+      ;;
+  esac
+
+  container_path=$(env_file_value "$source_info_file" BK_CONTAINER_IMAGE_PATH)
+  cached_container_sha256=$(env_file_value "$source_info_file" BK_CONTAINER_IMAGE_SHA256SUM)
+  if [ -n "$cached_container_sha256" ]; then
+    if [ -z "$container_path" ] || [ ! -f "$container_path" ]; then
+      echo "cannot verify cached container image"
+      return 1
+    fi
+    current_container_sha256=$(bk_sha256_file "$container_path")
+    if [ "$current_container_sha256" != "$cached_container_sha256" ]; then
+      echo "container image sha256 changed"
+      return 1
+    fi
+    return 0
+  fi
+
+  if [ "${BK_BUILD_CACHE_ALLOW_HOST_ENV_CACHE:-false}" != "true" ]; then
+    echo "host build cache restore requires BK_BUILD_CACHE_ALLOW_HOST_ENV_CACHE=true"
+    return 1
+  fi
+  if [ -z "${BK_BUILD_CACHE_ENV_KEY:-}" ]; then
+    echo "host build cache restore requires non-empty BK_BUILD_CACHE_ENV_KEY"
+    return 1
+  fi
+  if [ "$(manifest_value BK_CACHE_ENV_KEY_B64 | decode_base64_value 2>/dev/null || true)" != "$BK_BUILD_CACHE_ENV_KEY" ]; then
+    echo "host build cache environment key changed"
+    return 1
+  fi
+}
+
+restore_cache() {
+  local current_inputs_hash
+  local cached_inputs_hash
+  local cached_source_info="${cache_dir}/results/source_info.env"
+  local reason
+
+  if [ "${BK_BUILD_CACHE_ENABLED:-true}" != "true" ]; then
+    write_status disabled "BK_BUILD_CACHE_ENABLED is not true"
+    return 1
+  fi
+  if [ ! -f "$cache_manifest" ]; then
+    write_status miss "cache manifest is missing"
+    return 1
+  fi
+  if [ ! -d "${cache_dir}/artifacts" ] || [ ! -f "$cached_source_info" ]; then
+    write_status miss "cached artifacts or source_info.env are missing"
+    return 1
+  fi
+
+  current_inputs_hash=$(build_inputs_hash)
+  cached_inputs_hash=$(manifest_value BK_CACHE_BUILD_INPUTS_SHA256)
+  if [ "$current_inputs_hash" != "$cached_inputs_hash" ]; then
+    write_status miss "build inputs changed"
+    return 1
+  fi
+
+  if ! reason=$(validate_cached_source "$cached_source_info"); then
+    write_status miss "$reason"
+    return 1
+  fi
+
+  rm -rf "${repo_root}/artifacts"
+  mkdir -p "${repo_root}/artifacts" "${repo_root}/results"
+  cp -a "${cache_dir}/artifacts/." "${repo_root}/artifacts/"
+  if [ -d "${cache_dir}/results" ]; then
+    cp -a "${cache_dir}/results/." "${repo_root}/results/"
+  fi
+  write_status hit "restored cached build artifacts"
+  echo "build cache: hit for ${code}/${system}"
+}
+
+store_cache() {
+  local tmp_dir
+  local inputs_hash
+  local source_info_sha256=""
+  local source_info_file="${repo_root}/results/source_info.env"
+  local container_sha256=""
+
+  if [ "${BK_BUILD_CACHE_ENABLED:-true}" != "true" ]; then
+    write_status disabled "BK_BUILD_CACHE_ENABLED is not true"
+    return 0
+  fi
+  if [ ! -d "${repo_root}/artifacts" ] || [ ! -f "$source_info_file" ]; then
+    write_status miss "build completed but artifacts or source_info.env are missing"
+    return 0
+  fi
+  container_sha256=$(env_file_value "$source_info_file" BK_CONTAINER_IMAGE_SHA256SUM)
+  if [ -z "$container_sha256" ] && [ -z "${BK_BUILD_CACHE_ENV_KEY:-}" ]; then
+    write_status miss "host build cache store requires non-empty BK_BUILD_CACHE_ENV_KEY"
+    return 0
+  fi
+
+  inputs_hash=$(build_inputs_hash)
+  source_info_sha256=$(bk_sha256_file "$source_info_file")
+  tmp_dir="${cache_dir}.tmp.$$"
+  rm -rf "$tmp_dir"
+  mkdir -p "${tmp_dir}/artifacts" "${tmp_dir}/results"
+  cp -a "${repo_root}/artifacts/." "${tmp_dir}/artifacts/"
+  cp "$source_info_file" "${tmp_dir}/results/source_info.env"
+  if [ -f "${repo_root}/results/environment_snapshot_build_actual.json" ]; then
+    cp "${repo_root}/results/environment_snapshot_build_actual.json" \
+      "${tmp_dir}/results/environment_snapshot_build_actual.json"
+  fi
+  {
+    printf 'BK_BUILD_CACHE_FORMAT=base64-v1\n'
+    printf 'BK_CACHE_CODE_B64=%s\n' "$(bk_base64_encode_value "$code")"
+    printf 'BK_CACHE_SYSTEM_B64=%s\n' "$(bk_base64_encode_value "$system")"
+    printf 'BK_CACHE_BUILD_INPUTS_SHA256=%s\n' "$inputs_hash"
+    printf 'BK_CACHE_SOURCE_INFO_SHA256=%s\n' "$source_info_sha256"
+    printf 'BK_CACHE_ENV_KEY_B64=%s\n' "$(bk_base64_encode_value "${BK_BUILD_CACHE_ENV_KEY:-}")"
+    printf 'BK_CACHE_CREATED_AT=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  } > "${tmp_dir}/manifest.env"
+
+  rm -rf "$cache_dir"
+  mkdir -p "$(dirname "$cache_dir")"
+  mv "$tmp_dir" "$cache_dir"
+  write_status miss "stored cache after build" true
+  echo "build cache: stored ${code}/${system}"
+}
+
+validate_path_component "$code" code
+validate_path_component "$system" system
+
+case "$program_path" in
+  /*) ;;
+  *) program_path="${repo_root}/${program_path}" ;;
+esac
+if [ ! -f "${program_path}/build.sh" ]; then
+  echo "build cache: build script not found: ${program_path}/build.sh" >&2
+  exit 2
+fi
+
+mkdir -p "${repo_root}/results"
+export BK_SYSTEM="${BK_SYSTEM:-$system}"
+export BK_BENCHKIT_ROOT="$repo_root"
+export PATH="${repo_root}/scripts/build_tool_wrappers:${PATH:-}"
+
+if restore_cache; then
+  exit 0
+fi
+
+echo "build cache: miss for ${code}/${system}; running build.sh"
+bash "${program_path}/build.sh" "$system"
+store_cache

--- a/scripts/matrix_generate.sh
+++ b/scripts/matrix_generate.sh
@@ -129,9 +129,14 @@ ${build_key}_build:
     - export PATH=\"\$PWD/scripts/build_tool_wrappers:\$PATH\"
     - bash scripts/record_timestamp.sh results/build_start
     - echo \"[BUILD] $program for $system\"
-    - bash $program_path/build.sh $system
+    - bash scripts/build_with_cache.sh $program $system $program_path
     - bash scripts/record_timestamp.sh results/build_end
     - chmod -R a+rX artifacts results 2>/dev/null || true
+  cache:
+    key: \"benchkit-build-${program}-${system}\"
+    paths:
+      - .benchkit_build_cache/${program}/${system}/
+    policy: pull-push
   artifacts:
     paths:
       - artifacts/

--- a/scripts/tests/test_build_cache.sh
+++ b/scripts/tests/test_build_cache.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_DIR=$(cd "${SCRIPT_DIR}/../.." && pwd)
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+mkdir -p \
+  "${TMP_DIR}/project/programs/app" \
+  "${TMP_DIR}/project/scripts" \
+  "${TMP_DIR}/project/scripts/build_tool_wrappers" \
+  "${TMP_DIR}/source"
+
+cp "${REPO_DIR}/scripts/bk_functions.sh" "${TMP_DIR}/project/scripts/bk_functions.sh"
+cp "${REPO_DIR}/scripts/build_with_cache.sh" "${TMP_DIR}/project/scripts/build_with_cache.sh"
+cp "${REPO_DIR}/scripts/collect_environment_snapshot.sh" "${TMP_DIR}/project/scripts/collect_environment_snapshot.sh"
+cp "${REPO_DIR}/scripts/matrix_generate.sh" "${TMP_DIR}/project/scripts/matrix_generate.sh"
+cp -R "${REPO_DIR}/scripts/build_tool_wrappers" "${TMP_DIR}/project/scripts/"
+
+pushd "${TMP_DIR}/source" >/dev/null
+git init --initial-branch=main >/dev/null
+git config user.email "benchkit@example.invalid"
+git config user.name "Benchkit Test"
+printf 'one\n' > source.txt
+git add source.txt
+git commit -m "first" >/dev/null
+first_commit=$(git rev-parse HEAD)
+popd >/dev/null
+
+cat > "${TMP_DIR}/project/programs/app/build.sh" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+system="$1"
+source scripts/bk_functions.sh
+mkdir -p artifacts
+bk_fetch_source "${BK_TEST_SOURCE_REPO}" appsrc main
+
+count=0
+if [ -f "${BK_TEST_BUILD_COUNT}" ]; then
+  count=$(cat "${BK_TEST_BUILD_COUNT}")
+fi
+count=$((count + 1))
+printf '%s\n' "$count" > "${BK_TEST_BUILD_COUNT}"
+printf 'artifact %s %s\n' "$system" "$BK_COMMIT_HASH" > artifacts/app.bin
+EOF
+chmod +x "${TMP_DIR}/project/programs/app/build.sh"
+
+app_build_hash=$(sha256sum "${TMP_DIR}/project/programs/app/build.sh" | awk '{print $1}')
+
+run_build_with_cache_for_root() {
+  local project_root="$1"
+
+  pushd "$project_root" >/dev/null
+  BK_BENCHKIT_ROOT="$project_root" \
+    BK_BUILD_CACHE_DIR="${TMP_DIR}/cache" \
+    BK_BUILD_CACHE_ALLOW_HOST_ENV_CACHE=true \
+    BK_BUILD_CACHE_ENV_KEY=test-toolchain-v1 \
+    BK_TEST_SOURCE_REPO="${TMP_DIR}/source/.git" \
+    BK_TEST_BUILD_COUNT="${TMP_DIR}/build-count" \
+    bash scripts/build_with_cache.sh app TestSystem programs/app
+  popd >/dev/null
+}
+
+run_build_with_cache() {
+  run_build_with_cache_for_root "${TMP_DIR}/project"
+}
+
+run_build_without_host_restore_opt_in_for_root() {
+  local project_root="$1"
+
+  pushd "$project_root" >/dev/null
+  BK_BENCHKIT_ROOT="$project_root" \
+    BK_BUILD_CACHE_DIR="${TMP_DIR}/cache" \
+    BK_TEST_SOURCE_REPO="${TMP_DIR}/source/.git" \
+    BK_TEST_BUILD_COUNT="${TMP_DIR}/build-count" \
+    bash scripts/build_with_cache.sh app TestSystem programs/app
+  popd >/dev/null
+}
+
+run_build_without_host_restore_opt_in() {
+  run_build_without_host_restore_opt_in_for_root "${TMP_DIR}/project"
+}
+
+run_build_with_cache
+test "$(cat "${TMP_DIR}/build-count")" = "1"
+grep -q "$first_commit" "${TMP_DIR}/project/artifacts/app.bin"
+grep -q '^BK_BUILD_CACHE_STORED=true$' "${TMP_DIR}/project/results/build_cache.env"
+test -f "${TMP_DIR}/cache/app/TestSystem/manifest.env"
+grep -q "$app_build_hash" "${TMP_DIR}/cache/app/TestSystem/manifest.env" && {
+  echo "build cache manifest should contain only aggregate hashes, not raw file hashes" >&2
+  exit 1
+}
+
+cp -a "${TMP_DIR}/project" "${TMP_DIR}/project-copy"
+rm -rf "${TMP_DIR}/project-copy/artifacts" "${TMP_DIR}/project-copy/results" "${TMP_DIR}/project-copy/appsrc"
+run_build_with_cache_for_root "${TMP_DIR}/project-copy"
+test "$(cat "${TMP_DIR}/build-count")" = "1"
+grep -q "$first_commit" "${TMP_DIR}/project-copy/artifacts/app.bin"
+grep -q '^BK_BUILD_CACHE_STATUS=hit$' "${TMP_DIR}/project-copy/results/build_cache.env"
+
+rm -rf "${TMP_DIR}/project/artifacts" "${TMP_DIR}/project/results" "${TMP_DIR}/project/appsrc"
+run_build_without_host_restore_opt_in
+test "$(cat "${TMP_DIR}/build-count")" = "2"
+grep -q "$first_commit" "${TMP_DIR}/project/artifacts/app.bin"
+grep -q '^BK_BUILD_CACHE_STATUS=miss$' "${TMP_DIR}/project/results/build_cache.env"
+grep -q '^BK_BUILD_CACHE_STORED=false$' "${TMP_DIR}/project/results/build_cache.env"
+
+rm -rf "${TMP_DIR}/project/artifacts" "${TMP_DIR}/project/results" "${TMP_DIR}/project/appsrc"
+run_build_with_cache
+test "$(cat "${TMP_DIR}/build-count")" = "2"
+grep -q "$first_commit" "${TMP_DIR}/project/artifacts/app.bin"
+grep -q '^BK_BUILD_CACHE_STATUS=hit$' "${TMP_DIR}/project/results/build_cache.env"
+
+pushd "${TMP_DIR}/source" >/dev/null
+printf 'two\n' > source.txt
+git add source.txt
+git commit -m "second" >/dev/null
+second_commit=$(git rev-parse HEAD)
+popd >/dev/null
+
+rm -rf "${TMP_DIR}/project/artifacts" "${TMP_DIR}/project/results" "${TMP_DIR}/project/appsrc"
+run_build_with_cache
+test "$(cat "${TMP_DIR}/build-count")" = "3"
+grep -q "$second_commit" "${TMP_DIR}/project/artifacts/app.bin"
+grep -q '^BK_BUILD_CACHE_STORED=true$' "${TMP_DIR}/project/results/build_cache.env"
+
+printf '\n# build input change\n' >> "${TMP_DIR}/project/programs/app/build.sh"
+rm -rf "${TMP_DIR}/project/artifacts" "${TMP_DIR}/project/results" "${TMP_DIR}/project/appsrc"
+run_build_with_cache
+test "$(cat "${TMP_DIR}/build-count")" = "4"
+grep -q "$second_commit" "${TMP_DIR}/project/artifacts/app.bin"
+grep -q '^BK_BUILD_CACHE_STORED=true$' "${TMP_DIR}/project/results/build_cache.env"
+
+echo "build cache test passed"


### PR DESCRIPTION
## Summary
- add a common build cache wrapper for cross build jobs without requiring app build.sh changes
- verify cache hits against build input hashes, current source provenance, and container hashes when present
- require explicit host-build env keys before restoring/storing non-container host caches
- add shell regression coverage and CI/docs updates

## Tests
- bash -n scripts/build_with_cache.sh scripts/tests/test_build_cache.sh scripts/matrix_generate.sh
- shellcheck -S error scripts/build_with_cache.sh scripts/tests/test_build_cache.sh scripts/matrix_generate.sh
- bash scripts/tests/test_build_cache.sh
- bash scripts/matrix_generate.sh code=genesis system=RIKYU
- .venv/bin/python -m pytest result_server/tests
- .venv/bin/python scripts/tests/check_text_integrity.py
- git diff --check
- full Result Server Tests shell regression locally