### PR TITLE
Clarify public portal changes

### DIFF
--- a/docs/deploy/public-portal-access-control.md
+++ b/docs/deploy/public-portal-access-control.md
@@ -61,6 +61,7 @@ The initial public allowlist should be deliberately small.
 | Route | Public | Restricted viewer | Authenticated console | Operator | Runner/API | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
 | `GET /` | yes | yes | yes | yes | no | Public home page. |
+| `GET /changes` | yes | yes | yes | yes | no | Public broad-grained portal release notes. |
 | `GET /systems` | yes | yes | yes | yes | no | Public system catalog. |
 | `GET /results/` | yes | yes | yes | yes | no | Public results list, rendered with public-safe columns only. |
 | `GET /results/detail/<filename>` | conditional | yes | yes | yes | no | Public only for public results and public-safe detail fields. |
@@ -108,6 +109,7 @@ Conceptual nginx layout:
 ```nginx
 # Public routes: allow all.
 location = / { proxy_pass http://portal_backend; }
+location = /changes { proxy_pass http://portal_backend; }
 location = /systems { proxy_pass http://portal_backend; }
 location = /results/ { proxy_pass http://portal_backend; }
 location /static/ { proxy_pass http://portal_backend; }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,17 +2,12 @@
 
 ## v2026.08.31 - Initial public CX Portal baseline
 
-Public portal baseline for scoped QWS measurements on Fugaku and RIKYU, with
-public-safe result pages and Portal-managed main-branch triggers.
+Initial public portal surface with result browsing, comparison, system
+information, and release visibility.
 
-- Public result browsing, comparison, and system catalog pages are available in
-  public portal mode.
-- Public mode hides operator-only views, raw result JSON routes, trigger
-  internals, and environment snapshot detail.
-- Portal-managed triggers submit scoped main-branch measurements with an
-  explicit result-server destination.
-- Build cache restore checks source identity, host build environment, and
-  restored artifact integrity.
-- Branch and tag source inputs record the resolved commit used for the build.
-- Manual GitLab CI is reserved for development and release-candidate validation,
-  not production main results.
+- Browse public benchmark results from the portal.
+- Open public-safe result detail pages.
+- Compare selected public results.
+- Browse connected system summaries.
+- Show the deployed portal version in the shared footer.
+- Open a public Changes page with broad release notes.

--- a/result_server/tests/test_home_template.py
+++ b/result_server/tests/test_home_template.py
@@ -82,4 +82,4 @@ def test_changes_page_renders_release_notes(monkeypatch):
     assert "CX Portal Changes" in html
     assert "v2026.08.31" in html
     assert "Initial public CX Portal baseline" in html
-    assert "Portal-managed triggers" in html
+    assert "Compare selected public results" in html

--- a/result_server/utils/portal_version.py
+++ b/result_server/utils/portal_version.py
@@ -13,16 +13,16 @@ RELEASE_NOTES = [
         "date": "2026-08-31",
         "title": "Initial public CX Portal baseline",
         "summary": (
-            "Public portal baseline for scoped QWS measurements on Fugaku and RIKYU, "
-            "with public-safe result pages and Portal-managed main-branch triggers."
+            "Initial public portal surface with result browsing, comparison, "
+            "system information, and release visibility."
         ),
         "changes": [
-            "Public result browsing, comparison, and system catalog pages are available in public portal mode.",
-            "Public mode hides operator-only views, raw result JSON routes, trigger internals, and environment snapshot detail.",
-            "Portal-managed triggers submit scoped main-branch measurements with an explicit result-server destination.",
-            "Build cache restore checks source identity, host build environment, and restored artifact integrity.",
-            "Branch and tag source inputs record the resolved commit used for the build.",
-            "Manual GitLab CI is reserved for development and release-candidate validation, not production main results.",
+            "Browse public benchmark results from the portal.",
+            "Open public-safe result detail pages.",
+            "Compare selected public results.",
+            "Browse connected system summaries.",
+            "Show the deployed portal version in the shared footer.",
+            "Open a public Changes page with broad release notes.",
         ],
     }
 ]


### PR DESCRIPTION
Summary:
- keep public /changes release notes focused on portal-facing functionality
- list /changes in the public portal route allowlist table
- include /changes in the conceptual nginx public-route example

Validation:
- .venv/bin/python -m pytest result_server/tests/test_home_template.py result_server/tests/test_portal_version.py result_server/tests/test_portal_access_policy.py
- python3 scripts/tests/check_text_integrity.py
- python3 scripts/tests/check_commit_messages.py
- git diff --check