### PR TITLE
Use custom runner build cache root

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -253,12 +253,16 @@ app support matrix、partial support、app entrypoint不足、`list.csv` 内の�
 ## GitLab Build Cache / GitLab build cache
 
 Generated GitLab CI uses `scripts/build_with_cache.sh` for `cross` build jobs.
-The cache key is broad (`code` + `system`), and the script decides whether the
-restored cache is safe to use by comparing the current build input hash and
-the cached `results/source_info.env`.
+If `BK_BUILD_CACHE_DIR` is set, it is used as the cache root. Otherwise, custom
+runners that expose `CUSTOM_DIR` use
+`$CUSTOM_DIR/build_cache/$CUSTOM_RUNNER_PROJECT_SLUG`. If neither is
+available, build cache is disabled. The script decides whether the restored
+cache is safe to use by comparing the current build input hash and the cached
+`results/source_info.env`.
 
 生成された GitLab CI の `cross` build job は `scripts/build_with_cache.sh` を使います。
-cache key は広めの `code` + `system` で、復元してよいかは script 側が現在の build input hash と cache 内の `results/source_info.env` を比較して判断します。
+`BK_BUILD_CACHE_DIR` が設定されていればそれを cache root として使います。未設定の場合、custom runner が `CUSTOM_DIR` を渡していれば `$CUSTOM_DIR/build_cache/$CUSTOM_RUNNER_PROJECT_SLUG` を使います。どちらもなければ build cache は無効です。
+復元してよいかは script 側が現在の build input hash と cache 内の `results/source_info.env` を比較して判断します。
 
 Git sources are rechecked with `git ls-remote`; file/archive sources are
 rechecked by SHA-256. If a container image hash is recorded, that image hash is
@@ -267,12 +271,15 @@ also verified. Host-build cache restore is conservative: it requires
 `BK_BUILD_CACHE_ENV_KEY` so site operators can invalidate cache entries when
 compiler/module stacks change. Cache misses fall back to the normal
 `programs/<code>/build.sh` path and store a fresh cache after a successful
-build.
+build. The generated child pipeline does not declare a GitLab `cache:` stanza;
+the cache directory must be a site-managed persistent path such as the custom
+runner's `CUSTOM_DIR`, not a per-job cleanup directory.
 
 Git source は `git ls-remote` で再確認し、file/archive source は SHA-256 を再計算します。
 container image hash が記録されている場合は image hash も確認します。
 host build の cache restore は保守的に扱い、compiler/module stack 変更時に site 運用側が cache を無効化できるよう、`BK_BUILD_CACHE_ALLOW_HOST_ENV_CACHE=true` と非空の `BK_BUILD_CACHE_ENV_KEY` を要求します。
 cache miss の場合は通常の `programs/<code>/build.sh` 経路に戻り、成功後に新しい cache を保存します。
+生成された child pipeline は GitLab の `cache:` stanza を出しません。cache directory は job ごとの cleanup 対象ではなく、custom runner の `CUSTOM_DIR` など site 側で管理する永続パスにしてください。
 
 ## Lightweight Repository Policy / 軽量repository policy
 

--- a/docs/guides/add-app.md
+++ b/docs/guides/add-app.md
@@ -140,6 +140,7 @@ CI の build job では `scripts/build_tool_wrappers/` を `PATH` の先頭に�
 
 cross build job では、共通 wrapper `scripts/build_with_cache.sh` が `build.sh` の前後で build artifact cache を扱います。
 app の `build.sh` から cache 用の関数を呼ぶ必要はありません。
+`BK_BUILD_CACHE_DIR` が設定されていればそれを cache root として使います。未設定の場合、custom runner が `CUSTOM_DIR` を渡していれば `$CUSTOM_DIR/build_cache/$CUSTOM_RUNNER_PROJECT_SLUG` を使います。どちらもなければ build cache は無効です。
 cache miss の場合は通常どおり `build.sh` が実行され、`artifacts/`、`results/source_info.env`、`results/environment_snapshot_build_actual.json` が cache に保存されます。
 cache hit の場合は保存済みの `artifacts/` と build provenance が復元され、`build.sh` は実行されません。
 

--- a/result_server/tests/test_environment_snapshot_ci_scripts.py
+++ b/result_server/tests/test_environment_snapshot_ci_scripts.py
@@ -20,8 +20,12 @@ def test_matrix_generator_collects_snapshots_in_common_wrappers():
     assert "export BK_BENCHKIT_ROOT=" in matrix_generate
     assert "scripts/build_tool_wrappers" in matrix_generate
     assert "bash scripts/build_with_cache.sh $program $system $program_path" in matrix_generate
-    assert ".benchkit_build_cache/${program}/${system}/" in matrix_generate
-    assert "policy: pull-push" in matrix_generate
+    assert ".benchkit_build_cache/${program}/${system}/" not in matrix_generate
+    assert "policy: pull-push" not in matrix_generate
+    build_cache = (REPO_ROOT / "scripts" / "build_with_cache.sh").read_text(
+        encoding="utf-8"
+    )
+    assert 'CUSTOM_DIR%/}/build_cache/${cache_project_slug}' in build_cache
 
 
 def test_send_results_process_does_not_collect_send_stage_snapshot():

--- a/scripts/build_with_cache.sh
+++ b/scripts/build_with_cache.sh
@@ -11,9 +11,23 @@ system="$2"
 program_path="$3"
 
 repo_root="${BK_BENCHKIT_ROOT:-$(pwd)}"
-cache_root="${BK_BUILD_CACHE_DIR:-${repo_root}/.benchkit_build_cache}"
-cache_dir="${cache_root}/${code}/${system}"
-cache_manifest="${cache_dir}/manifest.env"
+cache_project_slug="${CUSTOM_RUNNER_PROJECT_SLUG:-${CI_PROJECT_PATH_SLUG:-unknown}}"
+case "$cache_project_slug" in
+  ""|.|..|*/*|*../*|*..*) cache_project_slug="unknown" ;;
+esac
+if [ -n "${BK_BUILD_CACHE_DIR:-}" ]; then
+  cache_root="$BK_BUILD_CACHE_DIR"
+elif [ -n "${CUSTOM_DIR:-}" ]; then
+  cache_root="${CUSTOM_DIR%/}/build_cache/${cache_project_slug}"
+else
+  cache_root=""
+fi
+cache_dir=""
+cache_manifest=""
+if [ -n "$cache_root" ]; then
+  cache_dir="${cache_root}/${code}/${system}"
+  cache_manifest="${cache_dir}/manifest.env"
+fi
 status_file="${repo_root}/results/build_cache.env"
 
 source "${repo_root}/scripts/bk_functions.sh"
@@ -76,6 +90,27 @@ manifest_value() {
   local key="$1"
 
   awk -F= -v k="$key" '$1 == k {print substr($0, length(k) + 2); exit}' "$cache_manifest"
+}
+
+cache_dir_available() {
+  if [ -z "$cache_root" ]; then
+    return 1
+  fi
+  case "$cache_root" in
+    /*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+cache_dir_unavailable_reason() {
+  if [ -z "$cache_root" ]; then
+    printf '%s\n' "BK_BUILD_CACHE_DIR is not set and CUSTOM_DIR is unavailable"
+    return 0
+  fi
+  case "$cache_root" in
+    /*) printf '%s\n' "" ;;
+    *) printf '%s\n' "BK_BUILD_CACHE_DIR must be an absolute persistent path" ;;
+  esac
 }
 
 write_status() {
@@ -247,6 +282,10 @@ restore_cache() {
     write_status disabled "BK_BUILD_CACHE_ENABLED is not true"
     return 1
   fi
+  if ! cache_dir_available; then
+    write_status disabled "$(cache_dir_unavailable_reason)"
+    return 1
+  fi
   if [ ! -f "$cache_manifest" ]; then
     write_status miss "cache manifest is missing"
     return 1
@@ -287,6 +326,10 @@ store_cache() {
 
   if [ "${BK_BUILD_CACHE_ENABLED:-true}" != "true" ]; then
     write_status disabled "BK_BUILD_CACHE_ENABLED is not true"
+    return 0
+  fi
+  if ! cache_dir_available; then
+    write_status disabled "$(cache_dir_unavailable_reason)"
     return 0
   fi
   if [ ! -d "${repo_root}/artifacts" ] || [ ! -f "$source_info_file" ]; then

--- a/scripts/matrix_generate.sh
+++ b/scripts/matrix_generate.sh
@@ -132,11 +132,6 @@ ${build_key}_build:
     - bash scripts/build_with_cache.sh $program $system $program_path
     - bash scripts/record_timestamp.sh results/build_end
     - chmod -R a+rX artifacts results 2>/dev/null || true
-  cache:
-    key: \"benchkit-build-${program}-${system}\"
-    paths:
-      - .benchkit_build_cache/${program}/${system}/
-    policy: pull-push
   artifacts:
     paths:
       - artifacts/

--- a/scripts/tests/test_build_cache.sh
+++ b/scripts/tests/test_build_cache.sh
@@ -84,6 +84,62 @@ run_build_without_host_restore_opt_in() {
   run_build_without_host_restore_opt_in_for_root "${TMP_DIR}/project"
 }
 
+pushd "${TMP_DIR}/project" >/dev/null
+BK_BENCHKIT_ROOT="${TMP_DIR}/project" \
+  BK_TEST_SOURCE_REPO="${TMP_DIR}/source/.git" \
+  BK_TEST_BUILD_COUNT="${TMP_DIR}/build-count" \
+  bash scripts/build_with_cache.sh app TestSystem programs/app
+popd >/dev/null
+test "$(cat "${TMP_DIR}/build-count")" = "1"
+grep -q '^BK_BUILD_CACHE_STATUS=disabled$' "${TMP_DIR}/project/results/build_cache.env"
+grep -q '^BK_BUILD_CACHE_STORED=false$' "${TMP_DIR}/project/results/build_cache.env"
+test ! -d "${TMP_DIR}/project/.benchkit_build_cache"
+rm -rf "${TMP_DIR}/project/artifacts" "${TMP_DIR}/project/results" "${TMP_DIR}/project/appsrc"
+rm -f "${TMP_DIR}/build-count"
+
+pushd "${TMP_DIR}/project" >/dev/null
+BK_BENCHKIT_ROOT="${TMP_DIR}/project" \
+  CUSTOM_DIR="${TMP_DIR}/custom-runner" \
+  CUSTOM_RUNNER_PROJECT_SLUG="benchkit-test" \
+  BK_BUILD_CACHE_ALLOW_HOST_ENV_CACHE=true \
+  BK_BUILD_CACHE_ENV_KEY=test-toolchain-v1 \
+  BK_TEST_SOURCE_REPO="${TMP_DIR}/source/.git" \
+  BK_TEST_BUILD_COUNT="${TMP_DIR}/build-count" \
+  bash scripts/build_with_cache.sh app TestSystem programs/app
+popd >/dev/null
+test "$(cat "${TMP_DIR}/build-count")" = "1"
+grep -q '^BK_BUILD_CACHE_STORED=true$' "${TMP_DIR}/project/results/build_cache.env"
+test -f "${TMP_DIR}/custom-runner/build_cache/benchkit-test/app/TestSystem/manifest.env"
+rm -rf "${TMP_DIR}/project/artifacts" "${TMP_DIR}/project/results" "${TMP_DIR}/project/appsrc"
+
+pushd "${TMP_DIR}/project" >/dev/null
+BK_BENCHKIT_ROOT="${TMP_DIR}/project" \
+  CUSTOM_DIR="${TMP_DIR}/custom-runner" \
+  CUSTOM_RUNNER_PROJECT_SLUG="benchkit-test" \
+  BK_BUILD_CACHE_ALLOW_HOST_ENV_CACHE=true \
+  BK_BUILD_CACHE_ENV_KEY=test-toolchain-v1 \
+  BK_TEST_SOURCE_REPO="${TMP_DIR}/source/.git" \
+  BK_TEST_BUILD_COUNT="${TMP_DIR}/build-count" \
+  bash scripts/build_with_cache.sh app TestSystem programs/app
+popd >/dev/null
+test "$(cat "${TMP_DIR}/build-count")" = "1"
+grep -q '^BK_BUILD_CACHE_STATUS=hit$' "${TMP_DIR}/project/results/build_cache.env"
+rm -rf "${TMP_DIR}/project/artifacts" "${TMP_DIR}/project/results" "${TMP_DIR}/project/appsrc"
+rm -f "${TMP_DIR}/build-count"
+
+pushd "${TMP_DIR}/project" >/dev/null
+BK_BENCHKIT_ROOT="${TMP_DIR}/project" \
+  BK_BUILD_CACHE_DIR="relative-cache" \
+  BK_TEST_SOURCE_REPO="${TMP_DIR}/source/.git" \
+  BK_TEST_BUILD_COUNT="${TMP_DIR}/build-count" \
+  bash scripts/build_with_cache.sh app TestSystem programs/app
+popd >/dev/null
+test "$(cat "${TMP_DIR}/build-count")" = "1"
+grep -q '^BK_BUILD_CACHE_STATUS=disabled$' "${TMP_DIR}/project/results/build_cache.env"
+test ! -d "${TMP_DIR}/project/relative-cache"
+rm -rf "${TMP_DIR}/project/artifacts" "${TMP_DIR}/project/results" "${TMP_DIR}/project/appsrc"
+rm -f "${TMP_DIR}/build-count"
+
 run_build_with_cache
 test "$(cat "${TMP_DIR}/build-count")" = "1"
 grep -q "$first_commit" "${TMP_DIR}/project/artifacts/app.bin"


### PR DESCRIPTION
## Summary
- default build cache storage to CUSTOM_DIR/build_cache/<project-slug> on custom runners
- keep BK_BUILD_CACHE_DIR as an explicit override and disable cache when neither persistent root is available
- remove generated GitLab cache stanza so per-job runner cache directories are not required
- update docs and regression coverage

## Sensitive information check
- reviewed staged diff and generated YAML for token/secret/private-key style patterns before push
- added content contains only environment variable names and test dummy values, not secret values
- no runner tokens, env file contents, private keys, or allocation IDs are included

## Tests
- bash -n scripts/build_with_cache.sh scripts/tests/test_build_cache.sh scripts/matrix_generate.sh
- shellcheck -S error scripts/build_with_cache.sh scripts/tests/test_build_cache.sh scripts/matrix_generate.sh
- bash scripts/tests/test_build_cache.sh
- bash scripts/matrix_generate.sh code=genesis system=RIKYU
- /home/nakamura/fugakunext/venv/bin/python -m pytest result_server/tests/test_environment_snapshot_ci_scripts.py
- git diff --check