### PR TITLE
Avoid late cache probe during configure checks

### DIFF
--- a/scripts/build_tool_wrappers/bk_build_tool_wrapper.sh
+++ b/scripts/build_tool_wrappers/bk_build_tool_wrapper.sh
@@ -216,6 +216,59 @@ fallback_environment_json() {
   printf '}'
 }
 
+ancestor_command_line() {
+  local pid="$1"
+  local cmdline=""
+
+  if [ -r "/proc/${pid}/cmdline" ]; then
+    cmdline=$(tr '\0' ' ' < "/proc/${pid}/cmdline" 2>/dev/null || true)
+  fi
+  if [ -z "$cmdline" ] && [ -r "/proc/${pid}/comm" ]; then
+    cmdline=$(cat "/proc/${pid}/comm" 2>/dev/null || true)
+  fi
+  printf '%s' "$cmdline"
+}
+
+ancestor_parent_pid() {
+  local pid="$1"
+
+  if [ -r "/proc/${pid}/stat" ]; then
+    awk '{print $4}' "/proc/${pid}/stat" 2>/dev/null || true
+  fi
+}
+
+called_from_configure_probe() {
+  local pid="${PPID:-}"
+  local depth=0
+  local cmdline
+
+  while [ -n "$pid" ] && [ "$pid" != "0" ] && [ "$depth" -lt 8 ]; do
+    cmdline=$(ancestor_command_line "$pid")
+    case " $cmdline " in
+      *" ./configure "*|*"/configure "*|*" config.status "*|*"/config.status "*|*" missing "*|*"/missing "*)
+        return 0
+        ;;
+    esac
+    pid=$(ancestor_parent_pid "$pid")
+    depth=$((depth + 1))
+  done
+  return 1
+}
+
+should_exit_for_late_restore_probe() {
+  if [ "${BK_BUILD_CACHE_LATE_RESTORE_PROBE:-false}" != "true" ]; then
+    return 1
+  fi
+  case "$tool_name" in
+    make|ninja)
+      if called_from_configure_probe; then
+        return 1
+      fi
+      ;;
+  esac
+  return 0
+}
+
 write_fallback_snapshot() {
   local snapshot_file="$1"
   local stage="${BK_SNAPSHOT_STAGE:-build_actual}"
@@ -355,7 +408,7 @@ if [ "${BK_BUILD_TOOL_WRAPPER_SNAPSHOT:-true}" != "false" ]; then
     echo "bk_build_tool_wrapper: cannot collect build environment snapshot" >&2
     exit 1
   fi
-  if [ "$snapshot_written" = true ] && [ "${BK_BUILD_CACHE_LATE_RESTORE_PROBE:-false}" = "true" ]; then
+  if [ "$snapshot_written" = true ] && should_exit_for_late_restore_probe; then
     late_restore_status_file="${BK_BUILD_CACHE_LATE_RESTORE_STATUS_FILE:-${repo_root}/results/build_cache_late_restore.env}"
     mkdir -p "$(dirname "$late_restore_status_file")"
     {

--- a/scripts/tests/test_build_cache.sh
+++ b/scripts/tests/test_build_cache.sh
@@ -9,6 +9,7 @@ trap 'rm -rf "${TMP_DIR}"' EXIT
 
 mkdir -p \
   "${TMP_DIR}/project/programs/app" \
+  "${TMP_DIR}/project/programs/autotoolapp" \
   "${TMP_DIR}/project/programs/toolapp" \
   "${TMP_DIR}/project/scripts" \
   "${TMP_DIR}/project/scripts/build_tool_wrappers" \
@@ -26,7 +27,18 @@ git init --initial-branch=main >/dev/null
 git config user.email "benchkit@example.invalid"
 git config user.name "Benchkit Test"
 printf 'one\n' > source.txt
-git add source.txt
+cat > configure <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+if ! make configure-probe; then
+  echo "configure probe failed" >&2
+  exit 1
+fi
+test -f configure.probe
+EOF
+chmod +x configure
+git add source.txt configure
 git commit -m "first" >/dev/null
 first_commit=$(git rev-parse HEAD)
 popd >/dev/null
@@ -63,6 +75,20 @@ make "$system"
 EOF
 chmod +x "${TMP_DIR}/project/programs/toolapp/build.sh"
 
+cat > "${TMP_DIR}/project/programs/autotoolapp/build.sh" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+system="$1"
+source scripts/bk_functions.sh
+mkdir -p artifacts
+bk_fetch_source "${BK_TEST_SOURCE_REPO}" autosrc main
+cd autosrc
+./configure
+make "$system"
+EOF
+chmod +x "${TMP_DIR}/project/programs/autotoolapp/build.sh"
+
 cat > "${TMP_DIR}/tools/make" <<'EOF'
 #!/bin/bash
 set -euo pipefail
@@ -78,7 +104,13 @@ if [ -f "${BK_TEST_TOOL_BUILD_COUNT}" ]; then
 fi
 count=$((count + 1))
 printf '%s\n' "$count" > "${BK_TEST_TOOL_BUILD_COUNT}"
-printf 'tool artifact %s %s\n' "$*" "${BK_COMMIT_HASH:-missing}" > ../artifacts/toolapp.bin
+if [ "${1:-}" = "configure-probe" ]; then
+  printf 'ok\n' > configure.probe
+  exit 0
+fi
+artifact="${BK_TEST_TOOL_ARTIFACT:-../artifacts/toolapp.bin}"
+mkdir -p "$(dirname "$artifact")"
+printf 'tool artifact %s %s\n' "$*" "${BK_COMMIT_HASH:-missing}" > "$artifact"
 EOF
 chmod +x "${TMP_DIR}/tools/make"
 
@@ -133,6 +165,24 @@ run_tool_build_with_cache_for_root() {
 
 run_tool_build_with_cache() {
   run_tool_build_with_cache_for_root "${TMP_DIR}/project"
+}
+
+run_autotool_build_with_cache_for_root() {
+  local project_root="$1"
+
+  pushd "$project_root" >/dev/null
+  PATH="${TMP_DIR}/tools:${PATH}" \
+    BK_BENCHKIT_ROOT="$project_root" \
+    BK_BUILD_CACHE_DIR="${TMP_DIR}/autotool-cache" \
+    BK_TEST_SOURCE_REPO="${TMP_DIR}/source/.git" \
+    BK_TEST_TOOL_BUILD_COUNT="${TMP_DIR}/autotool-build-count" \
+    BK_TEST_TOOL_ARTIFACT="../artifacts/autotoolapp.bin" \
+    bash scripts/build_with_cache.sh autotoolapp TestSystem programs/autotoolapp
+  popd >/dev/null
+}
+
+run_autotool_build_with_cache() {
+  run_autotool_build_with_cache_for_root "${TMP_DIR}/project"
 }
 
 pushd "${TMP_DIR}/project" >/dev/null
@@ -237,6 +287,19 @@ rm -rf "${TMP_DIR}/project/artifacts" "${TMP_DIR}/project/results" "${TMP_DIR}/p
 run_tool_build_with_cache
 test "$(cat "${TMP_DIR}/tool-build-count")" = "1"
 grep -q "$first_commit" "${TMP_DIR}/project/artifacts/toolapp.bin"
+grep -q '^BK_BUILD_CACHE_STATUS=hit$' "${TMP_DIR}/project/results/build_cache.env"
+
+rm -rf "${TMP_DIR}/project/artifacts" "${TMP_DIR}/project/results" "${TMP_DIR}/project/autosrc"
+rm -f "${TMP_DIR}/autotool-build-count"
+run_autotool_build_with_cache
+test "$(cat "${TMP_DIR}/autotool-build-count")" = "2"
+grep -q "$first_commit" "${TMP_DIR}/project/artifacts/autotoolapp.bin"
+grep -q '^BK_BUILD_CACHE_STORED=true$' "${TMP_DIR}/project/results/build_cache.env"
+
+rm -rf "${TMP_DIR}/project/artifacts" "${TMP_DIR}/project/results" "${TMP_DIR}/project/autosrc"
+run_autotool_build_with_cache
+test "$(cat "${TMP_DIR}/autotool-build-count")" = "3"
+grep -q "$first_commit" "${TMP_DIR}/project/artifacts/autotoolapp.bin"
 grep -q '^BK_BUILD_CACHE_STATUS=hit$' "${TMP_DIR}/project/results/build_cache.env"
 
 pushd "${TMP_DIR}/source" >/dev/null


### PR DESCRIPTION
## Summary
- avoid terminating late host cache probes while configure/config.status/missing are probing make/ninja
- keep late restore active for the real build tool call after configure finishes
- add a cache test that reproduces an autotools-style configure probe before the real make build

## Safety
- common wrapper/test-only change; no app-side build API or runner YAML changes
- diff scan found no token/secret-like values

## Tests
- bash scripts/tests/test_build_cache.sh
- bash scripts/tests/test_build_environment_snapshot.sh
- shellcheck -S error scripts/build_with_cache.sh scripts/build_tool_wrappers/bk_build_tool_wrapper.sh scripts/collect_environment_snapshot.sh scripts/tests/test_build_cache.sh
- bash -n scripts/build_with_cache.sh scripts/build_tool_wrappers/bk_build_tool_wrapper.sh scripts/collect_environment_snapshot.sh scripts/tests/test_build_cache.sh
- /home/nakamura/fugakunext/venv/bin/python -m pytest result_server/tests/test_environment_snapshot_ci_scripts.py