### PR TITLE
Include artifact modes in build cache hash

### DIFF
--- a/scripts/build_with_cache.sh
+++ b/scripts/build_with_cache.sh
@@ -186,6 +186,7 @@ artifact_tree_hash() {
   local hash_input
   local rel
   local path
+  local mode
   local target
 
   [ -d "$artifact_root" ] || return 1
@@ -201,9 +202,17 @@ artifact_tree_hash() {
     [ -n "$rel" ] || continue
     path="${artifact_root}/${rel#./}"
     if [ -d "$path" ] && [ ! -L "$path" ]; then
-      printf 'D %s\n' "$(bk_base64_encode_value "$rel")" >> "$hash_input"
+      if ! mode=$(stat -c '%a' "$path"); then
+        rm -f "$file_list" "$hash_input"
+        return 1
+      fi
+      printf 'D %s %s\n' "$mode" "$(bk_base64_encode_value "$rel")" >> "$hash_input"
     elif [ -f "$path" ] && [ ! -L "$path" ]; then
-      printf 'F %s %s\n' "$(bk_sha256_file "$path")" "$(bk_base64_encode_value "$rel")" >> "$hash_input"
+      if ! mode=$(stat -c '%a' "$path"); then
+        rm -f "$file_list" "$hash_input"
+        return 1
+      fi
+      printf 'F %s %s %s\n' "$mode" "$(bk_sha256_file "$path")" "$(bk_base64_encode_value "$rel")" >> "$hash_input"
     elif [ -L "$path" ]; then
       if ! target=$(readlink "$path"); then
         rm -f "$file_list" "$hash_input"

--- a/scripts/tests/test_build_cache.sh
+++ b/scripts/tests/test_build_cache.sh
@@ -61,6 +61,7 @@ fi
 count=$((count + 1))
 printf '%s\n' "$count" > "${BK_TEST_BUILD_COUNT}"
 printf 'artifact %s %s\n' "$system" "$BK_COMMIT_HASH" > artifacts/app.bin
+chmod 755 artifacts/app.bin
 EOF
 chmod +x "${TMP_DIR}/project/programs/app/build.sh"
 
@@ -307,17 +308,25 @@ awk -F= '$1 == "BK_CACHE_SOURCE_INFO_SHA256" && length($2) == 64 {found=1} END {
 awk -F= '$1 == "BK_CACHE_ARTIFACTS_SHA256" && length($2) == 64 {found=1} END {exit(found ? 0 : 1)}' \
   "${integrity_cache_dir}/manifest.env"
 
-printf 'tampered artifact\n' > "${integrity_cache_dir}/artifacts/app.bin"
+chmod 644 "${integrity_cache_dir}/artifacts/app.bin"
 rm -rf "${TMP_DIR}/project/artifacts" "${TMP_DIR}/project/results" "${TMP_DIR}/project/appsrc"
 run_integrity_build_with_cache
 test "$(cat "${TMP_DIR}/integrity-build-count")" = "2"
+grep -q "$first_commit" "${TMP_DIR}/project/artifacts/app.bin"
+test -x "${TMP_DIR}/project/artifacts/app.bin"
+grep -q '^BK_BUILD_CACHE_STORED=true$' "${TMP_DIR}/project/results/build_cache.env"
+
+printf 'tampered artifact\n' > "${integrity_cache_dir}/artifacts/app.bin"
+rm -rf "${TMP_DIR}/project/artifacts" "${TMP_DIR}/project/results" "${TMP_DIR}/project/appsrc"
+run_integrity_build_with_cache
+test "$(cat "${TMP_DIR}/integrity-build-count")" = "3"
 grep -q "$first_commit" "${TMP_DIR}/project/artifacts/app.bin"
 grep -q '^BK_BUILD_CACHE_STORED=true$' "${TMP_DIR}/project/results/build_cache.env"
 
 printf '\n# tampered source info\n' >> "${integrity_cache_dir}/results/source_info.env"
 rm -rf "${TMP_DIR}/project/artifacts" "${TMP_DIR}/project/results" "${TMP_DIR}/project/appsrc"
 run_integrity_build_with_cache
-test "$(cat "${TMP_DIR}/integrity-build-count")" = "3"
+test "$(cat "${TMP_DIR}/integrity-build-count")" = "4"
 grep -q "$first_commit" "${TMP_DIR}/project/artifacts/app.bin"
 grep -q '^BK_BUILD_CACHE_STORED=true$' "${TMP_DIR}/project/results/build_cache.env"
 


### PR DESCRIPTION
## Summary
- include directory and regular-file mode bits in the build cache artifact tree hash
- add a regression test for mode-only artifact changes
- verify executable artifacts are restored with executable mode after rebuild

## Tests
- bash scripts/tests/test_build_cache.sh
- bash -n scripts/build_with_cache.sh scripts/tests/test_build_cache.sh
- shellcheck -S error scripts/build_with_cache.sh scripts/tests/test_build_cache.sh
- git diff --check