### PR TITLE
Handle caught late cache probe exits

### DIFF
--- a/scripts/build_with_cache.sh
+++ b/scripts/build_with_cache.sh
@@ -475,7 +475,7 @@ run_build_with_optional_late_host_restore() {
   build_status=$?
   set -e
 
-  if [ "$build_status" -eq "$late_restore_exit_code" ] && [ -f "$late_restore_status_file" ]; then
+  if [ -f "$late_restore_status_file" ]; then
     if restore_cache; then
       late_restore_hit=true
       return 0

--- a/scripts/tests/test_build_cache.sh
+++ b/scripts/tests/test_build_cache.sh
@@ -85,7 +85,9 @@ mkdir -p artifacts
 bk_fetch_source "${BK_TEST_SOURCE_REPO}" autosrc main
 cd autosrc
 ./configure
-make "$system"
+if ! make "$system" > make.log 2>&1; then
+  exit 1
+fi
 EOF
 chmod +x "${TMP_DIR}/project/programs/autotoolapp/build.sh"
 


### PR DESCRIPTION
## Summary
- treat a late restore probe status file as authoritative even when build.sh catches the build tool exit and returns a different nonzero code
- preserve fallback behavior by rerunning build.sh normally if restore validation still misses
- extend the autotools-style cache test to wrap the final make in an if/exit path like GENESIS Fugaku

## Safety
- common cache wrapper/test-only change
- diff scan found no token/secret-like values

## Tests
- bash scripts/tests/test_build_cache.sh
- bash scripts/tests/test_build_environment_snapshot.sh
- shellcheck -S error scripts/build_with_cache.sh scripts/build_tool_wrappers/bk_build_tool_wrapper.sh scripts/collect_environment_snapshot.sh scripts/tests/test_build_cache.sh
- bash -n scripts/build_with_cache.sh scripts/build_tool_wrappers/bk_build_tool_wrapper.sh scripts/collect_environment_snapshot.sh scripts/tests/test_build_cache.sh
- /home/nakamura/fugakunext/venv/bin/python -m pytest result_server/tests/test_environment_snapshot_ci_scripts.py