### PR TITLE
Block manual GitLab CI on main

### DIFF
--- a/.github/workflows/gitlab-manual-ci.yml
+++ b/.github/workflows/gitlab-manual-ci.yml
@@ -53,6 +53,19 @@ jobs:
           fetch-depth: 0
           path: trusted
 
+      - name: Reject production main target
+        env:
+          TARGET_REF: ${{ inputs.target_ref }}
+        run: |
+          set -euo pipefail
+
+          case "${TARGET_REF}" in
+            main|heads/main|refs/heads/main|origin/main|refs/remotes/origin/main)
+              echo "::error::GitLab Manual CI must not target the production main branch. Use develop, a trusted ci/pr-* branch, a feature branch, a tag, or a SHA for manual validation."
+              exit 1
+              ;;
+          esac
+
       - name: Prepare GitLab repository settings
         id: gitlab-repo
         uses: ./trusted/.github/actions/prepare-gitlab-repo

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -78,6 +78,10 @@ The workflow accepts these inputs:
 | `park_only` | Run only the legacy Benchpark bridge path / legacy Benchpark bridgeのみ実行 | `true` |
 | `park_send` | Run the legacy Benchpark bridge send-only path / legacy Benchpark bridge送信系のみ実行 | `true` |
 
+`GitLab Manual CI` is for development and release-candidate validation, not for producing production `main` branch results. The workflow rejects `target_ref` values that name the production `main` branch. Public `main` measurements should be produced by Portal-managed triggers with an explicit `code` / `system` scope and an explicit `RESULT_SERVER` pipeline variable.
+
+`GitLab Manual CI` は開発・release candidate検証用であり、本番 `main` branch結果を作る入口ではありません。このworkflowは本番 `main` branchを指す `target_ref` を拒否します。公開用の `main` 計測は、Portal管理のtriggerから、明示的な `code` / `system` scope と明示的な `RESULT_SERVER` pipeline variable を渡して作成します。
+
 このworkflowは以下を行います。
 
 The workflow:


### PR DESCRIPTION
## Summary
- reject GitLab Manual CI runs that target the production main branch by name
- document that Manual CI is for development and release-candidate validation
- keep production main measurements on the Portal-managed trigger path with explicit scope and RESULT_SERVER variables

## Tests
- python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/gitlab-manual-ci.yml", encoding="utf-8"))'
- python3 scripts/tests/check_text_integrity.py
- python3 scripts/tests/check_commit_messages.py
- git diff --check